### PR TITLE
Introduce tools/runner.js and integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
   - 7
   - 6
 
+services:
+  - docker
+
 # Dependencies for `canvas` (required by `d3`)
 # See https://github.com/Automattic/node-canvas/blob/master/.travis.yml
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
 
 script:
   - make lint
-  - make test
+  - make test-all
   - make cover
   - make docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - 7
   - 6
 
 services:

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,14 @@ test:
 test-browser:
 	npm run test-browser
 
+test-integration:
+	npm run build
+	./tests/integration.sh
+
 test-one:
 	npm run test-one -- $(FILE)
+
+test-all: test test-integration
 
 cover:
 	npm run cover

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ docker run -p 2100:2000 stencila/alpha
 Now start the development environment and point `STENCILA_PEERS` to the new host.
 
 ```bash
-STENCILA_PEERS=http://0.0.0.0:2100 npm start
+STENCILA_PEERS=http://localhost:2100 npm start
 ```
 
 Most development tasks can be run  via `npm` or `make` shortcuts:

--- a/examples/document/app.js
+++ b/examples/document/app.js
@@ -10,8 +10,8 @@ window.addEventListener('load', () => {
     host: new Host({
       // Initial peers can be set in an environment variable
       peers: window.STENCILA_PEERS ? window.STENCILA_PEERS.split(' ') : [],
-      // Don't do local peer discovery
-      discover: false
+      // Peer discovery defaults to false but its frequency (in seconds) can be set in an environment variable
+      discover: window.STENCILA_DISCOVER ? parseFloat(window.STENCILA_DISCOVER) : false,
     }),
     backend: new MemoryBackend(window.GUIDES),
     documentId: getQueryStringParam('documentId') || '01-welcome-to-stencila'

--- a/make.js
+++ b/make.js
@@ -154,17 +154,16 @@ function buildGuides() {
   })
 }
 
