### PR TITLE
Fix bug which caused only the first peer to be checked

### DIFF
--- a/src/host/Host.js
+++ b/src/host/Host.js
@@ -76,8 +76,6 @@ export default class Host {
             }
           }
         }
-
-        return null
       }
     }
 


### PR DESCRIPTION
This should fix the error that @michael was experiencing when attempting to use external languages in Docker containers. I have tested it locally and it fixes that problem for me. Could you please test before we release a patch.

There is one new dev setup step when wanting to test this in the desktop - related to our new linear dependencies stencila -> node -> desktop. I'll add something to desktop README about that.

More generally, we need some integration tests to catch this type of small but Very Bad™ bug. I'll set up a separate pull request for that.