### PR TITLE
Add charset="utf-8" instruction to example HTML.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>Stencila Project</title>
     <link rel="stylesheet" type="text/css" href="./stencila.css">
     <script type="text/javascript" src="./katex/katex.min.js"></script>


### PR DESCRIPTION
### Why

Charset is broken on builds.stenci.la
### What

Found out this can be fixed by explicitly providing the charset in the HTML, so did just that.
