### PR TITLE
Archiving of builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,12 @@ after_success:
 
 before_deploy:
   - |
+    # Get last line of commit message which, for a Github PR merge, is the PR title
+    COMMIT_LINE=$(echo $TRAVIS_COMMIT_MESSAGE | tail -n 1)
+    # Create a commit "slug"
+    COMMIT_SLUG=$(echo $COMMIT_LINE | cut -c 1-100 | sed -r s/[^a-zA-Z0-9]+/-/g | sed -r s/^-+\|-+$//g | tr A-Z a-z)
     # Generate a unique build version
-    export BUILD_NAME=$TRAVIS_BRANCH-$(date --utc --iso-8601)-$(echo $TRAVIS_COMMIT | cut -c 1-7)
+    BUILD_NAME=$COMMIT_SLUG-$(date --utc --iso-8601)-$(echo $TRAVIS_COMMIT | cut -c 1-7)
     # Create a versioned folder for the build
     mkdir -p bucket/stencila
     mv build bucket/stencila/$BUILD_NAME
@@ -52,6 +56,7 @@ before_deploy:
 deploy:
   on:
     all_branches: true
+    condition: " (($TRAVIS_BRANCH == 'master') || ($TRAVIS_BRANCH == 'develop')) && ( $(echo $TRAVIS_COMMIT_MESSAGE | grep -c -E "^Merge pull request") == '1') "
   skip_cleanup: true
   local_dir: bucket
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ before_deploy:
     mv build $BUILD_VERSION
 
 deploy:
-  branch: test-deploy
-  all_branches: true
+  on:
+    all_branches: true
   skip_cleanup: true
   local_dir: $BUILD_VERSION
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,15 @@ cache:
   directories:
     - node_modules
 
-# Temporarily skip to speed up debugging
-
-#before_script:
-#  - npm install documentation
+before_script:
+  - npm install documentation
 
 script:
-  #- make lint
+  - make lint
   - make build
-  #- make test-all
-  #- make cover
-  #- make docs
+  - make test-all
+  - make cover
+  - make docs
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
@@ -48,7 +46,7 @@ before_deploy:
     mkdir -p bucket/stencila
     mv build bucket/stencila/$BUILD_NAME
     # Update the list of builds
-    curl -s http://builds.stenci.la.s3-website-us-west-2.amazonaws.com/stencila/builds.txt > bucket/stencila/builds.txt
+    curl -s http://builds.stenci.la/stencila/builds.txt > bucket/stencila/builds.txt
     echo $BUILD_NAME >> bucket/stencila/builds.txt
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ cache:
 #before_script:
 #  - npm install documentation
 
-#script:
+script:
   #- make lint
+  - make build
   #- make test-all
   #- make cover
   #- make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,15 @@ after_success:
 
 before_deploy:
   - |
+    mkdir -p deploy
     export BUILD_VERSION=build-$(date --utc --iso-8601)-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
-    mv build $BUILD_VERSION
+    mv build deploy/$BUILD_VERSION
 
 deploy:
   on:
     all_branches: true
   skip_cleanup: true
-  local_dir: $BUILD_VERSION
+  local_dir: deploy
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,14 @@ after_success:
 
 before_deploy:
   - |
+    # Generate a unique build version
+    export BUILD_VERSION=$(TRAVIS_BRANCH)-$(date --utc --iso-8601)-$(echo $TRAVIS_COMMIT | cut -c 1-7)-$TRAVIS_BUILD_NUMBER
+    # Create a versioned folder for the build
     mkdir -p deploy
-    export BUILD_VERSION=build-$(date --utc --iso-8601)-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
     mv build deploy/$BUILD_VERSION
+    # Update the list of builds
+    curl -s http://test.stenci.la/builds.txt > deploy/builds.txt
+    echo $BUILD_VERSION >> builds.txt
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ after_success:
 
 before_deploy:
   - |
-  export BUILD_VERSION=build-$(date --utc --iso-8601)-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
-  mv build $BUILD_VERSION
+    export BUILD_VERSION=build-$(date --utc --iso-8601)-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
+    mv build $BUILD_VERSION
 
 deploy:
   branch: $TRAVIS_BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,15 @@ cache:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
+before_deploy:
+  - |
+  export BUILD_VERSION=build-$(date --utc --iso-8601)-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
+  mv build $BUILD_VERSION
+
 deploy:
-  all_branches: true
+  branch: $TRAVIS_BRANCH
   skip_cleanup: true
-  local_dir: build
+  local_dir: $BUILD_VERSION
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,19 +25,22 @@ cache:
   directories:
     - node_modules
 
-before_script:
-  - npm install documentation
+# Temporarily skip to speed up debugging
 
-script:
-  - make lint
-  - make test-all
-  - make cover
-  - make docs
+#before_script:
+#  - npm install documentation
+
+#script:
+  #- make lint
+  #- make test-all
+  #- make cover
+  #- make docs
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 deploy:
+  all_branches: true
   skip_cleanup: true
   local_dir: build
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,12 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+deploy:
+  skip_cleanup: true
+  local_dir: build
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_SECRET_ACCESS_KEY
+  region: us-west-2
+  bucket: test.stenci.la

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ before_deploy:
     mv build $BUILD_VERSION
 
 deploy:
-  branch: $TRAVIS_BRANCH
+  branch: test-deploy
+  all_branches: true
   skip_cleanup: true
   local_dir: $BUILD_VERSION
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,21 +43,21 @@ after_success:
 before_deploy:
   - |
     # Generate a unique build version
-    export BUILD_VERSION=$(TRAVIS_BRANCH)-$(date --utc --iso-8601)-$(echo $TRAVIS_COMMIT | cut -c 1-7)-$TRAVIS_BUILD_NUMBER
+    export BUILD_NAME=$TRAVIS_BRANCH-$(date --utc --iso-8601)-$(echo $TRAVIS_COMMIT | cut -c 1-7)
     # Create a versioned folder for the build
-    mkdir -p deploy
-    mv build deploy/$BUILD_VERSION
+    mkdir -p bucket/stencila
+    mv build bucket/stencila/$BUILD_NAME
     # Update the list of builds
-    curl -s http://test.stenci.la/builds.txt > deploy/builds.txt
-    echo $BUILD_VERSION >> builds.txt
+    curl -s http://builds.stenci.la.s3-website-us-west-2.amazonaws.com/stencila/builds.txt > bucket/stencila/builds.txt
+    echo $BUILD_NAME >> bucket/stencila/builds.txt
 
 deploy:
   on:
     all_branches: true
   skip_cleanup: true
-  local_dir: deploy
+  local_dir: bucket
   provider: s3
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY
   region: us-west-2
-  bucket: test.stenci.la
+  bucket: builds.stenci.la

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ test-browser:
 	npm run test-browser
 
 test-integration:
+	npm run build
 	./tests/integration.sh
 
 test-one:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ test-browser:
 	npm run test-browser
 
 test-integration:
-	npm run build
 	./tests/integration.sh
 
 test-one:

--- a/README.md
+++ b/README.md
@@ -128,3 +128,5 @@ Clean                                                   |                       
 To contribute, [get in touch](https://gitter.im/stencila/stencila), checkout the [platform-wide, cross-repository kanban board](https://github.com/orgs/stencila/projects/1), or just send us a pull request! Please read our contributor [code of conduct](CONDUCT.md).
 
 API documentation is at http://stencila.github.io/stencila/. These are published using Github Pages, so to update them after making changes: run `make docs`, commit the updates and do a `git push`.
+
+Builds done on [Travis CI](https://travis-ci.org/stencila/stencila) are archived at http://builds.stenci.la/stencila/. That site can be useful for user acceptance testing without the need to download Stencila Desktop. Provide test users with a link to an work-in-progress user interface e.g http://builds.stenci.la/stencila/test-deploy-2017-08-13-54a67a6/examples/document/index.html?documentId=01-welcome-to-stencila.

--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ To contribute, [get in touch](https://gitter.im/stencila/stencila), checkout the
 
 API documentation is at http://stencila.github.io/stencila/. These are published using Github Pages, so to update them after making changes: run `make docs`, commit the updates and do a `git push`.
 
-Builds done on [Travis CI](https://travis-ci.org/stencila/stencila) are archived at http://builds.stenci.la/stencila/. That site can be useful for user acceptance testing without the need to download Stencila Desktop. Provide test users with a link to an work-in-progress user interface e.g http://builds.stenci.la/stencila/test-deploy-2017-08-13-54a67a6/examples/document/index.html?documentId=01-welcome-to-stencila.
+Builds done on [Travis CI](https://travis-ci.org/stencila/stencila) are archived at http://builds.stenci.la/stencila/. That site can be useful for user acceptance testing without requiring users to download Stencila Desktop. Just provide test users with a link to a work-in-progress user interface e.g http://builds.stenci.la/stencila/test-deploy-2017-08-13-54a67a6/examples/document/index.html?documentId=01-welcome-to-stencila.


### PR DESCRIPTION
This PR archives each build to http://builds.stenci.la/stencila/. The primary purpose of this is to be able to provide tests users with links to WIP UIs without them having to clone the repo and run a dev setup. It also provides a readily accessible archive of build which could be useful if we want quickly go back and compare previous UIs.

We might build off this in the future to provide "demo" site that links to the most recent **release** build.

@michael and @oliver---- : could you review, and if OK merge. And if not make changes :)