### PR TITLE
Integrate with JupyterContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stencila",
-  "version": "0.28.1-preview.2",
+  "version": "0.28.0",
   "description": "Stencila is the office suite for reproducible research.",
   "main": "build/stencila.cjs.js",
   "jsnext:main": "index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stencila",
-  "version": "0.28.1-preview.1",
+  "version": "0.28.1-preview.2",
   "description": "Stencila is the office suite for reproducible research.",
   "main": "build/stencila.cjs.js",
   "jsnext:main": "index.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stencila",
-  "version": "0.28.0",
+  "version": "0.28.1-preview.1",
   "description": "Stencila is the office suite for reproducible research.",
   "main": "build/stencila.cjs.js",
   "jsnext:main": "index.es.js",

--- a/src/article/ArticleEditorPackage.js
+++ b/src/article/ArticleEditorPackage.js
@@ -180,6 +180,7 @@ export default {
     config.addCommand('set-js', SetLanguageCommand, { language: 'js', commandGroup: 'cell-actions' })
     config.addCommand('set-node', SetLanguageCommand, { language: 'node', commandGroup: 'cell-actions' })
     config.addCommand('set-py', SetLanguageCommand, { language: 'py', commandGroup: 'cell-actions' })
+    config.addCommand('set-pyjp', SetLanguageCommand, { language: 'pyjp', commandGroup: 'cell-actions' })
     config.addCommand('set-r', SetLanguageCommand, { language: 'r', commandGroup: 'cell-actions' })
     config.addCommand('set-sql', SetLanguageCommand, { language: 'sql', commandGroup: 'cell-actions' })
 
@@ -191,6 +192,7 @@ export default {
     config.addLabel('set-js', 'Javascript')
     config.addLabel('set-node', 'Node.js')
     config.addLabel('set-py', 'Python')
+    config.addLabel('set-pyjp', 'Python Jupyter')
     config.addLabel('set-r', 'R')
     config.addLabel('set-sql', 'SQL')
 

--- a/src/article/CellComponent.js
+++ b/src/article/CellComponent.js
@@ -11,6 +11,7 @@ const LANG_LABELS = {
   'node': 'Node',
   'sql': 'SQL',
   'py': 'Py',
+  'pyjp': 'PyJp',
   'r': 'R',
 }
 

--- a/src/host/Host.js
+++ b/src/host/Host.js
@@ -441,7 +441,7 @@ export default class Host extends EventEmitter {
 
   _put(host, path, data) {
     const token = this._token(host)
-    return this._request('PUT', host + path, data, token)
+    return this._request('PUT', host + path, data || {}, token)
   }
 
   _delete(host, path) {

--- a/src/host/Host.js
+++ b/src/host/Host.js
@@ -385,13 +385,21 @@ export default class Host extends EventEmitter {
         'mini': 'MiniContext',
         'node': 'NodeContext',
         'py': 'PythonContext',
+        'pyjp': 'JupyterContext',
         'r': 'RContext',
         'sql': 'SqliteContext'
       }[language]
+
+      const options = {
+        'pyjp': {
+          language: 'python'
+        }
+      }[language] || {}
+
       if (!type) {
         return Promise.reject(new Error(`Unable to create an execution context for language ${language}`))
       } else {
-        const promise = this.create(type).then((result) => {
+        const promise = this.create(type, options).then((result) => {
           if (result instanceof Error) {
             // Unable to create so set the cached context promise to null
             // so a retry is performed next time this method is called

--- a/src/shared/analyseCode.js
+++ b/src/shared/analyseCode.js
@@ -48,7 +48,7 @@ Prism.languages.insertBefore('python', 'punctuation', {
   'key': { pattern: KEY, greedy: true },
   'id': { pattern: ID, greedy: true }
 })
-languages['python'] = languages['py'] = Prism.languages.python
+languages['python'] = languages['py'] = languages['pyjp'] = Prism.languages.python
 
 Prism.languages.insertBefore('javascript', 'punctuation', {
   'function': /[a-z0-9_]+(?=\()/i,

--- a/src/sheet/SheetPackage.js
+++ b/src/sheet/SheetPackage.js
@@ -136,14 +136,18 @@ export default {
     // Cell Languages
     config.addCommand('set-mini', SetLanguageCommand, { language: undefined, commandGroup: 'cell-languages' })
     config.addCommand('set-js', SetLanguageCommand, { language: 'js', commandGroup: 'cell-languages' })
+    config.addCommand('set-node', SetLanguageCommand, { language: 'node', commandGroup: 'cell-languages' })
     config.addCommand('set-py', SetLanguageCommand, { language: 'py', commandGroup: 'cell-languages' })
+    config.addCommand('set-pyjp', SetLanguageCommand, { language: 'pyjp', commandGroup: 'cell-languages' })
     config.addCommand('set-r', SetLanguageCommand, { language: 'r', commandGroup: 'cell-languages' })
     config.addCommand('set-sql', SetLanguageCommand, { language: 'sql', commandGroup: 'cell-languages' })
 
     config.addLabel('cell-languages', 'Choose Language')
     config.addLabel('set-mini', 'Mini')
     config.addLabel('set-js', 'Javascript')
+    config.addLabel('set-node', 'Node.js')
     config.addLabel('set-py', 'Python')
+    config.addLabel('set-pyjp', 'Python Jupyter')
     config.addLabel('set-r', 'R')
     config.addLabel('set-sql', 'SQL')
 


### PR DESCRIPTION
## Why?

So we can try using `JupyterContexts` in https://github.com/minrk/jupyter-dar ! See the related PR 
https://github.com/stencila/node/pull/42

## What?

- [x] Add the option to set a cell's language to "Python Jupyter" (in Sheets and Articles)
- [x] Host can handle a request to create a `JupyterContext` with options `{language: 'python'}`