### PR TITLE
Binaries module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "bzip2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1645,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -3226,6 +3258,7 @@ dependencies = [
  "dirs-next",
  "enum_dispatch",
  "eyre",
+ "flate2",
  "futures",
  "gitignore",
  "glob",
@@ -3265,6 +3298,8 @@ dependencies = [
  "structopt",
  "strum",
  "strum_macros",
+ "tar",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.14.0",
@@ -3277,6 +3312,9 @@ dependencies = [
  "url",
  "validator",
  "warp",
+ "which",
+ "xz2",
+ "zip",
 ]
 
 [[package]]
@@ -4178,6 +4216,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+dependencies = [
+ "either",
+ "libc",
+]
+
+[[package]]
 name = "widestring"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4309,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
 
 [[package]]
+name = "xz2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
 dependencies = [
  "byteorder",
+ "bzip2",
  "crc32fast",
  "flate2",
  "thiserror",

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashMap, path::PathBuf};
 use stencila::{
+    binaries,
     cli::display,
     config, documents,
     eyre::{bail, Error, Result},
@@ -86,6 +87,8 @@ pub enum Command {
     Documents(documents::cli::Command),
     #[structopt(aliases = &["plugin"])]
     Plugins(plugins::cli::Command),
+    #[structopt(aliases = &["binary"])]
+    Binaries(binaries::cli::Command),
     Config(config::cli::Command),
     Upgrade(upgrade::cli::Args),
     Serve(serve::cli::Command),
@@ -115,6 +118,7 @@ pub async fn run_command(
         Command::Documents(command) => command.run(documents).await,
         Command::Projects(command) => command.run(projects).await,
         Command::Plugins(command) => plugins::cli::run(command).await,
+        Command::Binaries(command) => command.run().await,
         Command::Config(command) => config::cli::run(command).await,
         Command::Upgrade(command) => upgrade::cli::run(command).await,
         Command::Serve(command) => command.run(documents).await,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,6 +28,8 @@ request-docker = ["bollard"]
 request-http = ["reqwest", "jsonwebtoken"]
 request-ws = ["tokio-tungstenite", "jsonwebtoken"]
 
+binaries = ["flate2", "tar", "which", "xz2", "zip"]
+
 plugins = ["jsonschema", "semver"]
 plugins-docker = ["plugins", "bollard"]
 plugins-binary = ["plugins", "self_update"]
@@ -71,6 +73,7 @@ default = [
     "request-http",
     "request-stdio",
     "request-ws",
+    "binaries",
     "plugins",
     "plugins-binary",
     "plugins-docker",
@@ -107,6 +110,7 @@ defaults = "=0.2.0"
 dirs-next = "=2.0.0"
 enum_dispatch = "=0.3.7"
 eyre = "=0.6.5"
+flate2 = { version = "=1.0.20", optional = true }
 futures = "=0.3.15"
 gitignore = "=1.0.7"
 glob = "=0.3.0"
@@ -148,6 +152,8 @@ stencila-schema = "=1.9.0"
 structopt = { version = "=0.3.21", optional = true }
 strum = { version = "=0.21", features = ["derive"] }
 strum_macros = "=0.21.1"
+tar = { version = "=0.4.35", optional = true }
+tempfile = "3.2.0"
 thiserror = "=1.0.25"
 tokio = { version = "=1.7.1", features = ["full"] }
 tokio-tungstenite = { version = "=0.14.0", optional = true }
@@ -160,6 +166,9 @@ tracing-subscriber = "=0.2.19"
 url = "=2.2.2"
 validator = { version = "=0.13.0", features = ["derive"], optional = true }
 warp = { version = "=0.3.1", optional = true }
+which = { version = "=4.1.0", optional = true }
+xz2 = { version = "=0.1.6", optional = true }
+zip = { version = "=0.5.13", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.7.1", features = ["glob"] }

--- a/rust/src/binaries.rs
+++ b/rust/src/binaries.rs
@@ -517,8 +517,7 @@ impl Binary {
         for file in files {
             let path = dir.join(file);
             if path.exists() {
-                use std::os::unix::fs::PermissionsExt;
-                fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+                crate::utils::fs::set_perms(path, 0o755)?;
             }
         }
         Ok(())

--- a/rust/src/binaries.rs
+++ b/rust/src/binaries.rs
@@ -1,0 +1,781 @@
+use defaults::Defaults;
+use eyre::{bail, Result};
+use itertools::Itertools;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Serialize;
+use std::{
+    collections::HashMap,
+    env::{
+        self,
+        consts::{ARCH, OS},
+    },
+    fs, io,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    str::FromStr,
+};
+use tokio::sync::{Mutex, MutexGuard};
+
+///! A module for locating, running and installing third party binaries.
+///!
+///! Binaries may be used as runtimes for plugins (e.g. Node.js, Python) or
+///! are used directly by the `methods` module (e.g Pandoc).
+///!
+///! This modules defines the `Binary` struct that can be used to define a
+///! binary (e.g. how to determine the current version, how to download
+///! a desired version) and functions for resolving, installing and executing
+///! those binaries.
+
+/// Get the directory where binaries are stored
+pub fn binaries_dir() -> PathBuf {
+    let user_data_dir = dirs_next::data_dir().unwrap_or_else(|| env::current_dir().unwrap());
+    match env::consts::OS {
+        "macos" | "windows" => user_data_dir.join("Stencila").join("Binaries"),
+        _ => user_data_dir.join("stencila").join("binaries"),
+    }
+}
+
+#[derive(Defaults, Serialize)]
+struct Binary {
+    /// The name of the binary
+    name: String,
+
+    /// Any aliases used to search for the binary
+    aliases: Vec<String>,
+
+    /// Installations of the binary found locally
+    installs: Vec<BinaryInstalls>,
+
+    /// Versions of the binary that this module supports
+    /// installation of.
+    ///
+    /// Used to select a version to install based on semver
+    /// requirements.
+    versions: Vec<String>,
+
+    /// The arguments used to
+    #[serde(skip)]
+    #[def = r#"vec!["--version".to_string()]"#]
+    version_args: Vec<String>,
+
+    #[serde(skip)]
+    #[def = r#"Regex::new("\\d+.\\d+(.\\d+)?").unwrap()"#]
+    version_regex: Regex,
+}
+
+#[derive(Clone, Serialize)]
+struct BinaryInstalls {
+    /// The path the binary is installed to
+    path: PathBuf,
+
+    /// The version of the binary at the path
+    version: Option<String>,
+}
+
+impl Binary {
+    pub fn new(name: &str, aliases: &[&str], versions: &[&str]) -> Binary {
+        Binary {
+            name: name.to_string(),
+            aliases: aliases
+                .iter()
+                .map(|s| String::from_str(s).unwrap())
+                .collect(),
+            versions: versions
+                .iter()
+                .map(|s| String::from_str(s).unwrap())
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    /// Get the directory where versions of a binary are installed
+    pub fn dir(&self, version: Option<String>, ensure: bool) -> Result<PathBuf> {
+        let dir = binaries_dir().join(&self.name);
+        let dir = if let Some(version) = version {
+            dir.join(version)
+        } else {
+            dir
+        };
+
+        if ensure {
+            fs::create_dir_all(&dir)?
+        }
+
+        Ok(dir)
+    }
+
+    /// Resolve the path and version of a binary
+    pub fn resolve(&mut self) {
+        // Collect the directories for previously installed versions
+        let mut dirs: Vec<PathBuf> = Vec::new();
+        if let Ok(dir) = self.dir(None, false) {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries {
+                    if let Ok(entry) = entry {
+                        let path = entry.path();
+                        if path.is_dir() {
+                            // Search for binary in top level (Windows)
+                            dirs.push(path.clone());
+                            // Search for binary in `bin` (MacOS & Linux convention)
+                            dirs.push(path.join("bin"))
+                        }
+                    }
+                }
+            }
+        }
+        tracing::debug!("Found existing dirs {:?}", dirs);
+
+        // Add the system PATH env var
+        if let Some(path) = env::var_os("PATH") {
+            tracing::debug!("Found PATH {:?}", path);
+            let mut paths = env::split_paths(&path).collect();
+            dirs.append(&mut paths);
+        }
+
+        // Join together in a PATH style string
+        let dirs = if !dirs.is_empty() {
+            match env::join_paths(dirs) {
+                Ok(joined) => Some(joined),
+                Err(error) => {
+                    tracing::warn!("While joining paths: {}", error);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        // Search for executables with name or one of aliases
+        tracing::debug!("Searching for executables in {:?}", dirs);
+        let names = [vec![self.name.clone()], self.aliases.clone()].concat();
+        let paths = names
+            .iter()
+            .map(|name| {
+                match which::which_in_all(name, dirs.clone(), std::env::current_dir().unwrap()) {
+                    Ok(paths) => paths.collect(),
+                    Err(error) => {
+                        tracing::warn!(
+                            "While searching for executables for {}: {}",
+                            self.name,
+                            error
+                        );
+                        Vec::new()
+                    }
+                }
+            })
+            .flatten();
+
+        // Get version of each executable found
+        tracing::debug!("Getting versions for paths {:?}", paths);
+        self.installs = paths
+            .map(|path| BinaryInstalls {
+                path: path.clone(),
+                version: self.version(&path),
+            })
+            .collect();
+    }
+
+    /// Run a command on the
+    ///
+    /// Returns the output of the command
+    pub async fn run(
+        &mut self,
+        semver: Option<String>,
+        args: &[String],
+        install: bool,
+    ) -> Result<Output> {
+        let path = if let Some(path) = self.installed(semver.clone())? {
+            path
+        } else if install {
+            self.install(semver.clone(), None, None).await?;
+            self.installed(semver)?.expect("That is is now installed")
+        } else {
+            bail!("Not suitable install of '{}' found", self.name)
+        };
+        self.exec(&path, args)
+    }
+
+    /// Execute the binary at the path
+    ///
+    /// Returns the output of the command
+    pub fn exec(&self, path: &Path, args: &[String]) -> Result<Output> {
+        Ok(Command::new(path).args(args).output()?)
+    }
+
+    /// Get the version of the binary at the path
+    ///
+    /// Parses the output of the command and adds a `0` pathc semver part if
+    /// necessary.
+    pub fn version(&self, path: &Path) -> Option<String> {
+        if let Ok(output) = self.exec(&path, &self.version_args) {
+            let stdout = std::str::from_utf8(&output.stdout).unwrap_or("");
+            if let Some(version) = self.version_regex.captures(stdout).map(|captures| {
+                let mut parts: Vec<&str> = captures[0].split('.').collect();
+                while parts.len() < 3 {
+                    parts.push("0")
+                }
+                parts.join(".")
+            }) {
+                return Some(version);
+            }
+        }
+        None
+    }
+
+    /// Are any versions installed that match the semver requirement (if specified)
+    pub fn installed(&self, semver: Option<String>) -> Result<Option<PathBuf>> {
+        if let Some(semver) = semver {
+            let semver = semver::VersionReq::parse(&semver)?;
+            for install in &self.installs {
+                if let Some(version) = &install.version {
+                    let version = semver::Version::parse(&version)?;
+                    if semver.matches(&version) {
+                        return Ok(Some(install.path.clone()));
+                    }
+                }
+            }
+            Ok(None)
+        } else if let Some(install) = self.installs.first() {
+            Ok(Some(install.path.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Install the most recent version of the binary (meeting optional semver, OS,
+    /// and arch requirements).
+    pub async fn install(
+        &mut self,
+        semver: Option<String>,
+        os: Option<String>,
+        arch: Option<String>,
+    ) -> Result<()> {
+        let semver = if let Some(semver) = semver {
+            semver
+        } else {
+            self.versions
+                .first()
+                .expect("Always at least one version")
+                .clone()
+        };
+        let semver = semver::VersionReq::parse(&semver)?;
+
+        if let Some(version) = self.versions.iter().find_map(|version| {
+            match semver
+                .matches(&semver::Version::parse(&version).expect("Version to always be valid"))
+            {
+                true => Some(version),
+                false => None,
+            }
+        }) {
+            self.install_version(version, os, arch).await?;
+        } else {
+            bail!(
+                "No known version of '{}' which meets semantic version requirement '{}'",
+                self.name,
+                semver
+            )
+        }
+
+        // Always re-resolve after an install
+        self.resolve();
+
+        Ok(())
+    }
+
+    /// Install a specific version of the binary
+    pub async fn install_version(
+        &self,
+        version: &str,
+        os: Option<String>,
+        arch: Option<String>,
+    ) -> Result<()> {
+        let os = os.unwrap_or_else(|| OS.to_string());
+        let arch = arch.unwrap_or_else(|| ARCH.to_string());
+        match self.name.as_ref() {
+            "chrome" => self.install_chrome(version, &os, &arch).await,
+            "node" => self.install_node(version, &os, &arch).await,
+            "pandoc" => self.install_pandoc(version, &os, &arch).await,
+            _ => bail!("Install not implemented for binary '{}'", self.name),
+        }
+    }
+
+    /// Install Chrome
+    async fn install_chrome(&self, version: &str, os: &str, _arch: &str) -> Result<()> {
+        // Chrome uses a peculiar version system with the build number
+        // at the third position and not every build for every OS. So, use minor versio
+        // for mapping
+        let minor_version = version.split('.').take(2).join(".");
+        // Map the minor_version to a "position" number which can be obtained from
+        // https://vikyd.github.io/download-chromium-history-version
+        let suffix = match minor_version.as_ref() {
+            "91.0" => match os {
+                "macos" => "Mac/869727/chrome-mac.zip",
+                "windows" => "Win_x64/867878/chrome-win.zip",
+                "linux" => "Linux_x64/860960/chrome-linux.zip",
+                _ => bail!("Unmapped OS '{}'", os),
+            },
+            _ => bail!("Unmapped version number '{}'", version),
+        };
+
+        let url = format!(
+            "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/{suffix}?alt=media",
+            suffix = suffix.replace("/", "%2F")
+        );
+
+        let archive = self.download(&url).await?;
+        let dest = self.dir(Some(version.into()), true)?;
+        self.extract(&archive, 1, &self.dir(Some(version.into()), true)?)?;
+        self.executable(&dest, &["chrome", "chrome.exe"])?;
+
+        Ok(())
+    }
+
+    /// Install Node.js
+    async fn install_node(&self, version: &str, os: &str, arch: &str) -> Result<()> {
+        let url = format!(
+            "https://nodejs.org/dist/v{version}/node-v{version}-",
+            version = version
+        ) + match os {
+            "macos" => match arch {
+                "arm" => "darwin-arm64.tar.gz",
+                _ => "darwin-x64.tar.gz",
+            },
+            "windows" => match arch {
+                "x86" => "win-x86.zip",
+                _ => "win-x64.zip",
+            },
+            "linux" => match arch {
+                "arm" => "linux-arm64.tar.xz",
+                _ => "linux-x64.tar.xz",
+            },
+            _ => bail!("Unable to determine Node download URL"),
+        };
+
+        let archive = self.download(&url).await?;
+        let dest = self.dir(Some(version.into()), true)?;
+        self.extract(&archive, 1, &dest)?;
+        self.executable(&dest, &["bin/node", "bin/npm", "node.exe", "npm"])?;
+
+        Ok(())
+    }
+
+    /// Install Pandoc
+    async fn install_pandoc(&self, version: &str, os: &str, arch: &str) -> Result<()> {
+        // Map standard semver triples to Pandoc's version numbers
+        // See https://github.com/jgm/pandoc/releases
+        let version = match version {
+            "2.14.0" => "2.14.0.3",
+            _ => version,
+        };
+
+        let url = format!(
+            "https://github.com/jgm/pandoc/releases/download/{version}/pandoc-{version}-",
+            version = version
+        ) + match os {
+            "macos" => "macOS.zip",
+            "windows" => "windows-x86_64.zip",
+            "linux" => match arch {
+                "arm" => "linux-arm64.tar.gz",
+                _ => "linux-amd64.tar.gz",
+            },
+            _ => bail!("Unable to determine Pandoc download URL"),
+        };
+
+        let archive = self.download(&url).await?;
+        let dest = self.dir(Some(version.into()), true)?;
+        self.extract(&archive, 1, &dest)?;
+        self.executable(&dest, &["bin/pandoc", "pandoc.exe"])?;
+
+        Ok(())
+    }
+
+    /// Download a URL (usually an archive) to a temporary, but optionally cached, file
+    async fn download(&self, url: &str) -> Result<PathBuf> {
+        let url_parsed = url::Url::parse(&url)?;
+        let filename = url_parsed
+            .path_segments()
+            .expect("No segments in URL")
+            .last()
+            .expect("No file in URL");
+        let path = binaries_dir().join("downloads").join(filename);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?
+        }
+
+        // Reuse downloaded files, only use this during development
+        // and testing to avoid multiple downloads
+        #[cfg(ignore)]
+        if path.exists() {
+            return Ok(path);
+        }
+
+        tracing::info!("📥 Downloading {} to {}", url, path.display());
+        let response = reqwest::get(url).await?.error_for_status()?;
+        let bytes = response.bytes().await?;
+        let mut file = fs::File::create(&path)?;
+        io::copy(&mut bytes.as_ref(), &mut file)?;
+
+        Ok(path)
+    }
+
+    /// Extract an archive to a destination
+    fn extract(&self, path: &Path, strip: usize, dest: &Path) -> Result<()> {
+        tracing::info!("🔓 Extracting {} to {}", path.display(), dest.display());
+
+        let ext = path
+            .extension()
+            .expect("Always has an extension")
+            .to_str()
+            .expect("Always convertible to str");
+
+        match ext {
+            "zip" => self.extract_zip(path, strip, dest),
+            _ => self.extract_tar(ext, path, strip, dest),
+        }
+    }
+
+    /// Extract a tar archive
+    fn extract_tar(&self, ext: &str, file: &Path, strip: usize, dest: &Path) -> Result<()> {
+        let file = fs::File::open(&file)?;
+        let mut archive = tar::Archive::new(match ext {
+            "tar" => Box::new(file) as Box<dyn io::Read>,
+            "gz" | "tgz" => Box::new(flate2::read::GzDecoder::new(file)),
+            "xz" => Box::new(xz2::read::XzDecoder::new(file)),
+            _ => bail!("Unhandled archive extension {}", ext),
+        });
+
+        let extracted = archive
+            .entries()?
+            .filter_map(|entry| entry.ok())
+            .map(|mut entry| -> Result<()> {
+                let mut path = entry.path()?.display().to_string();
+                if strip > 0 {
+                    let mut components: Vec<String> = path.split('/').map(String::from).collect();
+                    components.drain(0..strip);
+                    path = components.join("/")
+                }
+
+                let out_path = dest.join(&path);
+                entry.unpack(&out_path).expect("Unable to unpack");
+
+                Ok(())
+            })
+            .filter_map(|result| result.ok())
+            .collect::<Vec<()>>();
+
+        tracing::debug!("Extracted {} entries", extracted.len());
+        Ok(())
+    }
+
+    /// Extract a zip archive
+    fn extract_zip(&self, file: &Path, strip: usize, dest: &Path) -> Result<()> {
+        let file = fs::File::open(&file)?;
+        let mut archive = zip::ZipArchive::new(file)?;
+
+        let mut count = 0;
+        for index in 0..archive.len() {
+            let mut entry = archive.by_index(index)?;
+            let mut path = entry
+                .enclosed_name()
+                .expect("Always has an enclosed name")
+                .display()
+                .to_string();
+
+            if strip > 0 {
+                let mut components: Vec<String> = path.split('/').map(String::from).collect();
+                components.drain(0..strip);
+                path = components.join("/")
+            }
+
+            let out_path = dest.join(&path);
+            if let Some(parent) = out_path.parent() {
+                if let Err(error) = fs::create_dir_all(parent) {
+                    if error.kind() != io::ErrorKind::AlreadyExists {
+                        bail!(error)
+                    }
+                }
+            }
+
+            if entry.is_file() {
+                let mut out_file = fs::File::create(out_path)?;
+                std::io::copy(&mut entry, &mut out_file)?;
+                count += 1;
+            }
+        }
+
+        tracing::debug!("Extracted {} entries", count);
+        Ok(())
+    }
+
+    /// Make extracted files executable (if they exists)
+    ///
+    /// While tar archives retain permissions, zip archives do not,
+    /// so we need to make sure to do this.
+    fn executable(&self, dir: &Path, files: &[&str]) -> Result<()> {
+        for file in files {
+            let path = dir.join(file);
+            if path.exists() {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+type Binaries = HashMap<String, Binary>;
+
+static BINARIES: Lazy<Mutex<Binaries>> = Lazy::new(|| {
+    // Note: versions should be valid semver triples and listed in descending order!
+    // The first version meeting semver requirements will be installed is necessary
+    let binaries = vec![
+        // Version history at https://en.wikipedia.org/wiki/Google_Chrome_version_history
+        // but only use triples ending in `.0` here and make sure there is a mapping in the
+        // `install_chromium` function.
+        Binary::new("chrome", &["chromium"], &["91.0.0"]),
+        // Release list at https://nodejs.org/en/download/releases/
+        Binary::new("node", &[], &["16.4.1"]),
+        // Release list at https://github.com/jgm/pandoc/releases
+        // To avoid version parsing issues we map standard semver triples
+        // to Pandoc's quads in the `install_pandoc` function and use only triples here.
+        Binary::new("pandoc", &[], &["2.14.0"]),
+    ]
+    .into_iter()
+    .map(|binary| (binary.name.clone(), binary))
+    .collect();
+
+    Mutex::new(binaries)
+});
+
+/// Lock the global binaries store
+async fn lock() -> MutexGuard<'static, Binaries> {
+    BINARIES.lock().await
+}
+
+#[cfg(feature = "cli")]
+pub mod cli {
+    use super::*;
+    use crate::cli::display;
+    use structopt::StructOpt;
+
+    #[derive(Debug, StructOpt)]
+    #[structopt(
+        about = "Manage helper binaries",
+        setting = structopt::clap::AppSettings::ColoredHelp,
+        setting = structopt::clap::AppSettings::VersionlessSubcommands
+    )]
+    pub struct Command {
+        #[structopt(subcommand)]
+        pub action: Action,
+    }
+
+    #[derive(Debug, StructOpt)]
+    #[structopt(
+        setting = structopt::clap::AppSettings::DeriveDisplayOrder
+    )]
+    pub enum Action {
+        List(List),
+        Show(Show),
+        Install(Install),
+        Run(Run),
+    }
+
+    impl Command {
+        pub async fn run(self) -> display::Result {
+            let Self { action } = self;
+            match action {
+                Action::List(action) => action.run().await,
+                Action::Show(action) => action.run().await,
+                Action::Install(action) => action.run().await,
+                Action::Run(action) => action.run().await,
+            }
+        }
+    }
+
+    /// List binaries and their supported versions
+    ///
+    /// The returned list is a list of the binaries/versions
+    /// that Stencila knows how to install and use.
+    #[derive(Debug, StructOpt)]
+    #[structopt(
+        setting = structopt::clap::AppSettings::DeriveDisplayOrder,
+        setting = structopt::clap::AppSettings::ColoredHelp
+    )]
+    pub struct List {}
+
+    impl List {
+        pub async fn run(self) -> display::Result {
+            let binaries = &*lock().await;
+            let list: Vec<serde_json::Value> = binaries
+                .values()
+                .map(|binary| {
+                    serde_json::json!({
+                        "name": binary.name.clone(),
+                        "versions": binary.versions.clone()
+                    })
+                })
+                .collect();
+            display::value(list)
+        }
+    }
+
+    /// Show information on a particular binary
+    ///
+    /// Searches for the binary on your path and in Stencila's "binaries"
+    /// folder for versions that are installed. Use the `semver` argument
+    /// if you only want a result if the semantic version requirement is met.
+    ///
+    /// This command will work for binaries that are not registered as
+    /// "known" by Stencila (i.e. those not in `stencila binaries list`).
+    #[derive(Debug, StructOpt)]
+    #[structopt(
+        setting = structopt::clap::AppSettings::DeriveDisplayOrder,
+        setting = structopt::clap::AppSettings::ColoredHelp
+    )]
+    pub struct Show {
+        /// The name of the binary e.g. pandoc
+        name: String,
+
+        /// The semantic version requirement for the binary e.g. >2
+        ///
+        /// If this is supplied and the binary does not meet the semver
+        /// requirement nothing will be shown
+        semver: Option<String>,
+    }
+
+    impl Show {
+        pub async fn run(self) -> display::Result {
+            let Self { name, semver } = self;
+
+            let binaries = &mut *lock().await;
+
+            let binary = if let Some(binary) = binaries.get_mut(&name) {
+                binary.resolve();
+                Binary {
+                    name: binary.name.clone(),
+                    aliases: binary.aliases.clone(),
+                    installs: binary.installs.clone(),
+                    versions: binary.versions.clone(),
+                    ..Default::default()
+                }
+            } else {
+                let mut binary = Binary {
+                    name,
+                    ..Default::default()
+                };
+                binary.resolve();
+                binary
+            };
+
+            if binary.installed(semver)?.is_some() {
+                display::value(binary)
+            } else {
+                tracing::info!(
+                    "No matching binary found. Perhaps try `stencila binaries install`."
+                );
+                display::nothing()
+            }
+        }
+    }
+
+    /// Install a binary
+    ///
+    /// This will install the latest version of the binary that meets any
+    /// semantic version requirement supplied in the Stencila "binaries" folder.
+    #[derive(Debug, StructOpt)]
+    #[structopt(
+        setting = structopt::clap::AppSettings::DeriveDisplayOrder,
+        setting = structopt::clap::AppSettings::ColoredHelp
+    )]
+    pub struct Install {
+        /// The name of the binary (must be a registered binary name)
+        name: String,
+
+        /// The semantic version requirement (the most recent matching version will be installed)
+        semver: Option<String>,
+
+        /// The operating system to install for (defaults to the current)
+        #[structopt(short, long, possible_values = &OS_VALUES )]
+        os: Option<String>,
+
+        /// The architecture to install for (defaults to the current)
+        #[structopt(short, long, possible_values = &ARCH_VALUES)]
+        arch: Option<String>,
+    }
+
+    const OS_VALUES: [&str; 3] = ["macos", "windows", "linux"];
+    const ARCH_VALUES: [&str; 3] = ["x86", "x86_64", "arm"];
+
+    impl Install {
+        pub async fn run(self) -> display::Result {
+            let Self {
+                name,
+                semver,
+                os,
+                arch,
+            } = self;
+
+            if let Some(binary) = lock().await.get_mut(&name) {
+                binary.install(semver, os, arch).await?;
+                tracing::info!("📦 Installed {}", name);
+            } else {
+                tracing::info!("No registered binary with that name. See `stencila binaries list`.")
+            }
+
+            display::nothing()
+        }
+    }
+
+    /// Run a command using a binary
+    ///
+    /// Pass arguments and options to the binary after the `--` flag.
+    ///
+    /// Only works with binaries that are registered with Stencila.
+    #[derive(Debug, StructOpt)]
+    #[structopt(
+        setting = structopt::clap::AppSettings::DeriveDisplayOrder,
+        setting = structopt::clap::AppSettings::ColoredHelp
+    )]
+    pub struct Run {
+        /// The name of the binary e.g. node
+        name: String,
+
+        /// The semantic version requirement e.g. 16
+        semver: Option<String>,
+
+        /// Whether Stencila should automatically install the binary
+        /// if it is not yet available
+        #[structopt(long)]
+        install: bool,
+
+        /// The arguments and options to pass to the binary
+        #[structopt(raw(true))]
+        args: Vec<String>,
+    }
+
+    impl Run {
+        pub async fn run(self) -> display::Result {
+            let Self {
+                name,
+                semver,
+                install,
+                args,
+            } = self;
+
+            let output = if let Some(binary) = lock().await.get_mut(&name) {
+                binary.resolve();
+                binary.run(semver, &args, install).await?
+            } else {
+                bail!("Not a known binary")
+            };
+
+            use std::io::Write;
+            std::io::stdout().write_all(output.stdout.as_ref())?;
+            std::io::stderr().write_all(output.stderr.as_ref())?;
+
+            display::nothing()
+        }
+    }
+}

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -2,7 +2,7 @@ use crate::logging::config::LoggingConfig;
 use crate::plugins::config::PluginsConfig;
 use crate::serve::config::ServeConfig;
 use crate::upgrade::config::UpgradeConfig;
-use crate::{logging, plugins, projects, serve, telemetry, upgrade, utils::schemas};
+use crate::{binaries, logging, plugins, projects, serve, telemetry, upgrade, utils::schemas};
 use eyre::{bail, Result};
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
@@ -47,6 +47,9 @@ pub struct Config {
 
     #[validate]
     pub plugins: plugins::config::PluginsConfig,
+
+    #[validate]
+    pub binaries: binaries::config::BinariesConfig,
 
     #[validate]
     pub upgrade: upgrade::config::UpgradeConfig,

--- a/rust/src/config.rs
+++ b/rust/src/config.rs
@@ -318,11 +318,13 @@ pub mod cli {
             Action::Dirs => {
                 let config_dir = dir(false)?.display().to_string();
                 let logs_dir = crate::logging::config::dir(false)?.display().to_string();
-                let plugins_dir = crate::plugins::config::dir(false)?.display().to_string();
+                let plugins_dir = crate::plugins::plugins_dir(false)?.display().to_string();
+                let binaries_dir = crate::binaries::binaries_dir().display().to_string();
                 let value = serde_json::json!({
                     "config": config_dir,
                     "logs": logs_dir,
-                    "plugins": plugins_dir
+                    "plugins": plugins_dir,
+                    "binaries": binaries_dir
                 });
                 display::value(value)
             }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -52,6 +52,10 @@ pub mod traits {
 
 #[cfg(feature = "cli")]
 pub mod cli;
+
+#[cfg(feature = "binaries")]
+pub mod binaries;
+
 #[cfg(feature = "plugins")]
 pub mod plugins;
 

--- a/rust/src/utils/fs.rs
+++ b/rust/src/utils/fs.rs
@@ -1,6 +1,18 @@
-use std::path::Path;
-
+///! File system utilities, particularly functionality that requires
+///! alternative implementations for alternative operating systems.
 use eyre::Result;
+use std::{fs, os, path::Path};
+
+/// Set permissions on a file
+pub fn set_perms<File: AsRef<Path>>(path: File, mode: u32) -> Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    {
+        use os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
+    }
+
+    Ok(())
+}
 
 /// Create a symbolic (soft) link to a file
 pub fn symlink_file<Original: AsRef<Path>, Link: AsRef<Path>>(
@@ -8,10 +20,10 @@ pub fn symlink_file<Original: AsRef<Path>, Link: AsRef<Path>>(
     link: Link,
 ) -> Result<()> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    std::os::unix::fs::symlink(original, link)?;
+    os::unix::fs::symlink(original, link)?;
 
     #[cfg(target_os = "windows")]
-    std::os::windows::fs::symlink_file(original, link)?;
+    os::windows::fs::symlink_file(original, link)?;
 
     Ok(())
 }
@@ -22,10 +34,10 @@ pub fn symlink_dir<Original: AsRef<Path>, Link: AsRef<Path>>(
     link: Link,
 ) -> Result<()> {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    std::os::unix::fs::symlink(original, link)?;
+    os::unix::fs::symlink(original, link)?;
 
     #[cfg(target_os = "windows")]
-    std::os::windows::fs::symlink_dir(original, link)?;
+    os::windows::fs::symlink_dir(original, link)?;
 
     Ok(())
 }

--- a/rust/src/utils/tests.rs
+++ b/rust/src/utils/tests.rs
@@ -37,3 +37,18 @@ pub fn snapshot_content<F: FnMut(&str)>(pattern: &str, mut func: F) {
         });
     });
 }
+
+/// Should slow tests be skipped?
+///
+/// Use at the start of slow tests to return early except on CI or when
+/// the env var `RUN_SLOW_TESTS` is set.
+///
+/// Inspired by https://github.com/rust-analyzer/rust-analyzer/pull/2491
+pub fn skip_slow_tests() -> bool {
+    if std::env::var("CI").is_err() && std::env::var("RUN_SLOW_TESTS").is_err() {
+        eprintln!("Skipping slow test");
+        true
+    } else {
+        false
+    }
+}


### PR DESCRIPTION
Adds the `binaries` module for locating, running and installing third party binaries.

Binaries may be used as runtimes for plugins (e.g. Node.js, Python) or
are used directly by the `methods` module (e.g Pandoc).

This modules defines the `Binary` `struct` that can be used to define a
binary (e.g. how to determine the current version, how to download
a desired version) and functions for resolving, installing and executing
those binaries.