### PR TITLE
Clear errors after changing expression to constant.

### DIFF
--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -79,6 +79,10 @@ export default class Engine {
       this._candidates.delete(cell)
       this._updateDependencies(cellId)
       this._graph.removeCell(cellId)
+      let cellState = getCellState(cell)
+      cellState.messages = []
+      deriveCellStatus(cellState)
+      this._notifyCells(cell.id)
     }
   }
 


### PR DESCRIPTION
We have a bug (#596) with error notifications in sheets which are become immortal and you can't remove it neither with constant input, neither with deleting cell contents. The problem came from engine bug: when you are changing expression to constant cell got removed from graph, but the state didn't change for a cell. 
This PR addressing described bug by removing stuck error message, deriving cell status and notifying cell.