### PR TITLE
feat(Telemetry): Add telemetry module

### DIFF
--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -322,6 +322,29 @@ export interface Config {
     }
   }
   /**
+   * Configuration settings for telemetry
+   */
+  telemetry?: {
+    /**
+     * Telemetry settings for Stencila CLI
+     */
+    cli?: {
+      /**
+       * Whether to send error reports to Sentry. Default is false.
+       */
+      sentry?: boolean
+    }
+    /**
+     * Telemetry settings for Stencila Desktop
+     */
+    desktop?: {
+      /**
+       * Whether to send error reports to Sentry. Default is false.
+       */
+      sentry?: boolean
+    }
+  }
+  /**
    * Configuration settings for running as a server
    */
   serve?: {
@@ -398,6 +421,10 @@ export type Error =
   | {
       type: 'PluginNotInstalled'
       plugin: string
+    }
+  | {
+      type: 'Unknown'
+      [k: string]: unknown
     }
 /**
  * An enumeration of all methods

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{logging, plugins, projects, serve, upgrade, utils::schemas};
+use crate::{logging, plugins, projects, serve, telemetry, upgrade, utils::schemas};
 use eyre::{bail, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -17,6 +17,9 @@ pub struct Config {
 
     #[validate]
     pub logging: logging::config::LoggingConfig,
+
+    #[validate]
+    pub telemetry: telemetry::config::TelemetryConfig,
 
     #[validate]
     pub serve: serve::config::ServeConfig,

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use crate::{methods::Method, utils::schemas};
+use crate::methods::Method;
 use eyre::Result;
-use schemars::{gen::SchemaSettings, schema_for, JsonSchema};
+use schemars::{gen::SchemaSettings, JsonSchema};
 use serde::Serialize;
 use thiserror::Error;
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -60,11 +60,12 @@ pub mod jwt;
 #[cfg(any(feature = "request", feature = "serve"))]
 pub mod rpc;
 
-// Internal messaging
+// Internal messaging etc
 
 pub mod errors;
 pub mod logging;
 pub mod pubsub;
+pub mod telemetry;
 
 // Utilities
 //

--- a/rust/src/telemetry.rs
+++ b/rust/src/telemetry.rs
@@ -1,0 +1,44 @@
+///! A module for functions and configuration related to telemetry.
+///!
+///! Currently this module just has Sentry related settings but
+///! in the future may also include functionality around OpenTelemetry
+///! or similar for monitoring of worker processes.
+
+#[cfg(feature = "config")]
+pub mod config {
+    use defaults::Defaults;
+    use schemars::JsonSchema;
+    use serde::{Deserialize, Serialize};
+    use validator::Validate;
+
+    /// Telemetry settings for Stencila CLI
+    #[derive(Debug, Defaults, PartialEq, Clone, JsonSchema, Deserialize, Serialize, Validate)]
+    #[serde(default)]
+    #[schemars(deny_unknown_fields)]
+    pub struct TelemetryCLIConfig {
+        /// Whether to send error reports to Sentry. Default is false.
+        #[def = "false"]
+        pub sentry: bool,
+    }
+
+    /// Telemetry settings for Stencila Desktop
+    #[derive(Debug, Defaults, PartialEq, Clone, JsonSchema, Deserialize, Serialize, Validate)]
+    #[serde(default)]
+    #[schemars(deny_unknown_fields)]
+    pub struct TelemetryDesktopConfig {
+        /// Whether to send error reports to Sentry. Default is false.
+        #[def = "false"]
+        pub sentry: bool,
+    }
+
+    /// Telemetry
+    ///
+    /// Configuration settings for telemetry
+    #[derive(Debug, Default, PartialEq, Clone, JsonSchema, Deserialize, Serialize, Validate)]
+    #[serde(default)]
+    #[schemars(deny_unknown_fields)]
+    pub struct TelemetryConfig {
+        pub cli: TelemetryCLIConfig,
+        pub desktop: TelemetryDesktopConfig,
+    }
+}


### PR DESCRIPTION
This adds a `telemetry` module. Initially all this does is define some configuration settings for CLI and Desktop  (analogous to those in `logging`). In the future we may add functionality and configuration for reporting other metric e.g. from Stencila workers inside Docker containers.