-// This is used to expose certain environment variables to the js app
+// This is used to expose `STENCILA_XXXX` environment variables to the js app
 function buildEnv() {
   b.custom('Creating environment variables (env.js)...', {
     dest: './build/env.js',
     execute() {
-      // By default we don't have any peers attached, and no auto discovery is happening
       const variables = []
-      if (process.env.STENCILA_PEERS) {
-        variables.push(
-          ['window.STENCILA_PEERS = ', JSON.stringify(process.env.STENCILA_PEERS)].join('')
-        )
+      for (let name of Object.keys(process.env)) {
+        if (name.match(/^STENCILA_/)) {
+          variables.push(`window.${name} = "${process.env[name]}"`)
+        }
       }
       b.writeSync('build/env.js', variables.join('\n'), 'utf8')
     }

--- a/package.json
+++ b/package.json
@@ -53,15 +53,16 @@
     "remark-squeeze-paragraphs": "^3.0.0",
     "remark-stringify": "^3.0.0",
     "semantic-ui-css": "^2.2.4",
-    "substance": "1.0.0-beta.7-preview.16",
     "stencila-mini": "^0.11.3",
+    "substance": "1.0.0-beta.7-preview.16",
     "timeago.js": "3.0.0",
     "unified": "^6.1.1",
     "unist-util-find": "^1.0.1",
     "unist-util-remove": "^0.2.1",
     "unist-util-visit": "^1.1.1",
     "vega": "3.0.0-beta.22",
-    "vega-lite": "2.0.0-alpha.2"
+    "vega-lite": "2.0.0-alpha.2",
+    "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {
     "acorn": "^4.0.11",

--- a/src/document/DocumentEditor.js
+++ b/src/document/DocumentEditor.js
@@ -1,5 +1,4 @@
 import { AbstractEditor, ContainerEditor, WorkflowPane, SplitPane, Toolbar } from 'substance'
-import CellEngine from './CellEngine'
 
 /**
   The Stencila Document Editor
@@ -8,12 +7,10 @@ export default class DocumentEditor extends AbstractEditor {
 
   constructor (...args) {
     super(...args)
-    this._cellEngine = new CellEngine(this.editorSession)
   }
 
   dispose() {
     super.dispose()
-    this._cellEngine.dispose()
   }
 
   /**

--- a/src/document/DocumentPage.js
+++ b/src/document/DocumentPage.js
@@ -1,6 +1,7 @@
 import { Component, EditorSession } from 'substance'
 import DocumentEditor from './DocumentEditor'
 import DocumentConfigurator from './DocumentConfigurator'
+import CellEngine from './CellEngine'
 import { importHTML, exportHTML } from './documentConversion'
 import debounce from 'lodash.debounce'
 
@@ -96,6 +97,7 @@ export default class DocumentPage extends Component {
               host: this.props.host
             }
           })
+          let cellEngine = new CellEngine(editorSession)
 
           return buffer.readFile('stencila-manifest.json', 'application/json').then((manifest) => {
             manifest = JSON.parse(manifest)
@@ -108,7 +110,8 @@ export default class DocumentPage extends Component {
             // editorSession._url = this.props.documentId
             this.setState({
               buffer,
-              editorSession
+              editorSession,
+              cellEngine
             })
           })
         })

--- a/src/util/requests.js
+++ b/src/util/requests.js
@@ -12,10 +12,12 @@
  * @return {Promise}
  */
 export function request (method, url, data) {
-  if (typeof window === 'undefined') return Promise.resolve(null)
+  var XMLHttpRequest
+  if (typeof window === 'undefined') XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest
+  else XMLHttpRequest = window.XMLHttpRequest
 
   return new Promise((resolve, reject) => {
-    var request = new window.XMLHttpRequest()
+    var request = new XMLHttpRequest()
     request.open(method, url, true)
     request.setRequestHeader('Accept', 'application/json')
 

--- a/tests/documents/external-language-cells.html
+++ b/tests/documents/external-language-cells.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Stencila Document</title>
+  </head>
+  <body>
+    <main>
+      <div id="data" data-format="html">
+        <div class="content">
+          <div data-cell="js()">
+            <pre data-source="">process.version</pre>
+          </div>
+          <div data-cell="r()">
+            <pre data-source="">sessionInfo()</pre>
+          </div>
+          <div data-cell="py()">
+            <pre data-source="">import sys; sys.version</pre>
+          </div>
+          <div data-cell="sql()">
+            <pre data-source="">SELECT date();</pre>
+          </div>
+        </div>
+      </div>
+    </main>
+  </body>
+</html>

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Integration tests
+
+# Run a Stencila Docker container which provides all external language contexts
+docker run --detach --publish 2100:2000 stencila/alpha
+sleep 5
+
+# Configured using Docker container as only peer
+STENCILA_PEERS=http://localhost:2100 node tools/runner.js tests/documents/external-language-cells.html
+
+# Configured using peer dicovery
+STENCILA_DISCOVER=30 node tools/runner.js tests/documents/external-language-cells.html

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -10,14 +10,17 @@ error_handler () {
 trap error_handler ERR
 
 
-# Run a Stencila Docker container which provides all external language contexts
+# Run a Stencila Docker container which provides a Node Host (as have in Desktop)
+docker run --detach --publish 2000:2000 stencila/iota
+# Run a Stencila Docker container which provides several language Hosts
 docker run --detach --publish 2100:2000 stencila/alpha
+
 sleep 5
 
-# Configured using Docker container as only peer
+# Configured using one of the containers as only peer
 STENCILA_PEERS=http://localhost:2100 node tools/runner.js tests/documents/external-language-cells.html
 
-# Configured using peer dicovery
+# Configured using peer dicovery (this is current configuration for Desktop)
 STENCILA_DISCOVER=30 node tools/runner.js tests/documents/external-language-cells.html
 
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1,6 +1,14 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Integration tests
+
+# Record errors
+errors=0
+error_handler () {
+  (( errors++ ))
+}
+trap error_handler ERR
+
 
 # Run a Stencila Docker container which provides all external language contexts
 docker run --detach --publish 2100:2000 stencila/alpha
@@ -11,3 +19,7 @@ STENCILA_PEERS=http://localhost:2100 node tools/runner.js tests/documents/extern
 
 # Configured using peer dicovery
 STENCILA_DISCOVER=30 node tools/runner.js tests/documents/external-language-cells.html
+
+
+# Exit with number of errors
+exit $errors

--- a/tools/runner.js
+++ b/tools/runner.js
@@ -1,0 +1,88 @@
+/**
+ * A Stencila document runner for use in integration tests and in 
+ * continuous integration tools.
+ *
+ * Executes all cells in a document, outputs execution information and
+ * exits with the number of cells with errors
+ */
+
+const fs = require('fs')
+const stencila = require('..')
+const substance = require('substance')
+
+const file = process.argv[2]
+if (!file) {
+  console.error('No file path given')
+  process.exit(1)
+}
+
+// Host for getting external execution contexts
+const host = new stencila.Host({
+  peers: process.env.STENCILA_PEERS ? process.env.STENCILA_PEERS.split(' ') : [],
+  discover: process.env.STENCILA_DISCOVER ? parseFloat(process.env.STENCILA_DISCOVER) : false,
+})
+
+// Backend for getting document content
+const backend = new stencila.MemoryBackend({
+  'file': fs.readFileSync(file, {encoding: 'utf8'})
+})
+
+// DOM for mounting
+const document = substance.DefaultDOMElement.parseHTML('<html><body></body></html>')
+const body = document.find('body')
+
+const documentPage = stencila.DocumentPage.mount({
+  host: host,
+  backend: backend,
+  documentId: 'file'
+}, body)
+
+const start = process.hrtime()
+
+// Give time to compute
+// TODO: better way to do this! listen to some 'finished' event?
+setTimeout(() => {
+  // Record duration
+  const diff = process.hrtime(start)
+  const duration = diff[0] + diff[1]/1e9
+
+  // Check each cell for errors
+  let counts = {
+    cells: 0,
+    errors: 0
+  }
+  let errors = []
+  const cells = documentPage.state.cellEngine._cells
+  for (let key of Object.keys(cells)) {
+    let cell = cells[key]
+    if (cell.hasErrors()) {
+      if (cell.hasSyntaxError()) {
+        errors.push({
+          where: key,
+          type: "syntax",
+          message: cell.getSyntaxError()
+        })
+      }
+      if (cell.hasRuntimeErrors()) {
+        errors.push({
+          where: key,
+          type: "runtime",
+          message: cell.getRuntimeErrors()
+        })
+      }
+      counts.errors += 1
+    }
+    counts.cells += 1
+  }
+
+  // Output results for use by other tools
+  console.log(JSON.stringify({
+    file,
+    counts,
+    duration,
+    errors
+  }))
+
+  // Exit with the number of errors
+  process.exit(errors)
+}, 1000)


### PR DESCRIPTION
`tools/runner.js` is a Node.js script for running Stencila documents to check for errors. It is intended to be used for integration tests within this repo but also for testing a document's "reproducibility" and "CI for documents" at http://open.stenci.la

The `tests/integration.sh` uses `runner.js` to do integration tests. The current tests in there should have caught the bug @michael recently found.

@michael and @oliver---- : could you review, in particular:

- commit 2a51afd moves CellEngine - which seems to be OK but may have unseen side effects
- currently runner waits one second for all cells to execute, but ideally it would just wait for a 'finished' signal from the document

