### PR TITLE
Dynamically loading of functions

### DIFF
--- a/src/contexts/ContextHttpClient.js
+++ b/src/contexts/ContextHttpClient.js
@@ -26,6 +26,15 @@ export default class ContextHttpClient extends Context {
   }
 
   /**
+   * Get a list of function libraries
+   *
+   * @override
+   */
+  getLibraries () {
+    return PUT(this.url + '!getLibraries')
+  }
+
+  /**
    * Analyse code
    *
    * @override
@@ -58,7 +67,7 @@ export default class ContextHttpClient extends Context {
    *
    * @override
    */
-  callFunction (name, inputs, namedInputs, options) {
-    return PUT(this.url + '!callFunction', {name: name, inputs: inputs, namedInputs: namedInputs, options: options})
+  callFunction (library, name, args, namedArgs) {
+    return PUT(this.url + '!callFunction', {library: library, name: name, args: args, namedArgs: namedArgs})
   }
 }

--- a/src/contexts/MiniContext.js
+++ b/src/contexts/MiniContext.js
@@ -55,49 +55,6 @@ export default class MiniContext {
     // Get a context for the implementation language
     return this._host.createContext(language)
     .then((context) => {
-      /*
-      // Generate a correctly ordered array of argument values taking into account
-      // named arguments and default values and check for:
-      //  - missing parameters
-      //  - superfluous arguments
-      //  - arguments of wrong type
-      let params = funcDoc.getParams()
-      let args = funcCall.args || []
-      if (args.length > params.length) {
-        return _error(`Too many parameters supplied (${args.length}), expected ${params.length} at most`)
-      }
-      let namedArgs = funcCall.namedArgs || []
-      let namedArgsMap = {}
-      for (let namedArg of namedArgs) {
-        let found = false
-        for (let param of params) {
-          if (param.name === namedArg.name) {
-            found = true
-            break
-          }
-        }
-        if (!found) {
-          return _error(`"${namedArg.name}" is not a valid parameter name for function "${functionName}"`)
-        }
-        namedArgsMap[namedArg.name] = namedArg
-      }
-      let argValues = []
-      let index = 0
-      for (let param of params) {
-        const arg = args[index] || namedArgsMap[param.name]
-        const value = arg ? arg.getValue() : param.default
-        if (!value) {
-          return _error(`Required parameter "${param.name}" was not supplied`)
-        }
-        if (value.type !== param.type) {
-          if (descendantTypes[param.type].indexOf(value.type) < 0) {
-            return _error(`Parameter "${param.name}" must be of type "${param.type}" but was of type "${value.type}"`)
-          }
-        }
-        argValues.push(value)
-        index++
-      }
-      */
       // Call the function implementation in the context, capturing any
       // messages or returning the value
       let libraryName = this._functionManager.getLibraryName(functionName)

--- a/src/contexts/MiniContext.js
+++ b/src/contexts/MiniContext.js
@@ -1,7 +1,6 @@
 import { parse } from 'stencila-mini'
 import libcore from 'stencila-libcore'
 import { getCellLabel } from '../shared/cellHelpers'
-import { descendantTypes } from '../types'
 import { gather } from '../value'
 
 export default class MiniContext {
@@ -56,6 +55,7 @@ export default class MiniContext {
     // Get a context for the implementation language
     return this._host.createContext(language)
     .then((context) => {
+      /*
       // Generate a correctly ordered array of argument values taking into account
       // named arguments and default values and check for:
       //  - missing parameters
@@ -97,10 +97,16 @@ export default class MiniContext {
         argValues.push(value)
         index++
       }
+      */
       // Call the function implementation in the context, capturing any
       // messages or returning the value
       let libraryName = this._functionManager.getLibraryName(functionName)
-      return context.callFunction(libraryName, functionName, argValues).then((res) => {
+      let argValues = funcCall.args.map(arg => arg.getValue())
+      let namedArgValues = {}
+      for (let name of Object.keys(funcCall.namedArgs)) {
+        namedArgValues[name] = funcCall.namedArgs[name].getValue()
+      }
+      return context.callFunction(libraryName, functionName, argValues, namedArgValues).then((res) => {
         if (res.messages && res.messages.length > 0) {
           funcCall.addErrors(res.messages)
           return undefined

--- a/src/host/Host.js
+++ b/src/host/Host.js
@@ -49,8 +49,6 @@ export default class Host {
      */
     this._peers = {}
 
-    // TODO: consider instantiating the FunctionManager here, within this host, instead of in setupStencilaContext.
-    // ATM, its the only place that FunctionManager and used
     this._functionManager = options.functionManager
 
     if (!this._functionManager) {

--- a/tests/contexts/MiniContext.test.js
+++ b/tests/contexts/MiniContext.test.js
@@ -75,24 +75,6 @@ test('MiniContext: no_params() + 1', t => {
   })
 })
 
-test('MiniContext: no_params(4)', t => {
-  let c = setupContextWithFunctions()
-  c.executeCode('no_params(4)').then((res) => {
-    t.ok(_hasError(res), 'should error')
-    t.equal(_getMessage(res), 'Too many parameters supplied (1), expected 0 at most', 'error message should be correct')
-    t.end()
-  })
-})
-
-test('MiniContext: no_params(param_foo=4)', t => {
-  let c = setupContextWithFunctions()
-  c.executeCode('no_params(param_foo=4)').then((res) => {
-    t.ok(_hasError(res), 'should error')
-    t.equal(_getMessage(res), '"param_foo" is not a valid parameter name for function "no_params"', 'error message should be correct')
-    t.end()
-  })
-})
-
 test('MiniContext: one_param(2)', t => {
   let c = setupContextWithFunctions()
   c.executeCode('one_param(2)').then((res) => {
@@ -103,49 +85,6 @@ test('MiniContext: one_param(2)', t => {
   })
 })
 
-test('MiniContext: one_param()', t => {
-  let c = setupContextWithFunctions()
-  c.executeCode('one_param()').then((res) => {
-    t.ok(_hasError(res), 'should error')
-    t.equal(_getMessage(res), 'Required parameter "param1" was not supplied', 'error message should be correct')
-    t.end()
-  })
-})
-
-test('MiniContext: one_param(1, 2, 3)', t => {
-  let c = setupContextWithFunctions()
-  c.executeCode('one_param(1, 2, 3)').then((res) => {
-    t.ok(_hasError(res), 'should error')
-    t.equal(_getMessage(res), 'Too many parameters supplied (3), expected 1 at most', 'error message should be correct')
-    t.end()
-  })
-})
-
-test('MiniContext: one_param(param1=4)', t => {
-  let c = setupContextWithFunctions()
-  c.executeCode('one_param(param1=4)').then((res) => {
-    t.equal(res.value.data, 4.4, 'result should be correct')
-    t.end()
-  })
-})
-
-test('MiniContext: one_param(param_foo=4)', t => {
-  let c = setupContextWithFunctions()
-  c.executeCode('one_param(param_foo=4)').then((res) => {
-    t.ok(_hasError(res), 'should error')
-    t.equal(_getMessage(res), '"param_foo" is not a valid parameter name for function "one_param"', 'error message should be correct')
-    t.end()
-  })
-})
-
-test('MiniContext: one_param("wrong type")', t => {
-  let c = setupContextWithFunctions()
-  c.executeCode('one_param("wrong type")').then((res) => {
-    t.ok(_hasError(res), 'should error')
-    t.equal(_getMessage(res), 'Parameter "param1" must be of type "number" but was of type "string"', 'error message should be correct')
-    t.end()
-  })
-})
 
 test('MiniContext: one_param_with_default("Howdy!")', t => {
   let c = setupContextWithFunctions()
@@ -162,12 +101,3 @@ test('MiniContext: one_param_with_default()', t => {
     t.end()
   })
 })
-
-function _hasError(res) {
-  return res.messages && res.messages.length > 0
-}
-
-function _getMessage(res) {
-  let error = res.messages[0]
-  return error ? error.message : undefined
-}

--- a/tests/contexts/libtest.js
+++ b/tests/contexts/libtest.js
@@ -60,7 +60,7 @@ const one_param_with_defaultXML = `
 </function>
 `
 
-function one_param_with_default(param1) {
+function one_param_with_default(param1='Hello!') {
   return param1
 }
 


### PR DESCRIPTION
At present only Javascript function libraries can be loaded and only at build (bundling) time. This PR allows for dynamic loading of libraries from external execution contexts (e.g. R, Python) in alternative languages.

The use case for this functionality is a researcher who would like to wrap existing R or Python code and make it available as a Stencila function. We are trying to keep this process as simple as possible and allow users to use existing documentation formats and tools. Allowing for "hot-loading" functions provides some motivation - allowing them to see their function immediately available - and for manual testing.

For example, here is an RStudio session which uses the [stencila/r](https://github.com/stencila/r) package to register some custom functions with Stencila:

- `register_function`: registers a function (either from source file or a function object) and converts the function's documentation (either from same source files, built-in, or by parsing function object's source) to Stencila `Function` XML.
- `register_library`: registers a folder of functions in `*.R` files

The user can then connect to the Stencila `Host` that was started in R, see the documentation, and use, those functions:

![image](https://user-images.githubusercontent.com/1152336/35200802-034be4ec-ff79-11e7-8e8b-194922a74cdb.png)

Then within Stencila the user can

![image](https://user-images.githubusercontent.com/1152336/35200784-d05b3876-ff78-11e7-8411-36c046518db6.png)

This PR also removes argument checking when calling a function from `MiniContext`. Checking of call arguments was done based on a function's XML spec, specifically, the `<params>` element - a form of dynamic type checking before each call. There needed to be concordance between the spec and the implementation (the spec wasn't just extra documentation).

This introduced friction when writing functions because, often, the implementation would diverge from the spec. To make it easier for contributors to write functions we`re moving towards dynamic argument checking/dispatching and XML specs/docs based of language native tools (e.g. JsDoc for Js, roxygen for R, docstrings for Python).

In the future we will introduce more formal static type checking (based on the entire call graph, not just single call arg checking). But for now this change makes it easier to implement and use functions.