### PR TITLE
Better message for some errors and Engine fixes

### DIFF
--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -1,7 +1,7 @@
 import { NodeComponent, FontAwesomeIcon } from 'substance'
 import ValueComponent from '../shared/ValueComponent'
 import CodeEditor from '../shared/CodeEditor'
-import { getCellState, getError } from '../shared/cellHelpers'
+import { getCellState, getError, getErrorMessage } from '../shared/cellHelpers'
 import { toString as stateToString, BROKEN, FAILED, OK, READY } from '../engine/CellStates'
 import NodeMenu from './NodeMenu'
 
@@ -92,7 +92,7 @@ class CellComponent extends NodeComponent {
       if(status === FAILED || status === BROKEN) {
         el.append(
           $$('div').addClass('se-error').append(
-            getError(cell).message
+            getErrorMessage(getError(cell))
           ).ref('error').setStyle('visibility', 'hidden')
         )
       } else if (status === OK) {

--- a/src/contexts/JsContext.js
+++ b/src/contexts/JsContext.js
@@ -1,7 +1,7 @@
 import { parse } from 'acorn'
 import { simple, base } from 'acorn/dist/walk'
 import { generate } from 'astring/src/astring'
-import { isFunction } from 'substance'
+import { isFunction, isNil } from 'substance'
 
 import Context from './Context'
 
@@ -278,7 +278,7 @@ export default class JsContext extends Context {
    * Pack a value for passing to `Engine` or another `Context`
    */
   _packValue (value) {
-    if (value === undefined) return null
+    if (isNil(value)) return null
     let type
     if (Number.isInteger(value)) type = 'integer'
     else type = value.type || typeof value

--- a/src/engine/CellGraph.js
+++ b/src/engine/CellGraph.js
@@ -180,7 +180,6 @@ export default class CellGraph {
   _registerInputs(id, oldInputs, newInputs) {
     let toAdd = new Set(newInputs)
     let toRemove = new Set()
-
     if (oldInputs) {
       oldInputs.forEach(s => {
         if (newInputs.has(s)) {
@@ -314,8 +313,7 @@ export default class CellGraph {
     let inputs = Array.from(cell.inputs)
     let unresolved = inputs.filter(s => !this._resolve(s))
     if (unresolved.length > 0) {
-      // TODO: maybe only clear UnresolvedInputErrors
-      cell.clearErrors('graph')
+      cell.clearErrors(e => e instanceof UnresolvedInputError)
       cell.addErrors([new UnresolvedInputError(MSG_UNRESOLVED_INPUT, { unresolved })])
       cell.status = BROKEN
     }

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -318,7 +318,10 @@ export default class Engine extends EventEmitter {
     const graph = this._graph
     const id = action.id
     const cell = graph.getCell(id)
-    cell.errors = []
+    // clear all errors which are not managed by the CellGraph
+    cell.clearErrors(e => {
+      return e.type !== 'graph'
+    })
     // in case of constants, casting the string into a value,
     // updating the cell graph and returning without further evaluation
     if (cell.isConstant()) {
@@ -386,8 +389,9 @@ export default class Engine extends EventEmitter {
     const graph = this._graph
     const id = action.id
     const cell = graph.getCell(id)
-    // TODO: is it really ok to wipe all the errors?
-    cell.errors = []
+    cell.clearErrors(e => {
+      return e.type !== 'graph'
+    })
     // console.log('evaluating cell', cell.toString())
     const lang = cell.getLang()
     let transpiledSource = cell.transpiledSource

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -327,7 +327,7 @@ export default class Engine extends EventEmitter {
     if (cell.isConstant()) {
       // TODO: use the preferred type from the sheet
       let preferredType = 'any'
-      let value = valueFromText(preferredType, cell.source)
+      let value = valueFromText(cell.source, preferredType)
       graph.setValue(id, value)
       return
     }

--- a/src/engine/Engine.js
+++ b/src/engine/Engine.js
@@ -368,20 +368,19 @@ export default class Engine extends EventEmitter {
         graph.addErrors(id, res.messages.map(err => {
           return new SyntaxError(err.message)
         }))
-      } else {
-        // console.log('analysed cell', cell, res)
-        // transform the extracted symbols into fully-qualified symbols
-        // e.g. in `x` in `sheet1` is compiled into `sheet1.x`
-        let { inputs, output } = this._compile(res, cell)
-        this._nextActions.set(id, {
-          type: 'register',
-          id,
-          // Note: these symbols are in plain-text analysed by the context
-          // based on the transpiled source
-          inputs,
-          output
-        })
       }
+      // console.log('analysed cell', cell, res)
+      // transform the extracted symbols into fully-qualified symbols
+      // e.g. in `x` in `sheet1` is compiled into `sheet1.x`
+      let { inputs, output } = this._compile(res, cell)
+      this._nextActions.set(id, {
+        type: 'register',
+        id,
+        // Note: these symbols are in plain-text analysed by the context
+        // based on the transpiled source
+        inputs,
+        output
+      })
     })
   }
 

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -131,10 +131,24 @@ export function getError(cell) {
 
 export function getErrorMessage(error) {
   switch(error.name) {
-    case 'unresolved':
+    case 'unresolved': {
       return 'Unresolved inputs: ' + error.details.unresolved.map(s => {
         return s.origStr || s.name
       }).join(', ')
+    }
+    case 'cyclic': {
+      let frags = []
+      let trace = error.details.trace
+      let symbols = error.details.symbols
+      trace.forEach(id => {
+        let s = symbols[id]
+        if (s) {
+          frags.push(s.origStr || s)
+        }
+      })
+      frags.push(frags[0])
+      return 'Cyclic Dependency: ' + frags.join(' -> ')
+    }
     default:
       return error.message
   }

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -129,6 +129,17 @@ export function getError(cell) {
   }
 }
 
+export function getErrorMessage(error) {
+  switch(error.name) {
+    case 'unresolved':
+      return 'Unresolved inputs: ' + error.details.unresolved.map(s => {
+        return s.origStr || s.name
+      }).join(', ')
+    default:
+      return error.message
+  }
+}
+
 export function getValue(cell) {
   let cellState = getCellState(cell)
   if (cellState) {

--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -17,20 +17,27 @@ export function getCellValue(cell) {
   if (cell.state) {
     return cell.state.value
   } else {
-    let type = getCellType(cell)
-    return valueFromText(type, cell.text())
+    let preferredType = getCellType(cell)
+    return valueFromText(cell.text(), preferredType)
   }
 }
 
 export function getCellType(cell) {
-  let sheet = cell.getDocument()
-  let row = cell.parentNode
-  let colIdx = row._childNodes.indexOf(cell.id)
-  let columnMeta = sheet.getColumnMeta(colIdx)
-  return cell.attr('type') || columnMeta.attr('type') || 'any'
+  let type = cell.attr('type')
+  if (!type) {
+    let doc = cell.getDocument()
+    let docType = doc.documentType
+    if (docType === 'sheet') {
+      let row = cell.parentNode
+      let colIdx = row._childNodes.indexOf(cell.id)
+      let columnMeta = doc.getColumnMeta(colIdx)
+      type = columnMeta.attr('type')
+    }
+  }
+  return type || 'any'
 }
 
-export function valueFromText(preferredType, text) {
+export function valueFromText(text, preferredType = 'any') {
   const data = _parseText(preferredType, text)
   const type_ = type(data)
   return { type: type_, data }

--- a/src/sheet/SheetCellComponent.js
+++ b/src/sheet/SheetCellComponent.js
@@ -1,6 +1,6 @@
 import { NodeComponent } from 'substance'
 import ValueComponent from '../shared/ValueComponent'
-import { isExpression, getError, getValue } from '../shared/cellHelpers'
+import { isExpression, getError, getValue, getErrorMessage } from '../shared/cellHelpers'
 
 export default class SheetCellComponent extends NodeComponent {
 
@@ -26,7 +26,7 @@ export default class SheetCellComponent extends NodeComponent {
     if (error) {
       el.append(
         $$('div').addClass('se-error').append(
-          getError(cell).message
+          getErrorMessage(getError(cell))
         )
       )
       el.addClass('sm-issue sm-error')

--- a/tests/engine/CellGraph.test.js
+++ b/tests/engine/CellGraph.test.js
@@ -347,6 +347,25 @@ test('CellGraph: cycle', t => {
   t.end()
 })
 
+test('CellGraph: resolving a cycle', t => {
+  let g = new CellGraph()
+  let cells = [
+    new Cell(null, { id: 'cell1', inputs: ['y'], output: 'x', status: ANALYSED }),
+    new Cell(null, { id: 'cell2', inputs: ['x'], output: 'y', status: ANALYSED }),
+  ]
+  cells.forEach(c => g.addCell(c))
+
+  let updates = g.update()
+  _checkStates(t, cells, [BROKEN, BROKEN])
+
+  g.setInputs('cell2', [])
+  updates = g.update()
+  _checkUpdates(t, updates, ['cell1', 'cell2'])
+  _checkStates(t, cells, [WAITING, READY])
+
+  t.end()
+})
+
 /*
   Two cells exposing the same variable is considered a conflict.
   All involved cells are marked as broken.

--- a/tests/engine/Engine.test.js
+++ b/tests/engine/Engine.test.js
@@ -964,6 +964,31 @@ test('Engine: delete last column of a cell range', t => {
   })
 })
 
+test('Engine: resolving a cycle', t => {
+  t.plan(2)
+  let { engine } = _setup()
+  let doc = engine.addDocument({
+    id: 'doc1',
+    lang: 'mini',
+    cells: [
+      { id: 'cell1', source: 'x = y' },
+      { id: 'cell2', source: 'y = x' }
+    ]
+  })
+  let cells = doc.getCells()
+  play(engine)
+  .then(() => {
+    t.deepEqual(getErrors(cells), [['cyclic'], ['cyclic']], 'Both cells should have a cyclic dependency error.')
+  })
+  .then(() => {
+    doc.updateCell('cell2', { source: 'y = 1'})
+  })
+  .then(() => play(engine))
+  .then(() => {
+    t.deepEqual(getErrors(cells), [[], []], 'Cyclic dependency error should be resolved.')
+  })
+})
+
 function _checkActions(t, engine, cells, expected) {
   let nextActions = engine.getNextActions()
   let actual = []

--- a/tests/engine/Engine.test.js
+++ b/tests/engine/Engine.test.js
@@ -989,6 +989,32 @@ test('Engine: resolving a cycle', t => {
   })
 })
 
+test('Engine: resolving a cycle when cell gets invalid', t => {
+  t.plan(2)
+  let { engine } = _setup()
+  let doc = engine.addDocument({
+    id: 'doc1',
+    lang: 'mini',
+    cells: [
+      { id: 'cell1', source: 'x = y' },
+      { id: 'cell2', source: 'y = x' }
+    ]
+  })
+  let cells = doc.getCells()
+  play(engine)
+  .then(() => {
+    t.deepEqual(getErrors(cells), [['cyclic'], ['cyclic']], 'Both cells should have a cyclic dependency error.')
+  })
+  .then(() => {
+    doc.updateCell('cell2', { source: 'y = '})
+  })
+  .then(() => play(engine))
+  .then(() => {
+    t.deepEqual(getErrors(cells), [[], ['syntax']], 'Cyclic dependency error should be resolved.')
+  })
+})
+
+
 function _checkActions(t, engine, cells, expected) {
   let nextActions = engine.getNextActions()
   let actual = []

--- a/tests/index.html
+++ b/tests/index.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="../node_modules/substance-texture/dist/texture.js"></script>
     <script type="text/javascript" src="../node_modules/plotly.js/dist/plotly.js"></script>
     <script type="text/javascript" src="../node_modules/stencila-mini/dist/stencila-mini.js"></script>
-    <script type="text/javascript" src="../node_modules/stencila-libcore/build/stencila-libcore.all.js"></script>
+    <script type="text/javascript" src="../node_modules/stencila-libcore/builds/stencila-libcore.min.js"></script>
     <script type="text/javascript" src="../node_modules/substance-test/dist/testsuite.js"></script>
     <script type="text/javascript" src="../tmp/tests.js"></script>
   </head>

--- a/tests/shared/cellHelpers.test.js
+++ b/tests/shared/cellHelpers.test.js
@@ -1,0 +1,147 @@
+import test from 'tape'
+import {
+  getCellState, isExpression, getCellValue, getCellType, valueFromText,
+  getSource, setSource
+} from '../../src/shared/cellHelpers'
+import createRawArchive from '../util/createRawArchive'
+import loadRawArchive from '../util/loadRawArchive'
+import setupEngine from '../util/setupEngine'
+import { play } from '../util/engineTestHelpers'
+
+
+test('cellHelpers: getCellState', t => {
+  let { archive } = _setup()
+  let article = archive.getEditorSession('article').getDocument()
+  let cell = article.get('cell1')
+  let cellState = getCellState(cell)
+  t.ok(Boolean(cellState), 'there should be a cell state')
+  t.ok(Boolean(cellState.status), 'cell state should have a status')
+  t.end()
+})
+
+test('cellHelpers: isExpression()', t => {
+  t.ok(isExpression('= foo()'), 'a cell with leading "=" is considered an expression')
+  t.end()
+})
+
+test('cellHelpers: getCellValue', t => {
+  t.plan(1)
+  let { archive, engine } = _setup()
+  let article = archive.getEditorSession('article').getDocument()
+  let cell = article.get('cell1')
+  play(engine)
+  .then(() => {
+    t.deepEqual(getCellValue(cell), {type: "number", data: 1}, 'getCellValue() should provide an unpacked value')
+  })
+})
+
+test('cellHelpers: getCellType', t => {
+  // TODO: do we want cell types only in sheets?
+  t.plan(2)
+  let { archive, engine } = _setup(sheetSample())
+  let sheet = archive.getEditorSession('sheet').getDocument()
+  let cells = sheet.getCellMatrix()
+  play(engine)
+  .then(() => {
+    t.deepEqual(getCellType(cells[0][0]), "number", 'getCellType() should provide the correct type')
+    t.deepEqual(getCellType(cells[0][1]), "any", 'getCellType() should provide the correct type')
+  })
+})
+
+test('cellHelpers: valueFromText', t => {
+  // TODO: add more of thi
+  t.deepEqual(valueFromText('false'), { type: "boolean", data: false }, 'valueFromText should provide a correct unpacked value')
+  t.deepEqual(valueFromText('true'), { type: "boolean", data: true }, 'valueFromText should provide a correct unpacked value')
+  t.deepEqual(valueFromText('1'), { type: "integer", data: 1 }, 'valueFromText should provide a correct unpacked value')
+  t.deepEqual(valueFromText('1.2'), { type: "number", data: 1.2 }, 'valueFromText should provide a correct unpacked value')
+  t.end()
+})
+
+test('cellHelpers: getSource', t => {
+  let { archive } = _setup(sheetAndArticle())
+  let article = archive.getEditorSession('article').getDocument()
+  let sheet = archive.getEditorSession('sheet').getDocument()
+  let articleCell = article.get('cell1')
+  let sheetCell = sheet.get('cell1')
+  t.equal(getSource(articleCell), '10', 'source of article cell should be provided correctly')
+  t.equal(getSource(sheetCell), '1', 'source of sheet cell should be provided correctly')
+  t.end()
+})
+
+test('cellHelpers: setSource', t => {
+  let { archive } = _setup(sample())
+  let article = archive.getEditorSession('article').getDocument()
+  let cell = article.get('cell1')
+  setSource(cell, '10')
+  t.equal(getSource(cell), '10', 'source of cell should have been updated correctly')
+  t.end()
+})
+
+function sample() {
+  return [
+    {
+      id: 'article',
+      path: 'article.xml',
+      type: 'article',
+      name: 'My Article',
+      body: [
+        "<p id='p1'>...</p>",
+        "<cell id='cell1' language='mini' type='number'>1</cell>",
+        "<p id='p2'>...</p>",
+        "<cell id='cell2' language='mini'>2</cell>",
+      ]
+    }
+  ]
+}
+
+function sheetSample() {
+  return [{
+    id: 'sheet',
+    path: 'sheet.xml',
+    type: 'sheet',
+    name: 'My Sheet',
+    columns: [{ name: 'x', type: 'number' }, { name: 'y' }, { name: 'z' }],
+    cells: [
+      ['1', '2', '3'],
+      ['4', '5', '6'],
+      ['7', '8', '9'],
+      ['10', '11', '12']
+    ]
+  }]
+}
+
+function sheetAndArticle() {
+  return [
+    {
+      id: 'article',
+      path: 'article.xml',
+      type: 'article',
+      name: 'My Article',
+      body: [
+        "<cell id='cell1' language='mini' type='number'>10</cell>",
+      ]
+    },
+    {
+      id: 'sheet',
+      path: 'sheet.xml',
+      type: 'sheet',
+      name: 'My Sheet',
+      cells: [
+        [{ id: 'cell1', source: '1'}, '2'],
+        ['3', '4'],
+      ]
+    }
+  ]
+}
+
+function _setup(archiveData) {
+  archiveData = archiveData || sample()
+  let host
+  let engine
+  let context = {}
+  ;({host, engine} = setupEngine())
+  context.host = host
+  let rawArchive = createRawArchive(archiveData)
+  let archive = loadRawArchive(rawArchive, context)
+  return { archive, engine }
+}


### PR DESCRIPTION
# Why?

Currently some cell errors are not very revealing. E.g.
- 'Unresolved inputs.' when one or more inputs could not be resolved
- 'Cyclic Dependency' when there is a cyclic dependency

# What?

Being there already in the error instances, this PR introduces a cell error message helper that exposes this information.

- Additionally I have fixed some bugs in the Engine related to cell updates.
- And added tests for `cellHelpers`.

On the long run we would like to have even more, such as being able to jump to the source of errors.