### PR TITLE
Fix build deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_deploy:
     BUILD_NAME=$COMMIT_SLUG-$(date --utc --iso-8601)-$(echo $TRAVIS_COMMIT | cut -c 1-7)
     # Create a versioned folder for the build
     mkdir -p bucket/stencila
-    mv build bucket/stencila/$BUILD_NAME
+    mv dist bucket/stencila/$BUILD_NAME
     # Update the list of builds
     curl -s http://builds.stenci.la/stencila/builds.txt > bucket/stencila/builds.txt
     echo $BUILD_NAME >> bucket/stencila/builds.txt

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,9 @@ cover:
 
 build:
 	npm run build
-.PHONY: build
 
 docs-serve:
 	npm run docs-serve
 
 clean:
-	rm -rf node_modules build tmp
+	node make clean


### PR DESCRIPTION
# Why

Changing the name of`build` to `dist` (which is more standard naming) broke the deployments of PR builds to builds.stenci.la.

# What

Just changed the name of the folder that is deployed and make some other fixes related to the name change.