### PR TITLE
Fix cell range transclusion issue

### DIFF
--- a/src/shared/CodeEditor.js
+++ b/src/shared/CodeEditor.js
@@ -59,15 +59,19 @@ export default class CodeEditor extends Component {
     if (this.props.mode === 'cell') {
       shouldAnalyse = Boolean(/^\s*=/.exec(code))
     }
+    // tokens for syntax-highlighting
     let tokens = []
+    // symbols such as 'var', 'cell', or 'range'
+    let symbols = []
+    // detected complex nodes, such as function calls
     let nodes = []
     if (shouldAnalyse) {
-      ({tokens, nodes} = analyseCode(code, this.props.language))
+      ({tokens, symbols, nodes} = analyseCode(code, this.props.language))
     }
     this._setMarkers(tokens)
     // TODO: rethink - if there was a State API how would we do this?
     // want to share code analysis e.g. with Commands
-    this._extendState({ tokens, nodes })
+    this._extendState({ tokens, symbols, nodes })
   }
 
   _getCode() {

--- a/src/shared/analyseCode.js
+++ b/src/shared/analyseCode.js
@@ -1,4 +1,5 @@
 import Prism from '../../tmp/prism.js'
+import { extractSymbols } from './expressionHelpers'
 
 const CELL = /\b([a-z0-9_]+[!])?([A-Z]{1,3}[1-9][0-9]*)(?:[:]([A-Z]{1,3}[1-9][0-9]*))?\b/
 const DEF = /(^|\n)[a-zA-Z_$][a-zA-Z_$0-9]*(?=\s*[=])/
@@ -102,6 +103,7 @@ function tokenize(code, lang) {
 // pseudo-parsing to collect information about functions
 export default function analyzeCode(code, lang = 'mini') {
   let tokens = tokenize(code, lang)
+  let symbols = extractSymbols(code)
   let nodes = []
   let calls = []
 
@@ -176,5 +178,5 @@ export default function analyzeCode(code, lang = 'mini') {
   // also push incomplete function calls
   _push(code.length)
 
-  return { tokens, nodes }
+  return { tokens, symbols, nodes }
 }

--- a/src/shared/expressionHelpers.js
+++ b/src/shared/expressionHelpers.js
@@ -54,12 +54,7 @@ const REF_RE = new RegExp(REF)
 */
 export function transpile(code, map = {}) {
   if (!code) return code
-  let re = new RegExp(REF, 'g')
-  let symbols = []
-  let m
-  while ((m = re.exec(code))) {
-    symbols.push(_createSymbol(m))
-  }
+  let symbols = extractSymbols(code)
   // Note: we are transpiling without changing the length of the original source
   // i.e. `'My Sheet'!A1:B10` is transpiled into `_My_Sheet__A1_B10`
   // thus the symbol locations won't get invalid by this step
@@ -69,6 +64,17 @@ export function transpile(code, map = {}) {
     map[s.mangledStr] = s
   }
   return code
+}
+
+export function extractSymbols(code) {
+  if (!code) return []
+  let re = new RegExp(REF, 'g')
+  let symbols = []
+  let m
+  while ((m = re.exec(code))) {
+    symbols.push(_createSymbol(m))
+  }
+  return symbols
 }
 
 /*

--- a/src/sheet/SheetEditor.js
+++ b/src/sheet/SheetEditor.js
@@ -345,9 +345,9 @@ export default class SheetEditor extends AbstractEditor {
     }
   }
 
-  _setReferenceSelection(reference) {
-    const from = reference.split(':')[0]
-    const to = reference.split(':')[1]
+  _setReferenceSelection(referenceSymbol) {
+    const from = referenceSymbol.anchor
+    const to = referenceSymbol.focus
     const [startRow, startCol] = getRowCol(from)
     const [endRow, endCol] = to ? getRowCol(to) : [startRow, startCol]
     const sheetComp = this.getSheetComponent()
@@ -374,16 +374,22 @@ export default class SheetEditor extends AbstractEditor {
       const cursorOffset = formulaSelection.start.offset
       const cell = formulaEditorSession.getDocument().get('cell')
       const cellState = getCellState(cell)
-      const tokens = cellState.tokens
-      const activeToken = tokens.find(token => {
-        return token.type === 'cell' && cursorOffset >= token.start && cursorOffset <= token.end
+      const symbols = cellState.symbols || []
+      const activeSymbol = symbols.find(s => {
+        return cursorOffset >= s.startPos && cursorOffset <= s.endPos
       })
-      if(activeToken) {
-        const cellReference = activeToken.text
-        this._setReferenceSelection(cellReference)
+      if(activeSymbol) {
+        // show a reference selection if the current symbol is pointing
+        // to a cell or range within the same sheet
+        if ((activeSymbol.type === 'cell' || activeSymbol.type === 'range') && !activeSymbol.scope) {
+          this._setReferenceSelection(activeSymbol)
+        } else {
+          this._hideCellRanges()
+        }
       } else {
         const sheetComp = this.getSheetComponent()
         sheetComp._hideSelection()
+        this._hideCellRanges()
       }
     }
   }

--- a/src/sheet/SheetEditor.js
+++ b/src/sheet/SheetEditor.js
@@ -27,7 +27,7 @@ export default class SheetEditor extends AbstractEditor {
       DefaultDOMElement.wrap(window).on('resize', this._onResize, this)
     }
     editorSession.onUpdate('selection', this._onSelectionChange, this)
-    this._formulaEditorContext.editorSession.onUpdate('selection', this._onCellEditorSelectionChange, this)
+    this._formulaEditorContext.editorSession.onRender('selection', this._onCellEditorSelectionChange, this)
   }
 
   didMount() {


### PR DESCRIPTION
# Why?

At the moment, in the Sheet editor, cell ranges of transcluded sheets are rendered like they were local references.

# What?

This PR makes use of the existing symbol parsing, used by the engine, to extract better information about cell and range references.
It also fixes an old bug due to wrong registration, which results the cell range renderer being called too early.

Fixes #663