### PR TITLE
Persist some cell state

### DIFF
--- a/src/StencilaArchive.js
+++ b/src/StencilaArchive.js
@@ -1,6 +1,7 @@
 import { prettyPrintXML } from 'substance'
-import { JATSExporter, TextureArchive } from 'substance-texture'
+import { TextureArchive } from 'substance-texture'
 import ArticleLoader from './article/ArticleLoader'
+import ArticleExporter from './article/ArticleExporter'
 import SheetLoader from './sheet/SheetLoader'
 
 export default class StencilaArchive extends TextureArchive {
@@ -66,19 +67,7 @@ export default class StencilaArchive extends TextureArchive {
   _exportDocument(type, session, sessions) {
     switch (type) {
       case 'article': {
-        // FIXME: hard-coded, and thus bad
-        // TODO: export only those resources which have been changed
-        // Also we need to
-        let jatsExporter = new JATSExporter()
-        let pubMetaDb = sessions['pub-meta'].getDocument()
-        let doc = session.getDocument()
-        let dom = doc.toXML()
-        let res = jatsExporter.export(dom, { pubMetaDb, doc })
-        console.info('saving jats', res.dom.getNativeElement())
-        // TODO: bring back pretty printing (currently messes up CDATA content)
-        let xmlStr = prettyPrintXML(res.dom)
-        //let xmlStr = res.dom.serialize()
-        return xmlStr
+        return ArticleExporter.export(session, { sessions })
       }
       case 'sheet': {
         let dom = session.getDocument().toXML()

--- a/src/article/ArticleExporter.js
+++ b/src/article/ArticleExporter.js
@@ -1,0 +1,23 @@
+import { prettyPrintXML } from 'substance'
+import { JATSExporter } from 'substance-texture'
+import persistCellStates from './persistCellStates'
+
+export default {
+  export (session, { sessions }) {
+    // FIXME: hard-coded, and thus bad
+    // TODO: export only those resources which have been changed
+    // Also we need to
+    let jatsExporter = new JATSExporter()
+    let pubMetaDb = sessions['pub-meta'].getDocument()
+    let doc = session.getDocument()
+    let dom = doc.toXML()
+
+    let res = jatsExporter.export(dom, { pubMetaDb, doc })
+    persistCellStates(doc, res.dom)
+
+    console.info('saving jats', res.dom.getNativeElement())
+    // TODO: bring back pretty printing (currently messes up CDATA content)
+    let xmlStr = prettyPrintXML(res.dom)
+    return xmlStr
+  }
+}

--- a/src/article/persistCellStates.js
+++ b/src/article/persistCellStates.js
@@ -1,0 +1,13 @@
+import { forEach } from 'substance'
+
+export default function persistCellStates (doc, dom) {
+  let cells = doc.getIndex('type').get('cell')
+  forEach(cells, cell => {
+    let el = dom.find(`#${cell.id}`)
+    let state = cell.state
+    // store the cell output
+    if (state.output) {
+      el.attr('output-name', state.output)
+    }
+  })
+}

--- a/src/shared/_connectDocumentToEngine.js
+++ b/src/shared/_connectDocumentToEngine.js
@@ -1,0 +1,29 @@
+import SheetAdapter from '../sheet/SheetAdapter'
+import ArticleAdapter from '../article/ArticleAdapter'
+
+// Connects documents with the Cell Engine
+// and registers hooks to update transclusions.
+export default function _connectDocumentToEngine (engine, archive, documentId) {
+  let manifest = archive.getEditorSession('manifest').getDocument()
+  let docEntry = manifest.get(documentId)
+  let editorSession = archive.getEditorSession(documentId)
+  let docType = docEntry.attr('type')
+  let name = docEntry.attr('name')
+  let docId = docEntry.id
+  let Adapter
+  switch (docType) {
+    case 'article': {
+      Adapter = ArticleAdapter
+      break
+    }
+    case 'sheet': {
+      Adapter = SheetAdapter
+      break
+    }
+    default:
+      //
+  }
+  if (Adapter) {
+    Adapter.connect(engine, editorSession, docId, name)
+  }
+}

--- a/src/shared/_initStencilaArchive.js
+++ b/src/shared/_initStencilaArchive.js
@@ -1,0 +1,53 @@
+import { forEach } from 'substance'
+import _connectDocumentToEngine from './_connectDocumentToEngine'
+
+export default function _initStencilaArchive (archive, context) {
+  const engine = context.host && context.host.engine
+  if (engine) {
+    // when a document is renamed, transclusions must be updated
+    _listenForDocumentRecordUpdates(archive, engine)
+    // documents and sheets must be registered with the engine
+    // and hooks for structural sheet updates must be established
+    // to update transclusions.
+    let entries = archive.getDocumentEntries()
+    forEach(entries, entry => {
+      _connectDocumentToEngine(engine, archive, entry.id)
+    })
+  }
+  return Promise.resolve(archive)
+}
+
+function _listenForDocumentRecordUpdates (archive, engine) {
+  let editorSession = archive.getEditorSession('manifest')
+  editorSession.on('update', _onManifestChange.bind(null, archive, engine), null, { resource: 'document' })
+}
+
+function _onManifestChange (archive, engine, change) {
+  let action = change.info.action
+  switch (action) {
+    case 'renameDocument': {
+      // extracting document id, old name and the new name
+      // TODO: maybe we can create an API to access such documentChange informations
+      let op = change.ops[0]
+      let docId = op.path[0]
+      let oldName = op.original
+      let newName = op.val
+      if (oldName !== newName) {
+        // TODO: it would be nice, if this could be done by the respective
+        // document/sheet adapter. However, ATM renaming is done on manifest only,
+        // so there is no document level notion of the name.
+        let resource = engine.getResource(docId)
+        resource.rename(newName)
+      }
+      break
+    }
+    case 'addDocument': {
+      let op = change.ops[0]
+      let docId = op.path[0]
+      _connectDocumentToEngine(engine, archive, docId)
+      break
+    }
+    default:
+      //
+  }
+}

--- a/src/stencilaAppHelpers.js
+++ b/src/stencilaAppHelpers.js
@@ -1,11 +1,8 @@
-import { forEach } from 'substance'
 import { JATSImportDialog } from 'substance-texture'
 import Project from './project/Project'
 import setupStencilaContext from './util/setupStencilaContext'
-import SheetAdapter from './sheet/SheetAdapter'
-import ArticleAdapter from './article/ArticleAdapter'
 
-export function _renderStencilaApp($$, app) {
+export function _renderStencilaApp ($$, app) {
   let el = $$('div').addClass('sc-app')
   let { archive, error } = app.state
   if (archive) {
@@ -31,89 +28,14 @@ export function _renderStencilaApp($$, app) {
   return el
 }
 
-export function _setupStencilaChildContext(originalContext) {
+export function _setupStencilaChildContext (originalContext) {
   const context = setupStencilaContext()
   return Object.assign({}, originalContext, context)
 }
 
-export function _initStencilaContext(context) {
+export function _initStencilaContext (context) {
   return context.host.initialize()
 }
 
-export function _initStencilaArchive(archive, context) {
-  const engine = context.host && context.host.engine
-  if (engine) {
-    // when a document is renamed, transclusions must be updated
-    _listenForDocumentRecordUpdates(archive, engine)
-    // documents and sheets must be registered with the engine
-    // and hooks for structural sheet updates must be established
-    // to update transclusions.
-    let entries = archive.getDocumentEntries()
-    forEach(entries, entry => {
-      _connectDocumentToEngine(engine, archive, entry.id)
-    })
-  }
-  return Promise.resolve(archive)
-}
-
-// Connects documents with the Cell Engine
-// and registers hooks to update transclusions.
-export function _connectDocumentToEngine(engine, archive, documentId) {
-  let manifest = archive.getEditorSession('manifest').getDocument()
-  let docEntry = manifest.get(documentId)
-  let editorSession = archive.getEditorSession(documentId)
-  let docType = docEntry.attr('type')
-  let name = docEntry.attr('name')
-  let docId = docEntry.id
-  let Adapter
-  switch (docType) {
-    case 'article': {
-      Adapter = ArticleAdapter
-      break
-    }
-    case 'sheet': {
-      Adapter = SheetAdapter
-      break
-    }
-    default:
-      //
-  }
-  if (Adapter) {
-    Adapter.connect(engine, editorSession, docId, name)
-  }
-}
-
-function _listenForDocumentRecordUpdates(archive, engine) {
-  let editorSession = archive.getEditorSession('manifest')
-  editorSession.on('update', _onManifestChange.bind(null, archive, engine), null, { resource: 'document' })
-}
-
-function _onManifestChange(archive, engine, change) {
-  let action = change.info.action
-  switch(action) {
-    case 'renameDocument': {
-      // extracting document id, old name and the new name
-      // TODO: maybe we can create an API to access such documentChange informations
-      let op = change.ops[0]
-      let docId = op.path[0]
-      let oldName = op.original
-      let newName = op.val
-      if (oldName !== newName) {
-        // TODO: it would be nice, if this could be done by the respective
-        // document/sheet adapter. However, ATM renaming is done on manifest only,
-        // so there is no document level notion of the name.
-        let resource = engine.getResource(docId)
-        resource.rename(newName)
-      }
-      break
-    }
-    case 'addDocument': {
-      let op = change.ops[0]
-      let docId = op.path[0]
-      _connectDocumentToEngine(engine, archive, docId)
-      break
-    }
-    default:
-      //
-  }
-}
+export { default as _initStencilaArchive } from './shared/_initStencilaArchive'
+export { default as _connectDocumentToEngine } from './shared/_connectDocumentToEngine'


### PR DESCRIPTION
# Why?

For the RDS prototype we need to be able to render cells 'statically' without running the engine.
For that we need to store a little more data from the cell state.

# What?

For the moment, this is only the output name of a cell. The output value itself is already persisted.

