### PR TITLE
Add example for `pars` property

### DIFF
--- a/docs/languages/js/README.md
+++ b/docs/languages/js/README.md
@@ -20,6 +20,7 @@ Stencila functions can be implemented using Javascript. To match Stencila's call
 function square(value) {
   return value * value
 }
+square.pars = ['value']
 ```
 
 


### PR DESCRIPTION
Why: I think the example was missing here (it's the code block directly after a sentence introducing something new).

What: I added the `pars` example to the code.
