### PR TITLE
Avoid invalid calls into Prism

### DIFF
--- a/src/shared/analyseCode.js
+++ b/src/shared/analyseCode.js
@@ -74,9 +74,13 @@ Prism.languages.insertBefore('sql', 'punctuation', {
 })
 languages['sql'] = Prism.languages.sql
 
-
-function tokenize(code, lang) {
-  let prismTokens = Prism.tokenize(code, languages[lang])
+function tokenize (code, lang) {
+  let grammar = languages[lang]
+  if (!grammar) {
+    console.error(`No tokenizer registered for language ${lang}`)
+    return []
+  }
+  let prismTokens = Prism.tokenize(code, grammar)
   let tokens = []
   let pos = 0
   for (let i = 0; i < prismTokens.length; i++) {

--- a/src/shared/analyseCode.js
+++ b/src/shared/analyseCode.js
@@ -96,7 +96,8 @@ function tokenize (code, lang) {
         tokens.push({
           type: t.type,
           text: t.content,
-          start, end
+          start,
+          end
         })
     }
     pos = end
@@ -105,13 +106,13 @@ function tokenize (code, lang) {
 }
 
 // pseudo-parsing to collect information about functions
-export default function analyzeCode(code, lang = 'mini') {
+export default function analyseCode (code, lang = 'mini') {
   let tokens = tokenize(code, lang)
   let symbols = extractSymbols(code)
   let nodes = []
   let calls = []
 
-  function _push(end) {
+  function _push (end) {
     let currentCall = calls[0]
     if (currentCall) {
       // tidy up


### PR DESCRIPTION
# Why?

We have seen some errors in the tokeniser used for syntax-highlighting. See https://github.com/stencila/desktop/issues/54 ( item 3. )

# What ?

This PR adds a guard  that checks that the tokenizer is actually available for a given language, before calling into Prism, and then fails gracefully by skipping the tokenization and displaying an error message on the console.
While the source of the error seems to be a wrong language identifier, which we need to investigate further, this still makes sense for sake of robustness.