### PR TITLE
Cell errors

### DIFF
--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -218,7 +218,7 @@ class CellComponent extends NodeComponent {
           if(errEl) {
             errEl.setStyle('visibility', 'visible')
           }
-        }, 1000)
+        }, 500)
       } else if (status === OK) {
         this.oldValue = cellState.value
         clearTimeout(this.delayError) // eslint-disable-line no-undef

--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -218,7 +218,7 @@ class CellComponent extends NodeComponent {
           if(errEl) {
             errEl.setStyle('visibility', 'visible')
           }
-        }, 500)
+        }, 1000)
       } else if (status === OK) {
         this.oldValue = cellState.value
         clearTimeout(this.delayError) // eslint-disable-line no-undef

--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -31,6 +31,13 @@ class CellComponent extends NodeComponent {
     this.context.editorSession.onRender('document', this._onNodeChange, this, { path: [this.props.node.id]})
   }
 
+  shouldRerender(newProps) {
+    if(newProps.focused !== this.props.focused) {
+      return false
+    }
+    return true
+  }
+
   getInitialState() {
     return {
       hideCode: false,


### PR DESCRIPTION
Why: as were reported in #665 errors messages are gone after focusing other node. There were also considerations that rerender hides the error too eagerly.
What: this PR blocks cell rerendering in case of focus changing. It is also increasing error delay. So now it will show error only if you will not change the cell contents during one second (it was half a second before).