### PR TITLE
Document digest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stencila",
-  "version": "0.27.9",
+  "version": "0.27.9-document-digest",
   "description": "Stencila is the office suite for reproducible research.",
   "main": "build/stencila.cjs.js",
   "jsnext:main": "index.es.js",

--- a/src/document/nodes/cell/CellHTMLConverter.js
+++ b/src/document/nodes/cell/CellHTMLConverter.js
@@ -13,14 +13,12 @@ export default {
     if (sourceCodeEl) {
       node.sourceCode = sourceCodeEl.textContent
     }
-    // TODO: discuss how we want to do this now:
-    // let outputEl = el.find('pre[data-output]')
-    // if (outputEl) {
-    //   node.value = JSON.parseoutputEl.textContent
-    // }
+    let outputEl = el.find('pre[data-output]')
+    if (outputEl) {
+      node.value = JSON.parse(outputEl.textContent)
+    }
   },
 
-  // TODO: This code has not yet been tested
   export: function (node, el, converter) {
     let $$ = converter.$$
     el.attr('data-cell', node.expression)
@@ -29,11 +27,9 @@ export default {
         $$('pre').attr('data-source', '').text(node.sourceCode)
       )
     }
-    // TODO: discuss how we want to do this now:
-    // to render in the same way as we do it in CellValueComponent
-    // el.append(
-    //   $$('pre').attr('data-output', '').text(node.value)
-    // )
+    el.append(
+      $$('pre').attr('data-output', '').text(JSON.stringify(node.value))
+    )
   }
 
 }


### PR DESCRIPTION
Document cells export their value and runner creates a document digest.

These changes allow us to create a digest for each document (pre and post execution) to help in determining if the execution, including the execution environment , has changed. 

This is used in our Docker image shrinking tests to verify that we get the same document reproduced after shrinking an image: https://github.com/stencila/images/blob/master/.test/shrink-alpha-documents/cmd.sh