### PR TITLE
WIP: Remove ability to show/hide code in the editor.

### DIFF
--- a/src/article/ArticleEditorPackage.js
+++ b/src/article/ArticleEditorPackage.js
@@ -20,9 +20,9 @@ import ImageValueComponent from '../shared/ImageValueComponent'
 import PlotlyValueComponent from '../shared/PlotlyValueComponent'
 
 import {
-  SetLanguageCommand, ToggleAllCodeCommand,
-  HideCellCodeCommand, InsertCellCommand, InsertReproFigCommand,
+  SetLanguageCommand, InsertCellCommand, InsertReproFigCommand,
   ForceCellOutputCommand, RunCellCommand
+  // ToggleAllCodeCommand, HideCellCodeCommand,
 } from './ArticleEditorCommands'
 
 import FunctionUsageCommand from '../shared/FunctionUsageCommand'
@@ -167,7 +167,7 @@ export default {
     */
 
     config.addCommand(RunCellCommand.name, RunCellCommand, { commandGroup: 'cell-actions' })
-    config.addCommand('hide-cell-code', HideCellCodeCommand, { commandGroup: 'cell-actions' })
+    // config.addCommand('hide-cell-code', HideCellCodeCommand, { commandGroup: 'cell-actions' })
     config.addCommand('force-cell-output', ForceCellOutputCommand, { commandGroup: 'cell-actions' })
     config.addCommand('set-mini', SetLanguageCommand, { language: 'mini', commandGroup: 'cell-actions' })
     config.addCommand('set-js', SetLanguageCommand, { language: 'js', commandGroup: 'cell-actions' })
@@ -199,14 +199,14 @@ export default {
     config.addLabel('auto-run', '${autoOrManual} Execution')
 
     // View Commands
-    config.addCommand('hide-all-code', ToggleAllCodeCommand, {
-      hideCode: true,
-      commandGroup: 'view'
-    })
-    config.addCommand('show-all-code', ToggleAllCodeCommand, {
-      hideCode: false,
-      commandGroup: 'view'
-    })
+    // config.addCommand('hide-all-code', ToggleAllCodeCommand, {
+    //   hideCode: true,
+    //   commandGroup: 'view'
+    // })
+    // config.addCommand('show-all-code', ToggleAllCodeCommand, {
+    //   hideCode: false,
+    //   commandGroup: 'view'
+    // })
 
     config.addKeyboardShortcut('CommandOrControl+Alt+L', { command: 'show-all-code' })
     config.addKeyboardShortcut('CommandOrControl+Alt+O', { command: 'hide-all-code' })

--- a/src/article/ArticleEditorPackage.js
+++ b/src/article/ArticleEditorPackage.js
@@ -21,8 +21,8 @@ import PlotlyValueComponent from '../shared/PlotlyValueComponent'
 
 import {
   SetLanguageCommand, InsertCellCommand, InsertReproFigCommand,
-  ForceCellOutputCommand, RunCellCommand
-  // ToggleAllCodeCommand, HideCellCodeCommand,
+  ForceCellOutputCommand, RunCellCommand,
+  ToggleAllCodeCommand
 } from './ArticleEditorCommands'
 
 import FunctionUsageCommand from '../shared/FunctionUsageCommand'
@@ -167,7 +167,6 @@ export default {
     */
 
     config.addCommand(RunCellCommand.name, RunCellCommand, { commandGroup: 'cell-actions' })
-    // config.addCommand('hide-cell-code', HideCellCodeCommand, { commandGroup: 'cell-actions' })
     config.addCommand('force-cell-output', ForceCellOutputCommand, { commandGroup: 'cell-actions' })
     config.addCommand('set-mini', SetLanguageCommand, { language: 'mini', commandGroup: 'cell-actions' })
     config.addCommand('set-js', SetLanguageCommand, { language: 'js', commandGroup: 'cell-actions' })
@@ -178,7 +177,7 @@ export default {
 
     // Labels and icons
     config.addLabel('run-cell-code', 'Run cell')
-    config.addLabel('hide-cell-code', 'Hide code')
+    //config.addLabel('hide-cell-code', 'Hide code')
     config.addLabel('force-cell-output', 'Force output')
     config.addLabel('set-mini', 'Mini')
     config.addLabel('set-js', 'Javascript')
@@ -192,21 +191,21 @@ export default {
     config.addIcon('test-passed', {'fontawesome': 'fa-check' })
 
 
-    config.addLabel('show-all-code', 'Show All Code')
-    config.addLabel('hide-all-code', 'Hide All Code')
+    config.addLabel('show-all-code', 'Show Code')
+    config.addLabel('hide-all-code', 'Hide Code')
 
     config.addLabel('settings', 'Settings')
     config.addLabel('auto-run', '${autoOrManual} Execution')
 
     // View Commands
-    // config.addCommand('hide-all-code', ToggleAllCodeCommand, {
-    //   hideCode: true,
-    //   commandGroup: 'view'
-    // })
-    // config.addCommand('show-all-code', ToggleAllCodeCommand, {
-    //   hideCode: false,
-    //   commandGroup: 'view'
-    // })
+    config.addCommand('hide-all-code', ToggleAllCodeCommand, {
+      hideCode: true,
+      commandGroup: 'view'
+    })
+    config.addCommand('show-all-code', ToggleAllCodeCommand, {
+      hideCode: false,
+      commandGroup: 'view'
+    })
 
     config.addKeyboardShortcut('CommandOrControl+Alt+L', { command: 'show-all-code' })
     config.addKeyboardShortcut('CommandOrControl+Alt+O', { command: 'hide-all-code' })

--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -1,4 +1,4 @@
-import { NodeComponent, FontAwesomeIcon } from 'substance'
+import { NodeComponent } from 'substance'
 import ValueComponent from '../shared/ValueComponent'
 import CodeEditor from '../shared/CodeEditor'
 import { getCellState, getError } from '../shared/cellHelpers'
@@ -73,17 +73,6 @@ class CellComponent extends NodeComponent {
         $$('div').addClass('se-language').append(
           LANG_LABELS[source.attributes.language]
         )
-      )
-    } else {
-      // TODO: Create proper visual style
-      el.append(
-        $$('button').append(
-          this._renderStatus($$),
-          $$(FontAwesomeIcon, { icon: 'fa-code' })
-        )
-          .addClass('se-show-code')
-          .attr('title', 'Show Code')
-          .on('click', this._showCode)
       )
     }
 


### PR DESCRIPTION
After our call yesterday we discussed how we want to handle toggling of code cells (green dot). We've came to the conclusion that we want to handle these as presentation settings as part of generating the publication. That means we remove all show/hide code functionality from the editor and move this into a separate "preview" or "publish" workflow.

1. This pull requests removes the show/hide code functionality
2. Work on preview/publish dialog (see #659)

@nokome are you ok with this approach? It means we drop the green dot for now completely, and bring it back for the reader view on a follow-up release.