### PR TITLE
Resize sheet on paste

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "plotly.js": "^1.31.1",
     "stencila-libcore": "^0.2.10",
     "stencila-mini": "^0.14.0",
-    "substance": "1.0.0-preview.39",
+    "substance": "1.0.0-preview.40",
     "substance-texture": "1.0.0-preview.1.6",
     "timeago.js": "3.0.0",
     "xmlhttprequest": "^1.8.0"

--- a/src/engine/Sheet.js
+++ b/src/engine/Sheet.js
@@ -90,7 +90,7 @@ export default class Sheet {
       let row = block[i]
       for (let j = 0; j < row.length; j++) {
         let cell = row[j]
-        if (spans[j]) cell.deps = new Set(spans[j])
+        if (spans && spans[j]) cell.deps = new Set(spans[j])
       }
     }
     // update sheet structure
@@ -135,7 +135,7 @@ export default class Sheet {
       let row = block[i]
       for (let j = 0; j < row.length; j++) {
         let cell = row[j]
-        if (spans[i]) cell.deps = new Set(spans[i])
+        if (spans && spans[i]) cell.deps = new Set(spans[i])
       }
     }
     this._registerCells(block)
@@ -284,18 +284,25 @@ function transformCells(engine, cells, dim, pos, count, affected) {
 // some symbols are spanning the insert position, and thus need to
 // be added to the deps of inserted cells
 function _computeSpans(cells, dim, pos) {
-  let spans = []
+  let spans
   if (pos > 0) {
-    let N = dim === 0 ? cells[0].length : cells.length
-    for (let i = 0; i < N; i++) {
+    if (cells.length === 0 || cells[0].length === 0) return
+    let size = [cells.length, cells[0].length]
+    if (pos >= size[dim]) return
+    // check cells along the other dimension
+    let L = dim === 0 ? size[1] : size[0]
+    for (let i = 0; i < L; i++) {
       let cell = dim === 0 ? cells[pos][i] : cells[i][pos]
-      cell.deps.forEach(s => {
+      let deps = Array.from(cell.deps)
+      for (let j = 0; j < deps.length; j++) {
+        let s = deps[j]
         let update = s._update
         if (update && update.start <= pos) {
+          if (!spans) spans = []
           if (!spans[i]) spans[i] = []
           spans[i].push(s)
         }
-      })
+      }
     }
   }
   return spans

--- a/src/sheet/SheetClipboard.js
+++ b/src/sheet/SheetClipboard.js
@@ -67,8 +67,8 @@ export default class SheetClipboard {
   _pasteHtml(html, plainText) {
     let vals = this._htmlToVals(html)
     if (vals && vals.length > 0) {
-      let range = this._getRange()
-      setValues(this.editorSession, range.startRow, range.startCol, vals)
+      let { startRow, startCol } = this._getRange()
+      setValues(this.editorSession, startRow, startCol, vals)
     } else {
       this._pastePlainText(plainText)
     }

--- a/src/sheet/SheetDocument.js
+++ b/src/sheet/SheetDocument.js
@@ -97,6 +97,16 @@ export default class SheetDocument extends XMLDocument {
     return data.getChildCount()
   }
 
+  getDimensions() {
+    let matrix = this.getCellMatrix()
+    let nrows = matrix.length
+    let ncols = 0
+    if (nrows > 0) {
+      ncols = matrix[0].length
+    }
+    return [nrows, ncols]
+  }
+
   _apply(change) {
     super._apply(change)
     // update the matrix on structural changes

--- a/src/sheet/sheetManipulations.js
+++ b/src/sheet/sheetManipulations.js
@@ -46,6 +46,7 @@ export function setCell(editorSession, row, col, val) {
 export function setValues(editorSession, startRow, startCol, vals) {
   let n = vals.length
   let m = vals[0].length
+  ensureSize(editorSession, startRow+n, startCol+m)
   editorSession.transaction(tx => {
     let sheet = tx.getDocument()
     _setValues(sheet, startRow, startCol, vals)
@@ -80,6 +81,17 @@ export function setCellTypes(editorSession, startRow, startCol, endRow, endCol, 
   editorSession.transaction(tx => {
     _setCellTypesForRange(tx.getDocument(), startRow, startCol, endRow, endCol, type)
   }, { action: 'setCellTypes' })
+}
+
+export function ensureSize(editorSession, nrows, ncols) {
+  let sheet = editorSession.getDocument()
+  let [_nrows, _ncols] = sheet.getDimensions()
+  if (_ncols < ncols) {
+    insertCols(editorSession, _ncols, ncols-_ncols)
+  }
+  if (_nrows < nrows) {
+    insertRows(editorSession, _nrows, nrows-_nrows)
+  }
 }
 
 function _setValues(sheet, startRow, startCol, vals) {

--- a/tests/engine/Engine.test.js
+++ b/tests/engine/Engine.test.js
@@ -593,6 +593,27 @@ test('Engine: insert rows', t => {
   })
 })
 
+test('Engine: append rows', t => {
+  t.plan(1)
+  let { engine } = _setup()
+  let sheet = engine.addSheet({
+    id: 'sheet1',
+    lang: 'mini',
+    cells: [
+      ['1', '2'],
+      ['3', '4']
+    ]
+  })
+  play(engine)
+  .then(() => {
+    sheet.insertRows(2, [['5', '6'], ['7', '8'], ['9', '10']])
+  })
+  .then(() => play(engine))
+  .then(() => {
+    t.deepEqual(getValues(queryCells(sheet.cells, 'A3:B5')), [[5, 6],[7, 8], [9, 10]], 'cells should have been inserted')
+  })
+})
+
 test('Engine: delete rows', t => {
   t.plan(1)
   let { engine } = _setup()
@@ -634,6 +655,27 @@ test('Engine: insert cols', t => {
   .then(() => play(engine))
   .then(() => {
     t.deepEqual(getValues(queryCells(sheet.cells, 'A1:C2')), [[1, 5, 2],[3, 6, 4]], 'cells should have been inserted')
+  })
+})
+
+test('Engine: append cols', t => {
+  t.plan(1)
+  let { engine } = _setup()
+  let sheet = engine.addSheet({
+    id: 'sheet1',
+    lang: 'mini',
+    cells: [
+      ['1', '2'],
+      ['3', '4']
+    ]
+  })
+  play(engine)
+  .then(() => {
+    sheet.insertCols(2, [['5', '6', '7'], ['8', '9', '10']])
+  })
+  .then(() => play(engine))
+  .then(() => {
+    t.deepEqual(getValues(queryCells(sheet.cells, 'C1:E2')), [[5, 6, 7],[8, 9, 10]], 'cells should have been inserted')
   })
 })
 

--- a/tests/sheet/Sheet.test.js
+++ b/tests/sheet/Sheet.test.js
@@ -1,5 +1,5 @@
 import test from 'tape'
-import { insertRows, deleteRows, insertCols, deleteCols, setCell } from '../../src/sheet/sheetManipulations'
+import { insertRows, deleteRows, insertCols, deleteCols, setCell, ensureSize } from '../../src/sheet/sheetManipulations'
 import createSheetXML from '../util/createSheetXML'
 import StubEngine from '../util/StubEngine'
 import setupEngine from '../util/setupEngine'
@@ -19,31 +19,38 @@ import setupSheetSession from '../util/setupSheetSession'
     - sheetManipulations
 */
 
-test('Sheet (model): inserting rows should increase row count', (t) => {
+test('Sheet: inserting rows should increase row count', (t) => {
   let { sheetSession, sheet } = _setupModel(simple())
   insertRows(sheetSession, 1, 2)
   t.deepEqual(sheet.getRowCount(), 6, 'row count should have been updated')
   t.end()
 })
 
-test('Sheet (model): deleting rows should decrease row count', (t) => {
+test('Sheet: deleting rows should decrease row count', (t) => {
   let { sheetSession, sheet } = _setupModel(simple())
   deleteRows(sheetSession, 1, 2)
   t.deepEqual(sheet.getRowCount(), 2, 'row count should have been updated')
   t.end()
 })
 
-test('Sheet (model): inserting columns should increase column count', (t) => {
+test('Sheet: inserting columns should increase column count', (t) => {
   let { sheetSession, sheet } = _setupModel(simple())
   insertCols(sheetSession, 1, 2)
   t.deepEqual(sheet.getColumnCount(), 5, 'row count should have been updated')
   t.end()
 })
 
-test('Sheet (model): deleting columns should decrease column count', (t) => {
+test('Sheet: deleting columns should decrease column count', (t) => {
   let { sheetSession, sheet } = _setupModel(simple())
   deleteCols(sheetSession, 1, 2)
-  t.deepEqual(sheet.getColumnCount(), 1, 'row count should have been updated')
+  t.deepEqual(sheet.getColumnCount(), 1, 'column count should have been updated')
+  t.end()
+})
+
+test('Sheet: ensure size', (t) => {
+  let { sheetSession, sheet } = _setupModel(simple())
+  ensureSize(sheetSession, 10, 5)
+  t.deepEqual(sheet.getDimensions(), [10,5], 'sheet dimensions should have been updated')
   t.end()
 })
 


### PR DESCRIPTION
# Why?

At the moment, when pasting a table into a sheet that is larger than the sheet itself, the data gets truncated. See https://github.com/stencila/desktop/issues/35

# What?

This PR introduces logic that automatically adds columns and rows as necessary to fit the pasted data.