### PR TITLE
Ensure an array for each type

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -26,6 +26,7 @@ const parentTypes = {
 // Children of each type
 let childrenTypes = {}
 for (let type of Object.keys(parentTypes)) {
+  if (!childrenTypes[type]) childrenTypes[type] = []
   let base = parentTypes[type]
   if (!base) continue
   if (childrenTypes[base]) childrenTypes[base].push(type)
@@ -35,6 +36,7 @@ for (let type of Object.keys(parentTypes)) {
 // Descendants (children, grandchildren etc) of each type
 let descendantTypes = {}
 for (let type of Object.keys(parentTypes)) {
+  if (!descendantTypes[type]) descendantTypes[type] = []
   let parent = parentTypes[type]
   while (parent) {
     if (descendantTypes[parent]) descendantTypes[parent].push(type)

--- a/tests/types.test.js
+++ b/tests/types.test.js
@@ -1,0 +1,16 @@
+import test from 'tape'
+
+import { childrenTypes, descendantTypes } from '../src/types'
+
+test('childrenTypes', t => {
+  t.deepEqual(childrenTypes['number'], ['integer'])
+  t.deepEqual(childrenTypes['table'], [])
+
+  t.end()
+})
+
+test('descendantTypes', t => {
+  t.deepEqual(descendantTypes['table'], [])
+
+  t.end()
+})


### PR DESCRIPTION
Fixes an issue when calling a function in mini when the param type had no decendant types array.