### PR TITLE
Persisted state

### DIFF
--- a/src/StencilaWebApp.js
+++ b/src/StencilaWebApp.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import { WebAppChrome } from 'substance-texture'
 import StencilaArchive from './StencilaArchive'
 
@@ -31,6 +32,9 @@ export default class StencilaWebApp extends WebAppChrome {
   }
 
   _initArchive(archive, context) {
-    return _initStencilaArchive(archive, context)
+    // return _initStencilaArchive(archive, context)
+    // HACK: do not connect the archive with the engine right away
+    // we gonna do this when the user asks to switch to reproducible mode
+    return Promise.resolve(archive)
   }
 }

--- a/src/article/ArticleLoader.js
+++ b/src/article/ArticleLoader.js
@@ -1,6 +1,7 @@
 import { EditorSession } from 'substance'
 import { TextureConfigurator, JATSImporter } from 'substance-texture'
 import ArticleEditorPackage from './ArticleEditorPackage'
+import loadPersistedCellStates from './loadPersistedCellStates'
 
 export default {
   load(xml, context) {
@@ -21,6 +22,9 @@ export default {
     let importer = configurator.createImporter('texture-article')
     let doc = importer.importDocument(jats.dom)
     let editorSession = new EditorSession(doc, { configurator, context })
+    // EXPERIMENTAL: taking persisted cell outputs to initialize cell state
+    loadPersistedCellStates(doc)
+
     return editorSession
   }
 }

--- a/src/article/loadPersistedCellStates.js
+++ b/src/article/loadPersistedCellStates.js
@@ -1,0 +1,31 @@
+import { forEach, isNil } from 'substance'
+import { OK, UNKNOWN } from '../engine/CellStates'
+import CellState from '../engine/Cell'
+import { getLang, getSource } from '../shared/cellHelpers'
+
+export default function loadPersistedCellStates (doc) {
+  let cells = doc.getIndex('type').get('cell')
+  forEach(cells, cell => {
+    let output = cell.find('output')
+    let value
+    if (output) {
+      let json = output.textContent
+      if (json) {
+        value = JSON.parse(json)
+      }
+    }
+    cell.state = new PseudoCellState(doc, cell, value)
+  })
+}
+
+class PseudoCellState extends CellState {
+  constructor (doc, cell, value) {
+    super(doc, {
+      id: cell.id,
+      lang: getLang(cell),
+      source: getSource(cell),
+      value,
+      status: !isNil(value) ? OK : UNKNOWN
+    })
+  }
+}


### PR DESCRIPTION
- load cell states from persisted code cells
- disable starting the engine after loading the document
- show a confirm dialog and start engine when the user toggles 'Reproducible' the first time