### PR TITLE
Simplify mini syntax error messages.

### DIFF
--- a/src/shared/cellHelpers.js
+++ b/src/shared/cellHelpers.js
@@ -156,6 +156,9 @@ export function getErrorMessage(error) {
       frags.push(frags[0])
       return 'Cyclic Dependency: ' + frags.join(' -> ')
     }
+    case 'syntax': {
+      return 'Syntax Error'
+    }
     default:
       return error.message
   }


### PR DESCRIPTION
# Why?

Syntax errors in mini are overly complex.

# What?

This PR turns them into a simple 'Syntax Error', which is apparently less revealing, but also less obtrusive.