### PR TITLE
Fix regression in cell value rendering.

### DIFF
--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -95,7 +95,7 @@ class CellComponent extends NodeComponent {
               this.oldValue.error
             ).ref('error').setStyle('visibility', 'hidden')
           )
-        } else {
+        } else if (this._showOutput()) {
           el.append(
             $$(ValueComponent, this.oldValue).ref('value')
           )


### PR DESCRIPTION
# Why?
After the last refactor, cell values are sometimes rendered even if the variable was assigned.

# What?

The cell component shows the retained value only if the variable is not assigned. 