### PR TITLE
Fix reference selection styles

### DIFF
--- a/src/sheet/SheetComponent.js
+++ b/src/sheet/SheetComponent.js
@@ -216,10 +216,13 @@ export default class SheetComponent extends CustomSurface {
     }
   }
 
-  _positionRangeSelection(sel) {
+  _positionReferenceSelection(sel) {
     const rects = this._computeSelectionRects(sel)
     const styles = this._computeSelectionStyles(sel, rects)
-    this.refs.selRange.css(styles.range)
+    const selRange = this.refs.selRange
+    selRange
+      .addClass('sm-reference-selection')
+      .css(styles.range)
   }
 
   _computeSelectionRects(sel) {
@@ -377,6 +380,11 @@ export default class SheetComponent extends CustomSurface {
     }
 
     return styles
+  }
+
+  _hideReferenceSelection() {
+    this.refs.selRange.removeClass('sm-reference-selection')
+    this._hideSelection()
   }
 
   _hideSelection() {
@@ -555,7 +563,7 @@ export default class SheetComponent extends CustomSurface {
 
   _onSelectionChange(sel) {
     if (sel.surfaceId !== this.getId()) {
-      this._hideSelection()
+      this._hideReferenceSelection()
     } else {
       // ensure that the view port is showing
       const sel = this._getSelection()

--- a/src/sheet/SheetComponent.js
+++ b/src/sheet/SheetComponent.js
@@ -477,6 +477,7 @@ export default class SheetComponent extends CustomSurface {
 
   _requestSelectionChange() {
     let sel = this._createSelection(clone(this._selectionData))
+    this._hideReferenceSelection()
     this.send('requestSelectionChange', sel)
   }
 

--- a/src/sheet/SheetEditor.js
+++ b/src/sheet/SheetEditor.js
@@ -324,7 +324,7 @@ export default class SheetEditor extends AbstractEditor {
     }
 
     const sheetComp = this.getSheetComponent()
-    sheetComp._positionRangeSelection({
+    sheetComp._positionReferenceSelection({
       type: 'custom',
       customType: 'sheet',
       data: selData,
@@ -355,7 +355,7 @@ export default class SheetEditor extends AbstractEditor {
         this._setReferenceSelection(cellReference)
       } else {
         const sheetComp = this.getSheetComponent()
-        sheetComp._hideSelection()
+        sheetComp._hideReferenceSelection()
       }
     }
   }
@@ -480,7 +480,7 @@ export default class SheetEditor extends AbstractEditor {
       const toCell = getCellLabel(selData.focusRow, selData.focusCol)
       const sheetComp = this.getSheetComponent()
       this._replaceEditorToken(fromCell, toCell)
-      sheetComp._positionRangeSelection(newSelection)
+      sheetComp._positionReferenceSelection(newSelection)
     } else {
       const editorSession = this.getEditorSession()
       editorSession.setSelection(newSelection)

--- a/src/sheet/_sheet.css
+++ b/src/sheet/_sheet.css
@@ -188,7 +188,13 @@
 
 .se-selection-overlay > .se-selection-range {
   position: absolute;
+  border: solid 1px #2684FC;
+  background: rgba(38, 132, 252, 0.1)
+}
+
+.se-selection-overlay > .se-selection-range.sm-reference-selection {
   border: dashed 1px #2684FC;
+  background: transparent;
 }
 
 .se-selection-overlay > .se-selection-columns,


### PR DESCRIPTION
This is somehow fixing #484 and should be reviewed.
In my taste it's a bit hacky, but the alternative would be creation of selection overlay just for handling reference selection, i think it's a bit stupid since it's absolutely the same as a range selection, it's only need to be visually distinguished.
Maybe we should return to this question when we will need to expose multiple range/reference selections. Because this would be not enough to cover that case.