### PR TITLE
Cell range updates (first round)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "plotly.js": "^1.31.1",
     "stencila-libcore": "^0.2.8",
     "stencila-mini": "^0.14.0",
-    "substance": "1.0.0-preview.32",
+    "substance": "1.0.0-preview.34",
     "substance-texture": "^1.0.0-preview.1.4",
     "timeago.js": "3.0.0",
     "xmlhttprequest": "^1.8.0"

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -147,6 +147,8 @@ export function qualifiedId(doc, cell) {
   }
 }
 
+export const BROKEN_REF = '#REF!'
+
 export function transformCellRangeExpression(expr, params) {
   const mode = params.mode
   const idx = params.idx

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -92,7 +92,9 @@ export function getRowCol(cellLabel) {
 
 export function getError(cell) {
   let cellState = getCellState(cell)
-  return cellState.errors[0]
+  if (cellState) {
+    return cellState.errors[0]
+  }
 }
 
 export function getFrameSize(layout) {
@@ -115,22 +117,27 @@ export function queryCells(cells, query) {
     }
     case 'range': {
       let [anchor, focus] = name.split(':')
-      const [anchorRow, anchorCol] = getRowCol(anchor)
-      const [focusRow, focusCol] = getRowCol(focus)
-      if (anchorRow === focusRow && anchorCol === focusCol) {
-        return cells[anchorCol][focusCol]
+      const [startRow, startCol] = getRowCol(anchor)
+      const [endRow, endCol] = getRowCol(focus)
+      if (startRow === endRow && startCol === endCol) {
+        return cells[startCol][endCol]
       }
-      if (anchorRow === focusRow) {
-        return cells[anchorRow].slice(anchorCol, focusCol+1)
+      if (startRow === endRow) {
+        return cells[startRow].slice(startCol, endCol+1)
       }
-      if (anchorCol === focusCol) {
+      if (startCol === endCol) {
         let res = []
-        for (let i = anchorRow; i <= focusRow; i++) {
-          res.push(cells[i][anchorCol])
+        for (let i = startRow; i <= endRow; i++) {
+          res.push(cells[i][startCol])
+        }
+        return res
+      } else {
+        let res = []
+        for (var i = startRow; i < endRow+1; i++) {
+          res.push(cells[i].slice(startCol, endCol+1))
         }
         return res
       }
-      throw new Error('Unsupported query')
     }
     default:
       throw new Error('Unsupported query')

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -158,7 +158,7 @@ export function transformCellRangeExpression(expr, params) {
     throw new Error('Illegal arguments')
   }
 
-  let borders = getCellRangeBorders(expr, dim)
+  let borders = _getCellRangeBorders(expr, dim)
   const isCellReference = borders.start === borders.end
 
   // If operation applied to col/rows after given borders we shoudn't modify expression
@@ -180,28 +180,28 @@ export function transformCellRangeExpression(expr, params) {
       return BROKEN_REF
     }
 
-    const pos1 = idx
-    const pos2 = idx + count
+    const x1 = idx
+    const x2 = idx + count
     const start = borders.start
     const end = borders.end
-    if (pos2 <= start) {
+    if (x2 <= start) {
       borders.start -= count
       borders.end -= count
     } else {
-      if (pos1 <= start) {
-        borders.start = start - Math.min(pos2-pos1, start-pos1)
+      if (idx <= start) {
+        borders.start = start - Math.min(count, start - x1)
       }
-      if (pos1 <= end) {
-        borders.end = end - Math.min(pos2-pos1, end-pos1)
+      if (idx <= end) {
+        borders.end = end - Math.min(count, end - x1 + 1)
       }
     }
   }
 
   // get labels
-  return modifyCellRangeLabel(expr, borders, dim)
+  return _modifyCellRangeLabel(expr, borders, dim)
 }
 
-export function getCellRangeBorders(expr, dim) {
+function _getCellRangeBorders(expr, dim) {
   if(!expr || !dim) {
     throw new Error('Illegal arguments.')
   }
@@ -233,7 +233,7 @@ export function getCellRangeBorders(expr, dim) {
   return borders
 }
 
-export function modifyCellRangeLabel(expr, borders, dim) {
+function _modifyCellRangeLabel(expr, borders, dim) {
   if(!expr || !borders || !dim) {
     throw new Error('Illegal arguments.')
   }
@@ -247,8 +247,6 @@ export function modifyCellRangeLabel(expr, borders, dim) {
       startCol = borders.start
     } else if (dim === 'row') {
       startRow = borders.start
-    } else {
-      throw new Error('Illegal dimension: ' + dim)
     }
 
     return getCellLabel(startRow, startCol)
@@ -263,8 +261,6 @@ export function modifyCellRangeLabel(expr, borders, dim) {
   } else if (dim === 'row') {
     startRow = borders.start
     endRow = borders.end
-  } else {
-    throw new Error('Illegal dimension: ' + dim)
   }
 
   return getCellLabel(startRow, startCol) + ':' + getCellLabel(endRow, endCol)

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -92,8 +92,15 @@ export function getRowCol(cellLabel) {
 
 export function getError(cell) {
   let cellState = getCellState(cell)
-  if (cellState) {
+  if (cellState && cellState.errors) {
     return cellState.errors[0]
+  }
+}
+
+export function getValue(cell) {
+  let cellState = getCellState(cell)
+  if (cellState) {
+    return cellState.value
   }
 }
 

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -150,7 +150,7 @@ export function qualifiedId(doc, cell) {
 export const BROKEN_REF = '#REF!'
 
 export function transformCellRangeExpression(expr, params) {
-  const dim = params.mode
+  const dim = params.dim
   const idx = params.idx
   const count = Math.abs(params.count)
   const mode = params.count > 0 ? 'insert' : 'remove'

--- a/src/shared/expressionHelpers.js
+++ b/src/shared/expressionHelpers.js
@@ -86,6 +86,8 @@ export function transpile(code, map = {}) {
 export function parseSymbol(str) {
   let m = REF_RE.exec(str)
   if (!m) throw new Error('Unrecognised symbol format.')
+  const startPos = m.index
+  const endPos = m[0].length + startPos
   const mangledStr = toIdentifier(m[0])
   const scope = m[1] || m[2]
   const anchorCell = m[3]
@@ -106,7 +108,7 @@ export function parseSymbol(str) {
   } else {
     throw new Error('Invalid symbol expression')
   }
-  return { type, scope, name, mangledStr }
+  return { type, scope, name, mangledStr, startPos, endPos }
 }
 
 /*
@@ -119,4 +121,28 @@ export function parseSymbol(str) {
 */
 export function toIdentifier(str, c = '_') {
   return str.replace(new RegExp(INVALID_ID_CHARACTERS,'g'), c)
+}
+
+
+export function getCellExpressions(source) {
+  let re = new RegExp(REF, 'g')
+  let m
+  let result = []
+  while ((m = re.exec(source))) {
+    // NOTE: the array indexes used here correspond to the position of the capturing group
+    // make sure to update these if you change the structure of the regular expression
+    const text = m[0]
+    const startPos = m.index
+    const endPos = text.length + startPos
+
+    // if this is given, the reference is a transclusion
+    const docName = m[1] || m[2]
+    const focusCell = m[4]
+    const varName = m[5]
+
+    if(!varName) {
+      result.push({text, startPos, endPos})
+    }
+  }
+  return result
 }

--- a/src/shared/expressionHelpers.js
+++ b/src/shared/expressionHelpers.js
@@ -134,10 +134,6 @@ export function getCellExpressions(source) {
     const text = m[0]
     const startPos = m.index
     const endPos = text.length + startPos
-
-    // if this is given, the reference is a transclusion
-    const docName = m[1] || m[2]
-    const focusCell = m[4]
     const varName = m[5]
 
     if(!varName) {

--- a/src/sheet/SheetAdapter.js
+++ b/src/sheet/SheetAdapter.js
@@ -26,57 +26,80 @@ export default class SheetAdapter extends DocumentAdapter {
   }
 
   _onDocumentChange(change) {
-    // TODO: deal with updates to columns (name, types)
-
-    // TODO: with 'semantic' changes this could be much simpler,
-    // i.e. `change.info.action` consistently, and then detect
-    // structural changes more easily.
-    // For now we follow the old approach handling changes on op-per-op basis
-
     const doc = this.doc
     const model = this.model
-    // inspecting ops to detect structural changes and updates
-    // Cell removals are applied directly to the engine model
-    // while insertions are applied at the end
-    // 1. removes, 2. creates, 3. updates, 3. creates
-    let updated
-    const ops = change.ops
-    for (let i = 0; i < ops.length; i++) {
-      const op = ops[i]
-      // TODO: detect insert/remove row/col
-      // TODO: detect change of column types
-      switch (op.type) {
-        case 'create': {
-          break
+
+    let action = change.info.action
+    let matrix, cellData
+    switch(action) {
+      case 'insertRows': {
+        const { pos, count } = change.info
+        matrix = doc.getCellMatrix()
+        cellData = []
+        for (let i = pos; i < pos + count; i++) {
+          cellData.push(matrix[i].map(_getCellData))
         }
-        case 'delete': {
-          break
-        }
-        case 'set':
-        case 'update': {
-          let node = doc.get(op.path[0])
-          // null if node is deleted within the same change
-          if (!node) continue
-          if (this._isCell(node)) {
-            if (!updated) updated = new Set()
-            updated.add(node.id)
-          }
-          break
-        }
-        default:
-          //
+        model.insertRows(pos, cellData)
+        break
       }
-    }
-    // TODO: insert/delete row/col
-    if (updated) {
-      updated.forEach(id => {
-        const cell = this.doc.get(id)
-        const cellData = {
-          source: _getSource(cell),
-          lang: _getLang(cell)
+      case 'deleteRows': {
+        const { pos, count } = change.info
+        model.deleteRows(pos, count)
+        break
+      }
+      case 'insertCols': {
+        const { pos, count } = change.info
+        matrix = doc.getCellMatrix()
+        cellData = []
+        const N = matrix.length
+        for (let i = 0; i < N; i++) {
+          cellData.push(matrix[i].slice(pos, pos+count).map(_getCellData))
         }
-        model.updateCell(id, cellData)
-      })
+        model.insertCols(pos, cellData)
+        break
+      }
+      case 'deleteCols': {
+        const { pos, count } = change.info
+        model.deleteCols(pos, count)
+        break
+      }
+      default: {
+        // Note: only detecting updates on operation level
+        // structural changes (insert/remove row/column) are special type of changes
+        // TODO: deal with updates to columns (name, types)
+        let updated
+        const ops = change.ops
+        for (let i = 0; i < ops.length; i++) {
+          const op = ops[i]
+          // TODO: detect insert/remove row/col
+          // TODO: detect change of column types
+          switch (op.type) {
+            case 'set':
+            case 'update': {
+              let node = doc.get(op.path[0])
+              // null if node is deleted within the same change
+              if (!node) continue
+              if (this._isCell(node)) {
+                if (!updated) updated = new Set()
+                updated.add(node.id)
+              }
+              break
+            }
+            default:
+              //
+          }
+        }
+        if (updated) {
+          updated.forEach(id => {
+            const cell = this.doc.get(id)
+            const cellData = {
+              source: _getSource(cell),
+              lang: _getLang(cell)
+            }
+            model.updateCell(id, cellData)
+          })
+        }
+      }
     }
   }
 

--- a/src/sheet/SheetCell.js
+++ b/src/sheet/SheetCell.js
@@ -1,6 +1,6 @@
 import { NodeComponent } from 'substance'
 import ValueComponent from '../shared/ValueComponent'
-import { isExpression, getError } from '../shared/cellHelpers'
+import { isExpression, getError, getValue } from '../shared/cellHelpers'
 
 export default class SheetCell extends NodeComponent {
 
@@ -40,7 +40,7 @@ export default class SheetCell extends NodeComponent {
   _renderContent($$, cell) {
     const text = cell.text()
     const isExpressionCell = isExpression(text)
-    const value = cell.state.value
+    const value = getValue(cell)
     if(isExpressionCell) {
       const valueEl = $$(ValueComponent, value).ref('value')
       return $$('div').addClass('sc-text-content').append(valueEl)

--- a/src/sheet/SheetCommands.js
+++ b/src/sheet/SheetCommands.js
@@ -80,54 +80,61 @@ class ColumnMetaCommand extends Command {
 }
 
 function insertRows({editorSession, commandState}, mode) {
-  const refRow = mode === 'above' ?
+  const pos = mode === 'above' ?
     commandState.startRow :
     commandState.endRow + 1
-  const nRows = commandState.nrows
+  const count = commandState.nrows
   editorSession.transaction((tx) => {
-    tx.getDocument().createRowsAt(refRow, nRows)
-    const cells = tx.findAll('cell')
-    cells.forEach(cell => {
-      transformCellExpressions(cell, {dim: 'row', idx: refRow, count: nRows})
-    })
-  })
+    tx.getDocument().createRowsAt(pos, count)
+    // const cells = tx.findAll('cell')
+    // cells.forEach(cell => {
+    //   // TODO: rename 'idx' to 'pos'
+    //   transformCellExpressions(cell, { dim: 'row', idx: pos, count })
+    // })
+  }, { action: 'insertRows', pos, count })
 }
 
 function insertCols({editorSession, commandState}, mode) {
   //const sel = selection.data
-  const refCol = mode === 'left' ?
+  const pos = mode === 'left' ?
     commandState.startCol :
     commandState.endCol + 1
-  const nCols = commandState.ncolumns
+  const count = commandState.ncolumns
   editorSession.transaction((tx) => {
-    tx.getDocument().createColumnsAt(refCol, nCols)
-    const cells = tx.findAll('cell')
-    cells.forEach(cell => {
-      transformCellExpressions(cell, {dim: 'col', idx: refCol, count: nCols})
-    })
-  })
+    tx.getDocument().createColumnsAt(pos, count)
+    // const cells = tx.findAll('cell')
+    // cells.forEach(cell => {
+    //   transformCellExpressions(cell, { dim: 'col', idx: pos, count })
+    // })
+  }, { action: 'insertCols', pos, count })
 }
 
 function deleteRows({editorSession, commandState}) {
+  const start = commandState.startRow
+  const end = commandState.endRow
+  const pos = start
+  const count = end - start + 1
   editorSession.transaction((tx) => {
-    tx.getDocument().deleteRows(commandState.startRow, commandState.endRow)
-    const count = commandState.endRow - commandState.startRow
-    const cells = tx.findAll('cell')
-    cells.forEach(cell => {
-      transformCellExpressions(cell, {dim: 'col', idx: commandState.startRow, count: count})
-    })
-  })
+    tx.getDocument().deleteRows(start, end)
+    // const cells = tx.findAll('cell')
+    // cells.forEach(cell => {
+    //   transformCellExpressions(cell, { dim: 'col', idx: pos, count })
+    // })
+  }, { action: 'deleteRows', pos, count })
 }
 
 function deleteColumns({editorSession, commandState}) {
+  const start = commandState.startCol
+  const end = commandState.endCol
+  const pos = start
+  const count = end - start + 1
   editorSession.transaction((tx) => {
-    tx.getDocument().deleteColumns(commandState.startCol, commandState.endCol)
-    const count = commandState.endCol - commandState.startCol
-    const cells = tx.findAll('cell')
-    cells.forEach(cell => {
-      transformCellExpressions(cell, {dim: 'col', idx: commandState.startCol, count: count})
-    })
-  })
+    tx.getDocument().deleteColumns(start, end)
+    // const cells = tx.findAll('cell')
+    // cells.forEach(cell => {
+    //   transformCellExpressions(cell, { dim: 'col', idx: pos, count })
+    // })
+  }, { action: 'deleteCols', pos, count })
 }
 
 export class InsertRowsAbove extends RowsCommand {

--- a/src/sheet/SheetCommands.js
+++ b/src/sheet/SheetCommands.js
@@ -86,11 +86,11 @@ function insertRows({editorSession, commandState}, mode) {
   const count = commandState.nrows
   editorSession.transaction((tx) => {
     tx.getDocument().createRowsAt(pos, count)
-    // const cells = tx.findAll('cell')
-    // cells.forEach(cell => {
-    //   // TODO: rename 'idx' to 'pos'
-    //   transformCellExpressions(cell, { dim: 'row', idx: pos, count })
-    // })
+    const cells = tx.findAll('cell')
+    cells.forEach(cell => {
+      // TODO: rename 'idx' to 'pos'
+      transformCellExpressions(cell, { dim: 'row', idx: pos, count })
+    })
   }, { action: 'insertRows', pos, count })
 }
 
@@ -102,10 +102,10 @@ function insertCols({editorSession, commandState}, mode) {
   const count = commandState.ncolumns
   editorSession.transaction((tx) => {
     tx.getDocument().createColumnsAt(pos, count)
-    // const cells = tx.findAll('cell')
-    // cells.forEach(cell => {
-    //   transformCellExpressions(cell, { dim: 'col', idx: pos, count })
-    // })
+    const cells = tx.findAll('cell')
+    cells.forEach(cell => {
+      transformCellExpressions(cell, { dim: 'col', idx: pos, count })
+    })
   }, { action: 'insertCols', pos, count })
 }
 
@@ -116,10 +116,10 @@ function deleteRows({editorSession, commandState}) {
   const count = end - start + 1
   editorSession.transaction((tx) => {
     tx.getDocument().deleteRows(start, end)
-    // const cells = tx.findAll('cell')
-    // cells.forEach(cell => {
-    //   transformCellExpressions(cell, { dim: 'col', idx: pos, count })
-    // })
+    const cells = tx.findAll('cell')
+    cells.forEach(cell => {
+      transformCellExpressions(cell, { dim: 'col', idx: pos, count })
+    })
   }, { action: 'deleteRows', pos, count })
 }
 
@@ -130,10 +130,10 @@ function deleteColumns({editorSession, commandState}) {
   const count = end - start + 1
   editorSession.transaction((tx) => {
     tx.getDocument().deleteColumns(start, end)
-    // const cells = tx.findAll('cell')
-    // cells.forEach(cell => {
-    //   transformCellExpressions(cell, { dim: 'col', idx: pos, count })
-    // })
+    const cells = tx.findAll('cell')
+    cells.forEach(cell => {
+      transformCellExpressions(cell, { dim: 'col', idx: pos, count })
+    })
   }, { action: 'deleteCols', pos, count })
 }
 

--- a/src/sheet/SheetDocument.js
+++ b/src/sheet/SheetDocument.js
@@ -233,6 +233,20 @@ export default class SheetDocument extends XMLDocument {
     }
   }
 
+  _apply(change) {
+    super._apply(change)
+    // update the matrix on structural changes
+    // TODO: we could be smarter by analysing the change
+    switch (change.info.action) {
+      case 'insertRows':
+      case 'deleteRows':
+      case 'insertCols':
+      case 'deleteCols': {
+        this._matrix = this._getCellMatrix()
+      }
+    }
+  }
+
   _getData() {
     if (!this._dataNode) {
       this._dataNode = this.get('data')

--- a/src/sheet/SheetDocument.js
+++ b/src/sheet/SheetDocument.js
@@ -30,6 +30,34 @@ export default class SheetDocument extends XMLDocument {
     return this.getRootNode().find('name').text()
   }
 
+  // EXPERIMENTAL: introducing
+  invert(change) {
+    let inverted = change.invert()
+    let info = inverted.info || {}
+    switch(change.info.action) {
+      case 'insertRows': {
+        info.action = 'deleteRows'
+        break
+      }
+      case 'deleteRows': {
+        info.action = 'insertRows'
+        break
+      }
+      case 'insertCols': {
+        info.action = 'deleteCols'
+        break
+      }
+      case 'deleteCols':  {
+        info.action = 'insertCols'
+        break
+      }
+      default:
+        //
+    }
+    inverted.info = info
+    return inverted
+  }
+
   getColumnForCell(cellId) {
     let cell = this.get(cellId)
     let row = cell.parentNode

--- a/src/sheet/SheetDocument.js
+++ b/src/sheet/SheetDocument.js
@@ -47,7 +47,7 @@ export default class SheetDocument extends XMLDocument {
         info.action = 'deleteCols'
         break
       }
-      case 'deleteCols':  {
+      case 'deleteCols': {
         info.action = 'insertCols'
         break
       }
@@ -271,7 +271,10 @@ export default class SheetDocument extends XMLDocument {
       case 'insertCols':
       case 'deleteCols': {
         this._matrix = this._getCellMatrix()
+        break
       }
+      default:
+        //
     }
   }
 

--- a/tests/contexts/libtest.js
+++ b/tests/contexts/libtest.js
@@ -37,7 +37,7 @@ function sum(...vals) {
   return vals.reduce((a,b) => {
     if (b.type === 'table') {
       forEach(b.data, (vals) => {
-        return a += sum(vals)
+        a += sum(vals)
       })
       return a
     } else if (isArray(b)) {

--- a/tests/contexts/libtest.js
+++ b/tests/contexts/libtest.js
@@ -1,3 +1,5 @@
+import { forEach, isArray } from 'substance'
+
 const addXML = `
 <function>
   <name>add</name>
@@ -13,6 +15,39 @@ const addXML = `
 
 function add(value, other) {
   return value + other
+}
+
+const sumXML = `
+<function>
+  <name>sum</name>
+  <params>
+    <param name="a" type="number" />
+    <param name="b" type="number" />
+    <param name="c" type="number" />
+    <param name="d" type="number" />
+    <param name="e" type="number" />
+  </params>
+  <implems>
+    <implem language="js" />
+  </implems>
+</function>
+`
+
+function sum(...vals) {
+  return vals.reduce((a,b) => {
+    if (b.type === 'table') {
+      forEach(b.data, (vals) => {
+        return a += sum(vals)
+      })
+      return a
+    } else if (isArray(b)) {
+      return sum(...b)
+    } else if (isArray(b.data)) {
+      return sum(...b.data)
+    } else {
+      return a+b
+    }
+  }, 0)
 }
 
 const multiplyXML = `
@@ -86,6 +121,7 @@ export const libtestXML = `
 <!DOCTYPE function PUBLIC "StencilaFunctionLibrary 1.0" "StencilaFunctionLibrary.dtd">
 <library name="test">
 ${addXML}
+${sumXML}
 ${multiplyXML}
 ${no_paramsXML}
 ${one_paramXML}
@@ -95,6 +131,7 @@ ${one_param_with_defaultXML}
 
 export const libtest = {
   add,
+  sum,
   multiply,
   no_params,
   one_param,

--- a/tests/sheet/transformCellRangeExpression.test.js
+++ b/tests/sheet/transformCellRangeExpression.test.js
@@ -174,7 +174,7 @@ test('transformCellRangeExpression: range / col / delete before', (t) => {
   let expr = 'C3:F10'
   let mode = 'col'
   let idx = 1
-  let count = 1
+  let count = -1
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'B3:E10', MSG)
   t.end()
@@ -184,7 +184,7 @@ test('transformCellRangeExpression: range / col / delete overlapping start', (t)
   let expr = 'C3:F10'
   let mode = 'col'
   let idx = 1
-  let count = 4
+  let count = -4
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'B3:B10', MSG)
   t.end()
@@ -194,7 +194,7 @@ test('transformCellRangeExpression: range / col / delete inside', (t) => {
   let expr = 'C3:F10'
   let mode = 'col'
   let idx = 3
-  let count = 2
+  let count = -2
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3:D10', MSG)
   t.end()
@@ -204,7 +204,7 @@ test('transformCellRangeExpression: range / col / delete overlapping end', (t) =
   let expr = 'C3:F10'
   let mode = 'col'
   let idx = 4
-  let count = 3
+  let count = -3
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3:D10', MSG)
   t.end()
@@ -214,7 +214,7 @@ test('transformCellRangeExpression: range / col / delete after', (t) => {
   let expr = 'C3:F10'
   let mode = 'col'
   let idx = 7
-  let count = 1
+  let count = -1
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3:F10', MSG)
   t.end()
@@ -256,7 +256,7 @@ test('transformCellRangeExpression: range / row / delete before', (t) => {
   let expr = 'C3:F10'
   let mode = 'row'
   let idx = 1
-  let count = 1
+  let count = -1
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C2:F9', MSG)
   t.end()
@@ -266,7 +266,7 @@ test('transformCellRangeExpression: range / row / delete overlapping start', (t)
   let expr = 'C3:F10'
   let mode = 'row'
   let idx = 1
-  let count = 4
+  let count = -4
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C2:F6', MSG)
   t.end()
@@ -276,7 +276,7 @@ test('transformCellRangeExpression: range / row / delete inside', (t) => {
   let expr = 'C3:F10'
   let mode = 'row'
   let idx = 5
-  let count = 2
+  let count = -2
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3:F8', MSG)
   t.end()
@@ -286,7 +286,7 @@ test('transformCellRangeExpression: range / row / delete overlapping end', (t) =
   let expr = 'C3:F10'
   let mode = 'row'
   let idx = 7
-  let count = 6
+  let count = -6
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3:F7', MSG)
   t.end()
@@ -296,7 +296,7 @@ test('transformCellRangeExpression: range / row / delete after', (t) => {
   let expr = 'C3:F10'
   let mode = 'row'
   let idx = 12
-  let count = 1
+  let count = -1
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3:F10', MSG)
   t.end()

--- a/tests/sheet/transformCellRangeExpression.test.js
+++ b/tests/sheet/transformCellRangeExpression.test.js
@@ -1,10 +1,11 @@
 import test from 'tape'
 
-import { transformCellRangeExpression } from '../../src/shared/cellHelpers'
+import { transformCellRangeExpression, BROKEN_REF } from '../../src/shared/cellHelpers'
 
 const MSG = 'expression should be transformed correctly'
+
 /*
-Test cases: (for rows and  columns)
+TODO
 
 ranges:
 - range expression inside deleted
@@ -12,17 +13,128 @@ ranges:
 - range expression overlaps deleted range on the 'left' side
 - range expression overlaps deleted range on the 'right' sides
 
-single:
-- before, inside, after
-
 */
+
+// cell reference - insert/delete columns
 
 test('transformCellRangeExpression: single / col / insert before', (t) => {
   let expr = 'C1'
   let mode = 'col'
   let idx = 1
+  let count = 2
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'E1', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / col / insert after', (t) => {
+  let expr = 'C1'
+  let mode = 'col'
+  let idx = 4
   let count = 1
   let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
-  t.equal(transformed, 'D1', MSG)
+  t.equal(transformed, 'C1', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / col / delete before', (t) => {
+  let expr = 'C1'
+  let mode = 'col'
+  let idx = 0
+  let count = -2
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'A1', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / col / delete after', (t) => {
+  let expr = 'C1'
+  let mode = 'col'
+  let idx = 4
+  let count = -1
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'C1', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / col / delete same', (t) => {
+  let expr = 'C1'
+  let mode = 'col'
+  let idx = 2
+  let count = -1
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'C1', BROKEN_REF)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / col / delete surrounding', (t) => {
+  let expr = 'C1'
+  let mode = 'col'
+  let idx = 1
+  let count = -4
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'C1', BROKEN_REF)
+  t.end()
+})
+
+// cell reference - insert/delete rows
+
+
+test('transformCellRangeExpression: single / row / insert before', (t) => {
+  let expr = 'C3'
+  let mode = 'row'
+  let idx = 1
+  let count = 3
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'C6', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / row / insert after', (t) => {
+  let expr = 'C3'
+  let mode = 'row'
+  let idx = 4
+  let count = 1
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'C3', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / row / delete before', (t) => {
+  let expr = 'C3'
+  let mode = 'row'
+  let idx = 0
+  let count = -2
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'C1', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / row / delete after', (t) => {
+  let expr = 'C3'
+  let mode = 'row'
+  let idx = 4
+  let count = -1
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'C3', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: single / col / delete same', (t) => {
+  let expr = 'C3'
+  let mode = 'row'
+  let idx = 2
+  let count = -1
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, BROKEN_REF, MSG)
+  t.end()
+})
+test('transformCellRangeExpression: single / row / delete surrounding', (t) => {
+  let expr = 'C3'
+  let mode = 'row'
+  let idx = 1
+  let count = -4
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })

--- a/tests/sheet/transformCellRangeExpression.test.js
+++ b/tests/sheet/transformCellRangeExpression.test.js
@@ -19,60 +19,60 @@ ranges:
 
 test('transformCellRangeExpression: single / col / insert before', (t) => {
   let expr = 'C1'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 1
   let count = 2
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'E1', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / col / insert after', (t) => {
   let expr = 'C1'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 4
   let count = 1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C1', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / col / delete before', (t) => {
   let expr = 'C1'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 0
   let count = -2
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'A1', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / col / delete after', (t) => {
   let expr = 'C1'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 4
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C1', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / col / delete same', (t) => {
   let expr = 'C1'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 2
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / col / delete surrounding', (t) => {
   let expr = 'C1'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 1
   let count = -4
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })
@@ -81,59 +81,59 @@ test('transformCellRangeExpression: single / col / delete surrounding', (t) => {
 
 test('transformCellRangeExpression: single / row / insert before', (t) => {
   let expr = 'C3'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 1
   let count = 3
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C6', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / row / insert after', (t) => {
   let expr = 'C3'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 4
   let count = 1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / row / delete before', (t) => {
   let expr = 'C3'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 0
   let count = -2
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C1', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / row / delete after', (t) => {
   let expr = 'C3'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 4
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: single / row / delete same', (t) => {
   let expr = 'C3'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 2
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })
 test('transformCellRangeExpression: single / row / delete surrounding', (t) => {
   let expr = 'C3'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 1
   let count = -4
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })
@@ -142,80 +142,80 @@ test('transformCellRangeExpression: single / row / delete surrounding', (t) => {
 
 test('transformCellRangeExpression: range / col / insert before', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 2
   let count = 2
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'E3:H10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / col / insert inside', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 4
   let count = 3
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:I10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / col / insert after', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 7
   let count = 1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:F10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / col / delete before', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 1
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'B3:E10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / col / delete overlapping start', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 1
   let count = -4
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'B3:B10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / col / delete inside', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 3
   let count = -2
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:D10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / col / delete overlapping end', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 4
   let count = -3
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:D10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / col / delete after', (t) => {
   let expr = 'C3:F10'
-  let mode = 'col'
+  let dim = 'col'
   let idx = 7
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:F10', MSG)
   t.end()
 })
@@ -224,80 +224,80 @@ test('transformCellRangeExpression: range / col / delete after', (t) => {
 
 test('transformCellRangeExpression: range / row / insert before', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 1
   let count = 3
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C6:F13', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / row / insert inside', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 6
   let count = 2
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:F12', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / row / insert after', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 12
   let count = 1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:F10', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / row / delete before', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 1
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C2:F9', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / row / delete overlapping start', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 1
   let count = -4
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C2:F6', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / row / delete inside', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 5
   let count = -2
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:F8', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / row / delete overlapping end', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 7
   let count = -6
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:F7', MSG)
   t.end()
 })
 
 test('transformCellRangeExpression: range / row / delete after', (t) => {
   let expr = 'C3:F10'
-  let mode = 'row'
+  let dim = 'row'
   let idx = 12
   let count = -1
-  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { dim, idx, count})
   t.equal(transformed, 'C3:F10', MSG)
   t.end()
 })

--- a/tests/sheet/transformCellRangeExpression.test.js
+++ b/tests/sheet/transformCellRangeExpression.test.js
@@ -22,7 +22,7 @@ test('transformCellRangeExpression: single / col / insert before', (t) => {
   let mode = 'col'
   let idx = 1
   let count = 2
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'E1', MSG)
   t.end()
 })
@@ -32,7 +32,7 @@ test('transformCellRangeExpression: single / col / insert after', (t) => {
   let mode = 'col'
   let idx = 4
   let count = 1
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C1', MSG)
   t.end()
 })
@@ -42,7 +42,7 @@ test('transformCellRangeExpression: single / col / delete before', (t) => {
   let mode = 'col'
   let idx = 0
   let count = -2
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'A1', MSG)
   t.end()
 })
@@ -52,7 +52,7 @@ test('transformCellRangeExpression: single / col / delete after', (t) => {
   let mode = 'col'
   let idx = 4
   let count = -1
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C1', MSG)
   t.end()
 })
@@ -62,7 +62,7 @@ test('transformCellRangeExpression: single / col / delete same', (t) => {
   let mode = 'col'
   let idx = 2
   let count = -1
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C1', BROKEN_REF)
   t.end()
 })
@@ -72,7 +72,7 @@ test('transformCellRangeExpression: single / col / delete surrounding', (t) => {
   let mode = 'col'
   let idx = 1
   let count = -4
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C1', BROKEN_REF)
   t.end()
 })
@@ -85,7 +85,7 @@ test('transformCellRangeExpression: single / row / insert before', (t) => {
   let mode = 'row'
   let idx = 1
   let count = 3
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C6', MSG)
   t.end()
 })
@@ -95,7 +95,7 @@ test('transformCellRangeExpression: single / row / insert after', (t) => {
   let mode = 'row'
   let idx = 4
   let count = 1
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3', MSG)
   t.end()
 })
@@ -105,7 +105,7 @@ test('transformCellRangeExpression: single / row / delete before', (t) => {
   let mode = 'row'
   let idx = 0
   let count = -2
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C1', MSG)
   t.end()
 })
@@ -115,7 +115,7 @@ test('transformCellRangeExpression: single / row / delete after', (t) => {
   let mode = 'row'
   let idx = 4
   let count = -1
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, 'C3', MSG)
   t.end()
 })
@@ -125,7 +125,7 @@ test('transformCellRangeExpression: single / col / delete same', (t) => {
   let mode = 'row'
   let idx = 2
   let count = -1
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })
@@ -134,7 +134,7 @@ test('transformCellRangeExpression: single / row / delete surrounding', (t) => {
   let mode = 'row'
   let idx = 1
   let count = -4
-  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })

--- a/tests/sheet/transformCellRangeExpression.test.js
+++ b/tests/sheet/transformCellRangeExpression.test.js
@@ -79,7 +79,6 @@ test('transformCellRangeExpression: single / col / delete surrounding', (t) => {
 
 // cell reference - insert/delete rows
 
-
 test('transformCellRangeExpression: single / row / insert before', (t) => {
   let expr = 'C3'
   let mode = 'row'
@@ -136,5 +135,169 @@ test('transformCellRangeExpression: single / row / delete surrounding', (t) => {
   let count = -4
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
   t.equal(transformed, BROKEN_REF, MSG)
+  t.end()
+})
+
+// range - insert/delete cols
+
+test('transformCellRangeExpression: range / col / insert before', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 2
+  let count = 2
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'E3:H10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / col / insert inside', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 4
+  let count = 3
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:I10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / col / insert after', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 7
+  let count = 1
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:F10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / col / delete before', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 1
+  let count = 1
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'B3:E10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / col / delete overlapping start', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 1
+  let count = 4
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'B3:B10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / col / delete inside', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 3
+  let count = 2
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:D10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / col / delete overlapping end', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 4
+  let count = 3
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:D10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / col / delete after', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'col'
+  let idx = 7
+  let count = 1
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:F10', MSG)
+  t.end()
+})
+
+// range - insert/delete rows
+
+test('transformCellRangeExpression: range / row / insert before', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 1
+  let count = 3
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C6:F13', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / row / insert inside', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 6
+  let count = 2
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:F12', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / row / insert after', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 12
+  let count = 1
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:F10', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / row / delete before', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 1
+  let count = 1
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C2:F9', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / row / delete overlapping start', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 1
+  let count = 4
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C2:F6', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / row / delete inside', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 5
+  let count = 2
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:F8', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / row / delete overlapping end', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 7
+  let count = 6
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:F7', MSG)
+  t.end()
+})
+
+test('transformCellRangeExpression: range / row / delete after', (t) => {
+  let expr = 'C3:F10'
+  let mode = 'row'
+  let idx = 12
+  let count = 1
+  let transformed = transformCellRangeExpression(expr, { mode, idx, count})
+  t.equal(transformed, 'C3:F10', MSG)
   t.end()
 })

--- a/tests/sheet/transformCellRangeExpression.test.js
+++ b/tests/sheet/transformCellRangeExpression.test.js
@@ -1,0 +1,28 @@
+import test from 'tape'
+
+import { transformCellRangeExpression } from '../../src/shared/cellHelpers'
+
+const MSG = 'expression should be transformed correctly'
+/*
+Test cases: (for rows and  columns)
+
+ranges:
+- range expression inside deleted
+- deleted range inside of range expression
+- range expression overlaps deleted range on the 'left' side
+- range expression overlaps deleted range on the 'right' sides
+
+single:
+- before, inside, after
+
+*/
+
+test('transformCellRangeExpression: single / col / insert before', (t) => {
+  let expr = 'C1'
+  let mode = 'col'
+  let idx = 1
+  let count = 1
+  let transformed = transformCellRangeExpression(expr,  { mode, idx, count})
+  t.equal(transformed, 'D1', MSG)
+  t.end()
+})

--- a/tests/sheet/transformCellRangeExpression.test.js
+++ b/tests/sheet/transformCellRangeExpression.test.js
@@ -63,7 +63,7 @@ test('transformCellRangeExpression: single / col / delete same', (t) => {
   let idx = 2
   let count = -1
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
-  t.equal(transformed, 'C1', BROKEN_REF)
+  t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })
 
@@ -73,7 +73,7 @@ test('transformCellRangeExpression: single / col / delete surrounding', (t) => {
   let idx = 1
   let count = -4
   let transformed = transformCellRangeExpression(expr, { mode, idx, count})
-  t.equal(transformed, 'C1', BROKEN_REF)
+  t.equal(transformed, BROKEN_REF, MSG)
   t.end()
 })
 
@@ -119,7 +119,7 @@ test('transformCellRangeExpression: single / row / delete after', (t) => {
   t.end()
 })
 
-test('transformCellRangeExpression: single / col / delete same', (t) => {
+test('transformCellRangeExpression: single / row / delete same', (t) => {
   let expr = 'C3'
   let mode = 'row'
   let idx = 2


### PR DESCRIPTION
# Why?

Cell range expressions in sheets have not been updated when changing the sheets structure, via insert/remove rows/columns.

# What?

- introduced Engine API react on updated structure
- creating transformations for expressions that contain cell references or ranges
- making it work with undo/redo
- transclusions are not supported yet