### PR TITLE
TAB confirms cell editing and moves to next column.

### DIFF
--- a/src/sheet/FormulaEditor.js
+++ b/src/sheet/FormulaEditor.js
@@ -21,9 +21,7 @@ export default class FormulaEditor extends Component {
         multiline: false,
         mode: 'cell',
         language: this.props.language
-      }).ref('cellEditor')
-        .on('enter', this._onCodeEditorEnter)
-        .on('escape', this._onCodeEditorEscape),
+      }).ref('cellEditor'),
       $$(Overlay, {
         toolPanel: configurator.getToolPanel('prompt'),
         theme: 'dark'
@@ -37,14 +35,6 @@ export default class FormulaEditor extends Component {
 
   getChildContext() {
     return this.props.context
-  }
-
-  _onCodeEditorEnter() {
-    this.send('updateCell')
-  }
-
-  _onCodeEditorEscape() {
-    this.send('cancelCellEditing')
   }
 
 }


### PR DESCRIPTION
# Why?

This behavior is common Spreadsheet UX, and currently missing.
See: #364 

# What?

This PR handles the TAB event received from the FormulaEditor and moved the selection to the next column.

Fixes #364 