### PR TITLE
Cross browser type over.

### DIFF
--- a/src/sheet/SheetComponent.js
+++ b/src/sheet/SheetComponent.js
@@ -793,10 +793,14 @@ export default class SheetComponent extends CustomSurface {
   /*
     Type into cell (replacing the existing content)
   */
-  _onInput(e) {
-    if (e.inputType === 'insertText') {
-      this.send('editCell', e.data)
-    }
+  _onInput() {
+    this.send('editCell')
+  }
+
+  _pullKeyTrapValue() {
+    const value = this.refs.keytrap.val()
+    this.refs.keytrap.val('')
+    return value
   }
 
   _onKeyDown(e) {

--- a/src/sheet/SheetComponent.js
+++ b/src/sheet/SheetComponent.js
@@ -794,13 +794,10 @@ export default class SheetComponent extends CustomSurface {
     Type into cell (replacing the existing content)
   */
   _onInput() {
-    this.send('editCell')
-  }
-
-  _pullKeyTrapValue() {
     const value = this.refs.keytrap.val()
+    this.send('editCell', value)
+    // Clear keytrap after sending an action
     this.refs.keytrap.val('')
-    return value
   }
 
   _onKeyDown(e) {

--- a/src/sheet/SheetEditor.js
+++ b/src/sheet/SheetEditor.js
@@ -429,9 +429,11 @@ export default class SheetEditor extends AbstractEditor {
   /*
     Request inline editor
   */
-  _editCell(initialValue) {
+  _editCell() {
     const formulaEditorSession = this._formulaEditorContext.editorSession
     const formulaNode = this._formulaEditorContext.node
+    const sheetComp = this.getSheetComponent()
+    const initialValue = sheetComp._pullKeyTrapValue()
     if (initialValue) {
       this._setFormula(initialValue)
     }

--- a/src/sheet/SheetEditor.js
+++ b/src/sheet/SheetEditor.js
@@ -429,11 +429,9 @@ export default class SheetEditor extends AbstractEditor {
   /*
     Request inline editor
   */
-  _editCell() {
+  _editCell(initialValue) {
     const formulaEditorSession = this._formulaEditorContext.editorSession
     const formulaNode = this._formulaEditorContext.node
-    const sheetComp = this.getSheetComponent()
-    const initialValue = sheetComp._pullKeyTrapValue()
     if (initialValue) {
       this._setFormula(initialValue)
     }


### PR DESCRIPTION
Current type over relies on experimental technology which is working only in chrome bigger than 60 and opera. 
This PR changes implementation to more classical one.