### PR TITLE
Only show the tooltip when cursor is on the function name.

### DIFF
--- a/src/shared/FunctionUsageCommand.js
+++ b/src/shared/FunctionUsageCommand.js
@@ -36,7 +36,11 @@ export default class FunctionUsageCommand extends Command {
 
     let candidate
     nodes.forEach((node) => {
-      if (node.type === 'function' && node.start <= cursorPos && node.start + node.name.length >= cursorPos) {
+      // At the moment we don't want to show function helper for a function arguments
+      // as we find it obtrusive, however this implementation contains function arguments
+      // highlighting.
+      // Currently we just restrict mathching with a function name and the first bracket.
+      if (node.type === 'function' && node.start <= cursorPos && node.start + node.name.length + 1 >= cursorPos) {
         let offset = cursorPos - node.start
         if (!candidate || offset < candidate.offset ) {
           // Param index

--- a/src/shared/FunctionUsageCommand.js
+++ b/src/shared/FunctionUsageCommand.js
@@ -39,7 +39,7 @@ export default class FunctionUsageCommand extends Command {
       // At the moment we don't want to show function helper for a function arguments
       // as we find it obtrusive, however this implementation contains function arguments
       // highlighting.
-      // Currently we just restrict mathching with a function name and the first bracket.
+      // Currently we just restrict matching with a function name and the first bracket.
       if (node.type === 'function' && node.start <= cursorPos && node.start + node.name.length + 1 >= cursorPos) {
         let offset = cursorPos - node.start
         if (!candidate || offset < candidate.offset ) {

--- a/src/shared/FunctionUsageCommand.js
+++ b/src/shared/FunctionUsageCommand.js
@@ -36,7 +36,7 @@ export default class FunctionUsageCommand extends Command {
 
     let candidate
     nodes.forEach((node) => {
-      if (node.type === 'function' && node.start <= cursorPos && node.end >= cursorPos) {
+      if (node.type === 'function' && node.start <= cursorPos && node.start + node.name.length >= cursorPos) {
         let offset = cursorPos - node.start
         if (!candidate || offset < candidate.offset ) {
           // Param index


### PR DESCRIPTION
Why: We want to make a function helper tooltip less obtrusive.
What: Number of alternative strategies when to show a tooltip were suggested here #641.
The first take is to show it only when a cursor is on the function name.