### PR TITLE
update execute html to use <code> tag

### DIFF
--- a/tests/documents/execute/default.html
+++ b/tests/documents/execute/default.html
@@ -1,7 +1,7 @@
-<pre data-execute="r"># No inputs, no output</pre>
-<pre data-execute="r" data-input="var1"># One input, no output</pre>
-<pre data-execute="r" data-input="var1,var2"># Two inputs, no output</pre>
-<pre data-execute="r" data-output="out" data-input="var1,var2"># Two inputs, an output</pre>
-<pre data-execute="r" data-output="out"># No input, an output</pre>
-<pre data-execute="r" data-output="out" data-input="var1,var2" data-width="3cm" data-show="true"># Inputs, output and options</pre>
+<pre data-execute="r"><code># No inputs, no output</code></pre>
+<pre data-execute="r" data-input="var1"><code># One input, no output</code></pre>
+<pre data-execute="r" data-input="var1,var2"><code># Two inputs, no output</code></pre>
+<pre data-execute="r" data-output="out" data-input="var1,var2"><code># Two inputs, an output</code></pre>
+<pre data-execute="r" data-output="out"><code># No input, an output</code></pre>
+<pre data-execute="r" data-output="out" data-input="var1,var2" data-width="3cm" data-show="true"><code># Inputs, output and options</code></pre>
 <pre class="r"><code># Just a codeblock</code></pre>


### PR DESCRIPTION
As discussed in https://github.com/stencila/js/issues/2#issuecomment-280496250, this adds `code` tags to the expected output of the `execute` module.