### PR TITLE
WIP: integrate updated version of Mini

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "katex": "^0.6.0",
     "lodash": "^4.17.4",
     "plotly.js": "^1.31.1",
-    "stencila-libcore": "0.2.4",
+    "stencila-libcore": "0.2.5",
     "stencila-mini": "^0.12.4",
     "substance": "1.0.0-preview.5",
     "substance-texture": "1.0.0-alpha.4-preview.5",

--- a/src/function/FunctionSchema.rng
+++ b/src/function/FunctionSchema.rng
@@ -37,6 +37,9 @@
         <optional>
           <ref name="function:tests"/>
         </optional>
+        <optional>
+          <ref name="function:authors"/>
+        </optional>
       </interleave>
     </element>
   </define>
@@ -220,6 +223,20 @@
         </optional>
         <ref name="function:result"/>
       </interleave>
+    </element>
+  </define>
+
+  <define name="function:authors">
+    <element name="authors">
+      <zeroOrMore>
+        <ref name="function:author"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="function:author">
+    <element name="author">
+      <text/>
     </element>
   </define>
 

--- a/src/types.js
+++ b/src/types.js
@@ -4,6 +4,10 @@
 const parentTypes = {
   'any': null,
 
+  'syntax': 'any',
+  'call': 'syntax',
+  'symbol': 'syntax',
+
   'boolean': 'any',
 
   'number': 'any',


### PR DESCRIPTION
Updates to Mini necessitate changes to`MiniContext`:

- operator functions are no longer necessary e.g. `minus`, `divide` etc as they are being implemented in libcore

- handling of lambda expressions which are evaluated within a function call see https://github.com/stencila/mini/pull/19