### PR TITLE
Add a SpreadsheetSchema.md

### DIFF
--- a/src/spreadsheet/SpreadsheetSchema.md
+++ b/src/spreadsheet/SpreadsheetSchema.md
@@ -1,0 +1,60 @@
+# Stencila Spreadsheet schema
+
+Documentation for the spreadsheet XML schema defined in `SpreadsheetSchema.rng`. Put here, instead of as `<a:documentation>` elements in the RNG, because it makes both the schema and the documentation, more readable.
+
+Where appropriate we have re-used existing schema definitions for spreadsheets and tabular data including:
+
+- [metadata of the Frictionless Data Data Resource](https://specs.frictionlessdata.io/data-resource/#metadata-properties).
+- [field descriptors the Frictionless Data Table Schema](https://specs.frictionlessdata.io/table-schema/#field-descriptors)
+
+- `spreadsheet` element
+
+  Contains one each of `meta` and `data` elements.
+
+  - `meta` element
+
+    Contains one each of `name`, `title`, `description` and `columns` elements (in any order).
+
+      - `name` element
+
+        Text name for the spreadsheet.
+        
+      - `title` element
+
+        Text title for the spreadsheet.
+
+      - `description` element
+
+        Text description of the spreadsheet.
+
+      - `columns` element
+
+        Contains zero or more `col` elements.
+
+        - `col` element
+
+          Empty element with optional `type` and `format` attribute.
+
+            - `type` attribute
+
+              Specifies the expected type of the cell values in the column (or individual cell).
+
+              Choice of: `string`, `number`, `integer`, `boolean`, `object`, `array`, `date`, `time`, `datetime`, `year`, `yearmonth`, `duration`, `geopoint`, `geojson`, `any`
+
+            - `format` attribute
+
+              Specifies the format to be applied to the cell values in the column (or individual cell).
+
+              A `sprinf` string (?).
+
+  - `data` element
+
+    Contains zero or more `row` elements
+
+    - `row` element
+
+      Has a `height` attribute and zero or more `cell` elements.
+
+      - `cell`
+
+      Text value and optional `type` and `format` attributes (see `col` element above).


### PR DESCRIPTION
@oliver---- : I've transferred across some of the documentation from the `datatable-schema` branch into a separate `md` file.

The only things missing in the new RNG from that old branch at this stage are:

-  `name` (restricted to alpha-numeric and underscores?) , `title` (a more readable name) and `description` attributes for columns.
- constraints for columns https://specs.frictionlessdata.io/table-schema/#constraints

I suspect you'll be adding `name` etc to the schema soon so haven't done anything for those. We can discuss adding constraints later. I'l go ahead and delete the `datatable-schema` branch and PR now.
