### PR TITLE
WIP: Updates to Functions

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -18,3 +18,4 @@ export { address, value }
 export { default as getQueryStringParam } from './src/util/getQueryStringParam'
 
 export * from './src/sheet/index.js'
+export * from './src/function/index.js'

--- a/src/contexts/JsContext.js
+++ b/src/contexts/JsContext.js
@@ -120,7 +120,7 @@ export default class JsContext extends Context {
    * @override
    */
   defineFunction (name, code) {
-    this._functions[name] = eval(code) // eslint-disable-line no-eval
+    this._functions[name] = eval('(' + code + ')') // eslint-disable-line no-eval
     return Promise.resolve()
   }
 

--- a/src/function/FunctionDocumentImporter.js
+++ b/src/function/FunctionDocumentImporter.js
@@ -11,11 +11,13 @@ export default class FunctionDocumentImporter extends XMLDocumentImporter {
    */
   compileDocument(xml, files) {
     let doc = DefaultDOMElement.parseXML(xml)
-    for (let $code of doc.findAll('code[include]')) {
-      let file = $code.attr('include')
-      let code = files[file]
-      if (!code) throw new Error(`File "${file}" to be included as in Function definition was not supplied`)
-      $code.text(code)
+    if (files) {
+      for (let $code of doc.findAll('code[include]')) {
+        let file = $code.attr('include')
+        let code = files[file]
+        if (!code) throw new Error(`File "${file}" to be included as in Function definition was not supplied`)
+        $code.text(code)
+      }
     }
     return doc
   }

--- a/src/function/FunctionSchema.rng
+++ b/src/function/FunctionSchema.rng
@@ -15,7 +15,13 @@
         <ref name="function:title"/>
       </optional>
       <optional>
+        <ref name="function:summary"/>
+      </optional>
+      <optional>
         <ref name="function:description"/>
+      </optional>
+      <optional>
+        <ref name="function:relateds"/>
       </optional>
       <optional>
         <ref name="function:params"/>
@@ -24,6 +30,9 @@
         <ref name="function:return"/>
       </optional>
       <ref name="function:implems"/>
+      <optional>
+        <ref name="function:examples"/>
+      </optional>
       <optional>
         <ref name="function:tests"/>
       </optional>
@@ -42,8 +51,28 @@
     </element>
   </define>
 
+  <define name="function:summary">
+    <element name="summary">
+      <text/>
+    </element>
+  </define>
+
   <define name="function:description">
     <element name="description">
+      <text/>
+    </element>
+  </define>
+
+  <define name="function:relateds">
+    <element name="relateds">
+      <zeroOrMore>
+        <ref name="function:related"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="function:related">
+    <element name="related">
       <text/>
     </element>
   </define>
@@ -134,6 +163,30 @@
       </optional>
       <text/>
     </element>
+  </define>
+
+  <define name="function:examples">
+    <element name="examples">
+      <zeroOrMore>
+        <ref name="function:example"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="function:example">
+    <element name="example">
+      <optional>
+        <ref name="function:description"/>
+      </optional>
+      <ref name="function:usage"/>
+      <optional>
+        <ref name="function:result"/>
+      </optional>
+    </element>
+  </define>
+
+  <define name="function:usage">
+    <text/>
   </define>
 
   <define name="function:tests">

--- a/src/function/importFunctionDocument.js
+++ b/src/function/importFunctionDocument.js
@@ -1,0 +1,14 @@
+import { Configurator } from 'substance'
+
+import FunctionPackage from './FunctionPackage'
+import FunctionSchema from './FunctionSchema'
+
+export default function (main, files) {
+  let configurator = new Configurator()
+  configurator.import(FunctionPackage)
+  const importer = configurator.createImporter(FunctionSchema.getName())
+  const xml = importer.compileDocument(main, files)
+  const func = importer.importDocument(xml)
+  return func
+}
+

--- a/src/function/index.js
+++ b/src/function/index.js
@@ -1,2 +1,3 @@
 export { default as FunctionPackage } from './FunctionPackage'
 export { default as FunctionSchema } from './FunctionSchema'
+export { default as importFunctionDocument } from './importFunctionDocument'

--- a/src/types.js
+++ b/src/types.js
@@ -16,9 +16,11 @@ const parentTypes = {
   'array': 'any',
   'array[boolean]': 'array',
   'array[number]': 'array',
-  'array[integer]': 'array',
+  'array[integer]': 'array[number]',
   'array[string]': 'array',
-  'array[object]': 'array'
+  'array[object]': 'array',
+
+  'table': 'any'
 }
 
 // Children of each type

--- a/src/types.js
+++ b/src/types.js
@@ -13,7 +13,12 @@ const parentTypes = {
 
   'object': 'any',
 
-  'array': 'any'
+  'array': 'any',
+  'array[boolean]': 'array',
+  'array[number]': 'array',
+  'array[integer]': 'array',
+  'array[string]': 'array',
+  'array[object]': 'array'
 }
 
 // Children of each type

--- a/tests/function/fixtures/code_include_1_any.js
+++ b/tests/function/fixtures/code_include_1_any.js
@@ -1,3 +1,3 @@
-(function () {
+function _() {
   return "any"
-})
+}

--- a/tests/function/fixtures/code_include_1_integer.js
+++ b/tests/function/fixtures/code_include_1_integer.js
@@ -1,3 +1,3 @@
-(function () {
+function _() {
   return "integer"
-})
+}

--- a/tests/function/fixtures/code_include_1_string.js
+++ b/tests/function/fixtures/code_include_1_string.js
@@ -1,3 +1,3 @@
-(function () {
+function _() {
   return "string"
-})
+}

--- a/tests/function/fixtures/defaults_1.fun.xml
+++ b/tests/function/fixtures/defaults_1.fun.xml
@@ -8,7 +8,7 @@
   </params>
   <implems>
     <implem language="js">
-      <code>(function(param1){ return param1 })</code>
+      <code>function(param1){ return param1 }</code>
     </implem>
   </implems>
   <tests>

--- a/tests/function/fixtures/defaults_2.fun.xml
+++ b/tests/function/fixtures/defaults_2.fun.xml
@@ -11,7 +11,7 @@
   </params>
   <implems>
     <implem language="js">
-      <code>(function(param1, param2){ return param1 + param2})</code>
+      <code>function(param1, param2){ return param1 + param2}</code>
     </implem>
   </implems>
   <tests>

--- a/tests/function/fixtures/maxi.fun.xml
+++ b/tests/function/fixtures/maxi.fun.xml
@@ -1,0 +1,45 @@
+<!DOCTYPE function PUBLIC "StencilaFunction 1.0" "StencilaFunction.dtd">
+<function>
+  <name>maxi</name>
+  <title>Maximal example</title>
+  <summary>Test of a maximal function definition with all elements included</summary>
+  <description>Hust a test fixture to ensure that a maximally defined function can at least be defined and imported into memory</description>
+  <relateds>
+    <related>min</related>
+  </relateds>
+  <params>
+    <param name="param1" type="integer">
+      <description>The parameter for this function</description>
+      <default type="integer">2</default>
+    </param>
+  </params>
+  <return type="integer">
+    <description>The argument multiplied by 2</description>
+  </return>
+  <implems>
+    <implem language="js">
+      <code>function(param1){ return param1 * 2 }</code>
+    </implem>
+  </implems>
+  <examples>
+    <example>
+      <description>When called with no argument, the default parameter value is used</description>
+      <usage>maxi()</usage>
+      <result type="integer">4</result>
+    </example>
+    <example>
+      <description>Another example for this function</description>
+      <usage>maxi(3)</usage>
+      <result type="integer">6</result>
+    </example>
+  </examples>
+  <tests>
+    <test>
+      <description>A test for this function</description>
+      <args>
+        <arg type="integer">4</arg>
+      </args>
+      <result type="integer">8</result>
+    </test>
+  </tests>
+</function>

--- a/tests/function/fixtures/min.fun.xml
+++ b/tests/function/fixtures/min.fun.xml
@@ -4,7 +4,7 @@
   <name>min</name>
   <implems>
     <implem language="js">
-      <code>(function(){ return 42 })</code>
+      <code>function(){ return 42 }</code>
     </implem>
   </implems>
 </function>

--- a/tests/function/fixtures/min_plus_tests.fun.xml
+++ b/tests/function/fixtures/min_plus_tests.fun.xml
@@ -3,7 +3,7 @@
   <name>min_plus_tests</name>
   <implems>
     <implem language="js">
-      <code>(function(){ return 42 })</code>
+      <code>function(){ return 42 }</code>
     </implem>
   </implems>
   <tests>

--- a/tests/function/fixtures/overloads_1.fun.xml
+++ b/tests/function/fixtures/overloads_1.fun.xml
@@ -9,19 +9,19 @@
       <types>
         <type type="number"/>
       </types>
-      <code>(function(){ return "number" })</code>
+      <code>function(){ return "number" }</code>
     </implem>
     <implem language="js">
       <types>
         <type type="integer"/>
       </types>
-      <code>(function(){ return "integer" })</code>
+      <code>function(){ return "integer" }</code>
     </implem>
     <implem language="js">
       <types>
         <type type="string"/>
       </types>
-      <code>(function(){ return "string" })</code>
+      <code>function(){ return "string" }</code>
     </implem>
   </implems>
   <tests>

--- a/tests/function/fixtures/overloads_2.fun.xml
+++ b/tests/function/fixtures/overloads_2.fun.xml
@@ -11,21 +11,21 @@
         <type type="number"/>
         <type type="number"/>
       </types>
-      <code>(function(){ return "number, number" })</code>
+      <code>function(){ return "number, number" }</code>
     </implem>
     <implem language="js">
       <types>
         <type type="number"/>
         <type type="integer"/>
       </types>
-      <code>(function(){ return "number, integer" })</code>
+      <code>function(){ return "number, integer" }</code>
     </implem>
     <implem language="js">
       <types>
         <type type="integer"/>
         <type type="any"/>
       </types>
-      <code>(function(){ return "integer, any" })</code>
+      <code>function(){ return "integer, any" }</code>
     </implem>
   </implems>
   <tests>

--- a/tests/function/functions.test.js
+++ b/tests/function/functions.test.js
@@ -2,7 +2,7 @@ import test from 'tape'
 import { Configurator } from 'substance'
 
 import { FunctionPackage, FunctionSchema } from '../../src/function'
-import JsContext from '../../src/js-context/JsContext'
+import JsContext from '../../src/contexts/JsContext'
 
 import testVFS from '../../tmp/test-vfs.js'
 
@@ -29,6 +29,7 @@ function loadFunction (path) {
 
 function testFunction (path) {
   const func = loadFunction(path)
+  func.initialize()
   let context = new JsContext()
   return func.test('js', context)
 }

--- a/tests/function/functions.test.js
+++ b/tests/function/functions.test.js
@@ -1,16 +1,11 @@
 import test from 'tape'
-import { Configurator } from 'substance'
 
-import { FunctionPackage, FunctionSchema } from '../../src/function'
+import { importFunctionDocument } from '../../src/function'
 import JsContext from '../../src/contexts/JsContext'
 
 import testVFS from '../../tmp/test-vfs.js'
 
 function loadFunction (path) {
-  let configurator = new Configurator()
-  configurator.import(FunctionPackage)
-  const importer = configurator.createImporter(FunctionSchema.getName())
-
   // Main XML function definition
   let main = testVFS[path]
   // Source code for function implementations that are "included"
@@ -22,9 +17,7 @@ function loadFunction (path) {
     if (match) siblings[match[1]] = testVFS[path]
   }
 
-  const xml = importer.compileDocument(main, siblings)
-  const func = importer.importDocument(xml)
-  return func
+  return importFunctionDocument(main, siblings)
 }
 
 function testFunction (path) {

--- a/tests/function/functions.test.js
+++ b/tests/function/functions.test.js
@@ -47,4 +47,3 @@ for (let file of Object.keys(testVFS)) {
     })
   }
 }
-


### PR DESCRIPTION
Some improvement to `Functions` and relevant parts of `JsContext`...

- remove `option.pack` from `JsContext` methods as it is an optimisation that we identified in July as causing confusion.

- fixes and improvements for multi-language dispatch of calls

- Add descriptive elements to the schema based on [our initial work on defining functions](https://github.com/stencila/stencila/issues/310#issuecomment-326141685) which was in turn informed by things like [JsDoc](http://usejsdoc.org/) and [R function documentation](https://cran.r-project.org/doc/manuals/R-exts.html#Rd-format);

  - `<summary>` : short one sentence summary suitable for use in tooltips etc (like JsDoc `@summary`)
  - `<relateds>` : names of related functions (like JsDoc `@see`)
  - `<examples>` : examples of usage (like JsDoc `@example`)

@oliver---- : I am hoping that this will be the end of the first iteration of `Functions`. Could you review and merge. 

I will work on defining functions in https://github.com/stencila/lib and use lessons learned during that for a possible second iteration in the next 2-3 weeks.