### PR TITLE
Remove generation of a float type

### DIFF
--- a/src/sheet/SheetLinter.js
+++ b/src/sheet/SheetLinter.js
@@ -229,20 +229,11 @@ function isInt(str) {
   return (parseInt(str, 10) == str) // eslint-disable-line eqeqeq
 }
 
-// TODO: we need to discuss if we want to
-// allow '1' as float, or if we want to force '1.0' when type is float
-function isFloat(str) {
-  return (str.indexOf('.') !== -1)
-}
-
 function autoDetectType(str) {
   // numbers
   if (!isNaN(str)) {
     if (isInt(str)) {
       return 'integer'
-    }
-    if (isFloat(str)) {
-      return 'float'
     }
     return 'number'
   }

--- a/src/value.js
+++ b/src/value.js
@@ -22,7 +22,7 @@ export function type (value) {
     let isInteger = false
     if (value.isInteger) isInteger = value.isInteger()
     else isInteger = (value % 1) === 0
-    return isInteger ? 'integer' : 'float'
+    return isInteger ? 'integer' : 'number'
   } else if (type === 'string') {
     return 'string'
   } else if (type === 'object') {
@@ -52,7 +52,7 @@ export function pack (value) {
 
   if (type_ === 'null') {
     content = 'null'
-  } else if (type_ === 'boolean' || type_ === 'integer' || type_ === 'float') {
+  } else if (type_ === 'boolean' || type_ === 'integer' || type_ === 'number') {
     content = value.toString()
   } else if (type_ === 'string') {
     content = value
@@ -94,7 +94,7 @@ export function unpack (pkg) {
     return content === 'true'
   } else if (type === 'integer') {
     return parseInt(content, 10)
-  } else if (type === 'float') {
+  } else if (type === 'number') {
     return parseFloat(content)
   } else if (type === 'string') {
     return content

--- a/tests/value.test.js
+++ b/tests/value.test.js
@@ -12,9 +12,9 @@ test('value.type', t => {
   t.equal(type(1000000000), 'integer')
   t.equal(type(1.1e20), 'integer')
 
-  t.equal(type(3.14), 'float')
-  t.equal(type(Math.PI), 'float')
-  t.equal(type(1.1e-20), 'float')
+  t.equal(type(3.14), 'number')
+  t.equal(type(Math.PI), 'number')
+  t.equal(type(1.1e-20), 'number')
 
   t.equal(type(''), 'string')
   t.equal(type('Yo!'), 'string')
@@ -52,11 +52,11 @@ test('value.pack works for primitive types', t => {
   check(t, 42, 'integer', 'text', '42')
   check(t, 1000000000, 'integer', 'text', '1000000000')
 
-  check(t, 3.14, 'float', 'text', '3.14')
-  check(t, Math.PI, 'float', 'text', '3.141592653589793')
+  check(t, 3.14, 'number', 'text', '3.14')
+  check(t, Math.PI, 'number', 'text', '3.141592653589793')
 
   check(t, 1.1e20, 'integer', 'text', '110000000000000000000')
-  check(t, 1.1e-20, 'float', 'text', '1.1e-20')
+  check(t, 1.1e-20, 'number', 'text', '1.1e-20')
 
   check(t, '', 'string', 'text', '')
   check(t, 'Yo!', 'string', 'text', 'Yo!')
@@ -129,8 +129,8 @@ test('value.unpack works for primitive types', t => {
   t.equal(unpack({type: 'integer', format: 'text', content: '42'}), 42)
   t.equal(unpack({type: 'integer', format: 'text', content: '1000000000'}), 1000000000)
 
-  t.equal(unpack({type: 'float', format: 'text', content: '3.12'}), 3.12)
-  t.equal(unpack({type: 'float', format: 'text', content: '1e20'}), 1e20)
+  t.equal(unpack({type: 'number', format: 'text', content: '3.12'}), 3.12)
+  t.equal(unpack({type: 'number', format: 'text', content: '1e20'}), 1e20)
 
   t.equal(unpack({type: 'string', format: 'text', content: 'Yo!'}), 'Yo!')
 


### PR DESCRIPTION
Fix for #480. Currently the type system treats `integer` as a specialisation of `number` and there is no `float` type. This remove generation of the `float` type in various places.
