### PR TITLE
Manual vs automatic evaluation of cells

### DIFF
--- a/src/article/ArticleAdapter.js
+++ b/src/article/ArticleAdapter.js
@@ -143,12 +143,12 @@ function _getCellData(cell) {
 }
 
 function _addAutorunFeature(doc, adapter) {
-  Object.assign(doc, {
-    set autorun(val) {
+  Object.defineProperty(doc, 'autorun', {
+    set(val) {
       doc._autorun = val
       adapter.model.setAutorun(val)
     },
-    get autorun() {
+    get() {
       return doc._autorun
     }
   })

--- a/src/article/ArticleEditorCommands.js
+++ b/src/article/ArticleEditorCommands.js
@@ -196,3 +196,22 @@ export class InsertCellCommand extends InsertNodeCommand {
   }
 
 }
+
+export class RunCellCommand extends Command {
+
+  /*
+    Always enabled
+  */
+  getCommandState({ editorSession }) {
+    const doc = editorSession.getDocument()
+    const autorun = doc.autorun
+    return {
+      disabled: autorun,
+      active: false
+    }
+  }
+
+  execute(params) {
+    console.info(params)
+  }
+}

--- a/src/article/ArticleEditorPackage.js
+++ b/src/article/ArticleEditorPackage.js
@@ -93,7 +93,7 @@ export default {
     })
     config.addIcon('run-all', { 'fontawesome': 'fa-caret-square-o-right' })
     config.addLabel('run-all', 'Run All Code')
-    config.addKeyboardShortcut('Shift+Enter+A', { command: 'run-all' })
+    config.addKeyboardShortcut('CommandOrControl+Shift+Enter', { command: 'run-all' })
 
     config.addToolPanel('toolbar', [
       {

--- a/src/article/ArticleEditorPackage.js
+++ b/src/article/ArticleEditorPackage.js
@@ -23,11 +23,14 @@ import PlotlyValueComponent from '../shared/PlotlyValueComponent'
 import {
   SetLanguageCommand, ToggleAllCodeCommand,
   HideCellCodeCommand, InsertCellCommand,
-  ForceCellOutputCommand
+  ForceCellOutputCommand, RunCellCommand
 } from './ArticleEditorCommands'
 
 import FunctionUsageCommand from '../shared/FunctionUsageCommand'
 import FunctionUsageTool from '../shared/FunctionUsageTool'
+
+import AutoRunCommand from '../shared/AutoRunCommand'
+import RunAllCommand from '../shared/RunAllCommand'
 
 export default {
   name: 'editor',
@@ -60,7 +63,7 @@ export default {
 
     config.addCommand('insert-cell', InsertCellCommand, {
       nodeType: 'disp-quote',
-      commandGroup: 'insert-block-element'
+      commandGroup: 'insert-cell-element'
     })
     config.addLabel('insert-cell', 'Cell')
     config.addKeyboardShortcut('CommandOrControl+Enter', { command: 'insert-cell' })
@@ -72,7 +75,7 @@ export default {
 
     config.addIcon('function-helper', {'fontawesome': 'fa-question-circle' })
 
-    config.addIcon('insert-cell', { 'fontawesome': 'fa-caret-square-o-right' })
+    config.addIcon('insert-cell', { 'fontawesome': 'fa-plus-square' })
 
     config.addLabel('function-examples', {
       en: 'Example Usage'
@@ -80,6 +83,17 @@ export default {
     config.addLabel('function-usage', {
       en: 'Syntax'
     })
+
+    config.addCommand('auto-run', AutoRunCommand, {
+      commandGroup: 'auto-run'
+    })
+
+    config.addCommand('run-all', RunAllCommand, {
+      commandGroup: 'run-all'
+    })
+    config.addIcon('run-all', { 'fontawesome': 'fa-caret-square-o-right' })
+    config.addLabel('run-all', 'Run All Code')
+    config.addKeyboardShortcut('Shift+Enter+A', { command: 'run-all' })
 
     config.addToolPanel('toolbar', [
       {
@@ -108,7 +122,14 @@ export default {
         type: 'tool-group',
         showDisabled: true,
         style: 'minimal',
-        commandGroups: ['insert-figure', 'insert-repro-figure', 'insert-table', 'insert-block-element']
+        commandGroups: ['insert-figure', 'insert-repro-figure', 'insert-table', 'insert-cell-element']
+      },
+      {
+        name: 'cell-execution',
+        type: 'tool-group',
+        showDisabled: false,
+        style: 'minimal',
+        commandGroups: ['run-all']
       },
       {
         name: 'cite',
@@ -123,6 +144,13 @@ export default {
         showDisabled: false,
         style: 'descriptive',
         commandGroups: ['toggle-content-section', 'view']
+      },
+      {
+        name: 'settings',
+        type: 'tool-dropdown',
+        showDisabled: true,
+        style: 'descriptive',
+        commandGroups: ['auto-run']
       }
     ])
 
@@ -140,6 +168,7 @@ export default {
       Cell Actions
     */
 
+    config.addCommand('run-cell-code', RunCellCommand, { commandGroup: 'cell-actions' })
     config.addCommand('hide-cell-code', HideCellCodeCommand, { commandGroup: 'cell-actions' })
     config.addCommand('force-cell-output', ForceCellOutputCommand, { commandGroup: 'cell-actions' })
     config.addCommand('set-mini', SetLanguageCommand, { language: 'mini', commandGroup: 'cell-actions' })
@@ -149,6 +178,7 @@ export default {
     config.addCommand('set-sql', SetLanguageCommand, { language: 'sql', commandGroup: 'cell-actions' })
 
     // Labels and icons
+    config.addLabel('run-cell-code', 'Run cell')
     config.addLabel('hide-cell-code', 'Hide code')
     config.addLabel('force-cell-output', 'Force output')
     config.addLabel('set-mini', 'Mini')
@@ -161,9 +191,12 @@ export default {
     config.addIcon('test-failed', {'fontawesome': 'fa-times' })
     config.addIcon('test-passed', {'fontawesome': 'fa-check' })
 
-    
+
     config.addLabel('show-all-code', 'Show All Code')
     config.addLabel('hide-all-code', 'Hide All Code')
+
+    config.addLabel('settings', 'Settings')
+    config.addLabel('auto-run', '${autoOrManual} Run Cells')
 
     // View Commands
     config.addCommand('hide-all-code', ToggleAllCodeCommand, {
@@ -177,6 +210,5 @@ export default {
 
     config.addKeyboardShortcut('CommandOrControl+Alt+L', { command: 'show-all-code' })
     config.addKeyboardShortcut('CommandOrControl+Alt+O', { command: 'hide-all-code' })
-
   }
 }

--- a/src/article/ArticleEditorPackage.js
+++ b/src/article/ArticleEditorPackage.js
@@ -210,5 +210,7 @@ export default {
 
     config.addKeyboardShortcut('CommandOrControl+Alt+L', { command: 'show-all-code' })
     config.addKeyboardShortcut('CommandOrControl+Alt+O', { command: 'hide-all-code' })
+    config.addKeyboardShortcut('Shift+Enter', { command: 'run-cell-code' })
+
   }
 }

--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -2,7 +2,7 @@ import { NodeComponent, FontAwesomeIcon } from 'substance'
 import ValueComponent from '../shared/ValueComponent'
 import CodeEditor from '../shared/CodeEditor'
 import { getCellState, getError } from '../shared/cellHelpers'
-import { toString as stateToString, BROKEN, FAILED, OK } from '../engine/CellStates'
+import { toString as stateToString, BROKEN, FAILED, OK, READY } from '../engine/CellStates'
 import NodeMenu from './NodeMenu'
 
 export default
@@ -200,6 +200,8 @@ class CellComponent extends NodeComponent {
         }, 500)
       } else if (status === OK) {
         this.oldValue = cellState.value
+        clearTimeout(this.delayError) // eslint-disable-line no-undef
+      } else if (status === READY) {
         clearTimeout(this.delayError) // eslint-disable-line no-undef
       }
     }

--- a/src/article/_cell.css
+++ b/src/article/_cell.css
@@ -38,7 +38,8 @@
   background: #FF0300;
 }
 
-.sc-cell .se-status.sm-blocked {
+.sc-cell .se-status.sm-blocked,
+.sc-cell .se-status.sm-ready {
   background: #FFAA00;
 }
 

--- a/src/article/_cell.css
+++ b/src/article/_cell.css
@@ -39,7 +39,8 @@
 }
 
 .sc-cell .se-status.sm-blocked,
-.sc-cell .se-status.sm-ready {
+.sc-cell .se-status.sm-ready,
+.sc-cell .se-status.sm-waiting {
   background: #FFAA00;
 }
 

--- a/src/engine/Cell.js
+++ b/src/engine/Cell.js
@@ -1,5 +1,5 @@
 import { isString } from 'substance'
-import { UNKNOWN } from './CellStates'
+import { UNKNOWN, toString as cellStatusToString } from './CellStates'
 import { transpile } from '../shared/expressionHelpers'
 import { isExpression, qualifiedId } from '../shared/cellHelpers'
 
@@ -150,6 +150,10 @@ export default class Cell {
     }
     parts.push(this._source.original)
     return parts.join('')
+  }
+
+  _getStatusString() {
+    return cellStatusToString(this.status)
   }
 
   _transpile(source) {

--- a/src/engine/CellErrors.js
+++ b/src/engine/CellErrors.js
@@ -13,11 +13,6 @@ export class CellError extends Error {
   }
 }
 
-export class SyntaxError extends CellError {
-  get type() { return 'engine' }
-  get name() { return 'syntax' }
-}
-
 export class ContextError extends CellError {
   get type() { return 'engine' }
   get name() { return 'context' }
@@ -25,6 +20,10 @@ export class ContextError extends CellError {
 
 export class GraphError extends CellError {
   get type() { return 'graph' }
+}
+
+export class SyntaxError extends GraphError {
+  get name() { return 'syntax' }
 }
 
 export class UnresolvedInputError extends GraphError {

--- a/src/engine/CellErrors.js
+++ b/src/engine/CellErrors.js
@@ -22,7 +22,8 @@ export class GraphError extends CellError {
   get type() { return 'graph' }
 }
 
-export class SyntaxError extends GraphError {
+export class SyntaxError extends CellError {
+  get type() { return 'engine' }
   get name() { return 'syntax' }
 }
 

--- a/src/engine/CellGraph.js
+++ b/src/engine/CellGraph.js
@@ -481,6 +481,21 @@ export default class CellGraph {
     return followSet
   }
 
+  // get a set of all ids a cell is depending on
+  _getPredecessorSet(id, res) {
+    if (!res) res = new Set()
+    let cell = this.getCell(id)
+    cell.inputs.forEach(s => {
+      let id = this._resolve(s)
+      if (id && isString(id)) res.add(id)
+      this._getPredecessorSet(id, res)
+    })
+    if (cell.hasSideEffects && cell.prev) {
+      this._getPredecessorSet(cell.prev, res)
+    }
+    return res
+  }
+
   _handleCycle(trace, updated) {
     let error = new CyclicDependencyError('Cyclic dependency', { trace })
     trace.forEach(id => {

--- a/src/engine/CellGraph.js
+++ b/src/engine/CellGraph.js
@@ -487,11 +487,15 @@ export default class CellGraph {
     let cell = this.getCell(id)
     cell.inputs.forEach(s => {
       let id = this._resolve(s)
-      if (id && isString(id)) res.add(id)
-      this._getPredecessorSet(id, res)
+      if (!res.has(id)) {
+        if (id && isString(id)) res.add(id)
+        this._getPredecessorSet(id, res)
+      }
     })
     if (cell.hasSideEffects && cell.prev) {
-      this._getPredecessorSet(cell.prev, res)
+      if (!res.has(id)) {
+        this._getPredecessorSet(cell.prev, res)
+      }
     }
     return res
   }

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -661,6 +661,10 @@ class Document {
     return this.cells
   }
 
+  setAutorun(val) {
+    this.autorun = val
+  }
+
   insertCellAt(pos, cellData) {
     let cell = this._createCell(cellData)
     this._registerCell(cell)
@@ -760,6 +764,10 @@ class Sheet {
   }
 
   get type() { return 'sheet' }
+
+  setAutorun(val) {
+    this.autorun = val
+  }
 
   getColumnName(colIdx) {
     let columnMeta = this.columns[colIdx]

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -339,6 +339,7 @@ export default class Engine extends EventEmitter {
     const graph = this._graph
     const id = action.id
     const cell = graph.getCell(id)
+    cell.errors = []
     // in case of constants, casting the string into a value,
     // updating the cell graph and returning without further evaluation
     if (cell.isConstant()) {
@@ -350,7 +351,6 @@ export default class Engine extends EventEmitter {
     }
     // TODO: we need to reset the cell status. Should we let CellGraph do this?
     cell.status = UNKNOWN
-    cell.errors = []
     // otherwise the cell source is assumed to be dynamic source code
     const transpiledSource = cell.transpiledSource
     const lang = cell.getLang()

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -301,6 +301,9 @@ export default class Engine extends EventEmitter {
   _sendUpdate(updatedCells) {
     // TODO: this should send a batch update over to the app
     // and for testing this method should be 'spied'
+    // updatedCells.forEach(cell => {
+    //   console.log(`Updated cell ${cell.id}: ${cell._getStatusString()}`)
+    // })
     this.emit('update', updatedCells)
   }
 

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -1,4 +1,4 @@
-import { uuid, isString, EventEmitter } from 'substance'
+import { uuid, isString, EventEmitter, flatten } from 'substance'
 import CellGraph from './CellGraph'
 import { ContextError, RuntimeError } from './CellErrors'
 import { UNKNOWN, ANALYSED, READY } from './CellStates'
@@ -611,6 +611,25 @@ export default class Engine extends EventEmitter {
     if (action) {
       delete action.suspended
     }
+  }
+
+  _allowRunningAllCellsOfDocument(docId) {
+    const graph = this._graph
+    let doc = this._docs[docId]
+    let cells = doc.getCells()
+    if (doc instanceof Sheet) {
+      cells = flatten(cells)
+    }
+    let ids = new Set()
+    cells.forEach(cell => {
+      ids.add(cell.id)
+    })
+    cells.forEach(cell => {
+      graph._getPredecessorSet(cell.id, ids)
+    })
+    ids.forEach(id => {
+      this._allowRunningCell(id)
+    })
   }
 }
 

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -593,7 +593,6 @@ export default class Engine extends EventEmitter {
     return cell.doc.autorun
   }
 
-  // EXPERIMENTAL: used for manual execution
   _allowRunningCellAndPredecessors(id) {
     const graph = this._graph
     let predecessors = graph._getPredecessorSet(id)

--- a/src/shared/AutoRunCommand.js
+++ b/src/shared/AutoRunCommand.js
@@ -2,13 +2,6 @@ import { Command } from 'substance'
 
 export default class RunAllCommand extends Command {
 
-  execute({ editorSession }) {
-    let doc = editorSession.getDocument()
-    const autorun = doc.autorun
-    doc.autorun = !autorun
-    editorSession.setSelection(null)
-  }
-
   getCommandState({ editorSession }) {
     const doc = editorSession.getDocument()
     const autorun = doc.autorun
@@ -17,4 +10,12 @@ export default class RunAllCommand extends Command {
       disabled: false
     }
   }
+
+  execute({ editorSession }) {
+    let doc = editorSession.getDocument()
+    const autorun = doc.autorun
+    doc.autorun = !autorun
+    editorSession.setSelection(null)
+  }
+
 }

--- a/src/shared/AutoRunCommand.js
+++ b/src/shared/AutoRunCommand.js
@@ -1,0 +1,20 @@
+import { Command } from 'substance'
+
+export default class RunAllCommand extends Command {
+
+  execute({ editorSession }) {
+    let doc = editorSession.getDocument()
+    const autorun = doc.autorun
+    doc.autorun = !autorun
+    editorSession.setSelection(null)
+  }
+
+  getCommandState({ editorSession }) {
+    const doc = editorSession.getDocument()
+    const autorun = doc.autorun
+    return {
+      autoOrManual: autorun ? 'Manual' : 'Auto',
+      disabled: false
+    }
+  }
+}

--- a/src/shared/RunAllCommand.js
+++ b/src/shared/RunAllCommand.js
@@ -1,0 +1,13 @@
+import { Command } from 'substance'
+
+export default class RunAllCommand extends Command {
+
+  getCommandState({ editorSession }) {
+    const doc = editorSession.getDocument()
+    const autorun = doc.autorun
+
+    return {
+      disabled: autorun
+    }
+  }
+}

--- a/src/shared/RunAllCommand.js
+++ b/src/shared/RunAllCommand.js
@@ -5,9 +5,15 @@ export default class RunAllCommand extends Command {
   getCommandState({ editorSession }) {
     const doc = editorSession.getDocument()
     const autorun = doc.autorun
-
     return {
       disabled: autorun
     }
+  }
+
+  execute(params, context) {
+    const editorSession = params.editorSession
+    const engine = context.engine
+    const doc = editorSession.getDocument()
+    engine._allowRunningAllCellsOfDocument(doc.id)
   }
 }

--- a/tests/engine/Engine.test.js
+++ b/tests/engine/Engine.test.js
@@ -523,6 +523,31 @@ test('Engine: manually run cell and predecessors', t => {
   })
 })
 
+test('Engine: run all cells in manual execution mode', t => {
+  t.plan(1)
+  let { engine } = _setup()
+  let doc = engine.addDocument({
+    id: 'doc1',
+    lang: 'mini',
+    autorun: false,
+    cells: [
+      'x = 2',
+      'y = x * 3',
+      'z = y + 2'
+    ]
+  })
+  let cells = doc.getCells()
+  _play(engine)
+  .then(() => {
+    debugger
+    engine._allowRunningAllCellsOfDocument('doc1')
+  })
+  .then(() => _play(engine))
+  .then(() => {
+    t.deepEqual(_getValues(cells), [2, 6, 8], 'cells should have been computed')
+  })
+})
+
 /*
   Waits for all actions to be finished.
   This is the slowest kind of scheduling, as every cycle
@@ -558,7 +583,7 @@ function _needsUpdate(engine) {
   const nextActions = engine._nextActions
   if (nextActions.size === 0) return false
   // update is required if there is an action that has not been suspended
-  for (let [id, a] of nextActions) {
+  for (let [, a] of nextActions) {
     if (!a.suspended) return true
   }
   return false

--- a/tests/engine/Engine.test.js
+++ b/tests/engine/Engine.test.js
@@ -539,7 +539,6 @@ test('Engine: run all cells in manual execution mode', t => {
   let cells = doc.getCells()
   _play(engine)
   .then(() => {
-    debugger
     engine._allowRunningAllCellsOfDocument('doc1')
   })
   .then(() => _play(engine))


### PR DESCRIPTION
# Why?

The original idea was to introduce breakpoints to give the user more control of cell execution e.g. in presence of long-running tasks.

# What?

For sake of simplicity, we introduce a flag on document level, that controls whether cells are evaluated automatically or triggered by the user explicitly.
A manual request for evaluating a cell is interpreted as 'run this cell and all its dependencies' (i.e. anything needed to run this cell).
