### PR TITLE
Improve application setup

### DIFF
--- a/src/StencilaArchive.js
+++ b/src/StencilaArchive.js
@@ -5,16 +5,24 @@ import SheetLoader from './sheet/SheetLoader'
 
 export default class StencilaArchive extends TextureArchive {
 
+  constructor(storage, buffer, context) {
+    super(storage, buffer)
+
+    this._context = context
+  }
+
   _loadDocument(type, record, sessions) {
+    let context = this._context
     switch (type) {
       case 'article': {
-        return ArticleLoader.load(record.data, {
+        context = Object.assign({}, this._context, {
           pubMetaDb: sessions['pub-meta'].getDocument(),
           archive: this
         })
+        return ArticleLoader.load(record.data, context)
       }
       case 'sheet': {
-        return SheetLoader.load(record.data)
+        return SheetLoader.load(record.data, context)
       }
       default:
         throw new Error('Unsupported document type')

--- a/src/article/index.js
+++ b/src/article/index.js
@@ -5,3 +5,4 @@ export { Editor as ArticleEditor }
 
 export { default as ArticleEditorPackage } from './ArticleEditorPackage'
 export { default as ArticleLoader } from './ArticleLoader'
+export { default as ArticleAdapter } from './ArticleAdapter'

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -106,10 +106,11 @@ import { gather } from '../value'
 */
 export default class Engine extends EventEmitter {
 
-  constructor(host) {
+  constructor(options = {}) {
     super()
 
-    this._host = host
+    // needs to be connected to a host to be able to create contexts
+    this._host = options.host
 
     this._docs = {}
     this._graph = new CellGraph()
@@ -124,7 +125,13 @@ export default class Engine extends EventEmitter {
     this._nextActions = new Map()
   }
 
+  setHost(host) {
+    this._host = host
+  }
+
   run /* istanbul ignore next */ (interval) {
+    if (!this._host) throw new Error('Must call setHost() before starting the Engine')
+
     // TODO: does this only work in the browser?
     if (this._runner) {
       clearInterval(this._runner)

--- a/src/host/Host.js
+++ b/src/host/Host.js
@@ -60,7 +60,7 @@ export default class Host extends EventEmitter {
      *
      * @type {Engine}
      */
-    this._engine = null
+    this._engine = options.engine || new Engine({ host: this })
 
 
     /**

--- a/src/project/Project.js
+++ b/src/project/Project.js
@@ -40,9 +40,6 @@ export default class Project extends Component {
   getChildContext() {
     let pubMetaDbSession = this._getPubMetaDbSession()
     return {
-      functionManager: this.props.functionManager,
-      cellEngine: this.props.engine,
-      host: this.props.host,
       pubMetaDbSession: pubMetaDbSession,
       urlResolver: this.props.documentArchive
     }

--- a/src/sheet/SheetLoader.js
+++ b/src/sheet/SheetLoader.js
@@ -3,14 +3,15 @@ import SheetPackage from './SheetPackage'
 import SheetSchema from './SheetSchema'
 
 export default {
-  load(xml) {
+  load(xml, context) {
     let configurator = new Configurator()
     configurator.import(SheetPackage)
     let importer = configurator.createImporter(SheetSchema.getName())
 
     let doc = importer.importDocument(xml)
     let editorSession = new EditorSession(doc, {
-      configurator
+      configurator,
+      context
     })
     return editorSession
   }

--- a/tests/engine/Engine.test.js
+++ b/tests/engine/Engine.test.js
@@ -555,7 +555,7 @@ function _setup() {
     functionManager
   }
   miniContext = new MiniContext(host)
-  let engine = new Engine(host)
+  let engine = new Engine({ host })
   let graph = engine._graph
   return { host, engine, graph }
 }


### PR DESCRIPTION
# Why?

Currently there is some confusion about application context. E.g. EditorSessions do define their own 'context', but not use the context provided by the application.

# What?

This change tries to tidy up the mess a bit, reducing some of the confusion.