### PR TITLE
Desktop errors and handlers

### DIFF
--- a/desktop/src/main/config/index.ts
+++ b/desktop/src/main/config/index.ts
@@ -10,7 +10,7 @@ import {
   PluginsUpgrade,
   ReadConfig,
 } from '../../preload/types'
-import { removeChannelHandlers } from '../utils/handler'
+import { makeHandlers, removeChannelHandlers } from '../utils/handler'
 import { handle, valueToSuccessResult } from '../utils/ipc'
 import { CONFIG_CHANNEL } from './channels'
 import { showSettings } from './window'
@@ -36,48 +36,46 @@ const getPlugins = (): Result<NormalizedPlugins> => {
   )
 }
 
-export const registerConfigHandlers = () => {
-  try {
-    handle<ConfigWindowOpen>(CHANNEL.CONFIG_WINDOW_OPEN, async () => {
-      showSettings()
-      return valueToSuccessResult()
-    })
+const registerConfigHandlers = () => {
+  handle<ConfigWindowOpen>(CHANNEL.CONFIG_WINDOW_OPEN, async () => {
+    showSettings()
+    return valueToSuccessResult()
+  })
 
-    handle<ReadConfig>(CHANNEL.CONFIG_READ, async () => getConfig())
+  handle<ReadConfig>(CHANNEL.CONFIG_READ, async () => getConfig())
 
-    handle<PluginsList>(CHANNEL.PLUGINS_LIST, async () => {
-      plugins.refresh([])
-      return getPlugins()
-    })
+  handle<PluginsList>(CHANNEL.PLUGINS_LIST, async () => {
+    plugins.refresh([])
+    return getPlugins()
+  })
 
-    handle<PluginsInstall>(CHANNEL.PLUGINS_INSTALL, async (_event, name) => {
-      return dispatch.plugins.install(name)
-    })
+  handle<PluginsInstall>(CHANNEL.PLUGINS_INSTALL, async (_event, name) => {
+    return dispatch.plugins.install(name)
+  })
 
-    handle<PluginsUninstall>(
-      CHANNEL.PLUGINS_UNINSTALL,
-      async (_event, name) => {
-        return dispatch.plugins.uninstall(name)
-      }
-    )
+  handle<PluginsUninstall>(CHANNEL.PLUGINS_UNINSTALL, async (_event, name) => {
+    return dispatch.plugins.uninstall(name)
+  })
 
-    handle<PluginsUpgrade>(CHANNEL.PLUGIN_UPGRADE, async (_event, name) => {
-      return dispatch.plugins.upgrade(name)
-    })
+  handle<PluginsUpgrade>(CHANNEL.PLUGIN_UPGRADE, async (_event, name) => {
+    return dispatch.plugins.upgrade(name)
+  })
 
-    handle<PluginsRefresh>(
-      CHANNEL.PLUGINS_REFRESH,
-      async (_event, pluginList) => {
-        return dispatch.plugins.refresh(
-          pluginList ?? plugins.list().map((plugin) => plugin.name)
-        )
-      }
-    )
-  } catch {
-    // Handlers likely already registered
-  }
+  handle<PluginsRefresh>(
+    CHANNEL.PLUGINS_REFRESH,
+    async (_event, pluginList) => {
+      return dispatch.plugins.refresh(
+        pluginList ?? plugins.list().map((plugin) => plugin.name)
+      )
+    }
+  )
 }
 
-export const removeConfigHandlers = () => {
+const removeConfigHandlers = () => {
   removeChannelHandlers(CONFIG_CHANNEL)
 }
+
+export const configHandlers = makeHandlers(
+  registerConfigHandlers,
+  removeConfigHandlers
+)

--- a/desktop/src/main/config/window.ts
+++ b/desktop/src/main/config/window.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow } from 'electron'
-import { registerConfigHandlers, removeConfigHandlers } from '.'
+import { configHandlers } from '.'
 import { i18n } from '../../i18n'
 import { createWindow } from '../window'
 
@@ -18,13 +18,17 @@ export const showSettings = () => {
     title: i18n.t('settings.title'),
   })
 
+  // The ID needs to be stored separately from the window object. Otherwise an error
+  // is thrown because the time remove handlers are called the window object is already destroyed.
+  const windowId = settingsWindow.id
+
   settingsWindow.on('closed', () => {
-    removeConfigHandlers()
+    configHandlers.remove(windowId)
     settingsWindow = null
   })
 
   settingsWindow.webContents.on('did-finish-load', () => {
-    registerConfigHandlers()
+    configHandlers.register(windowId)
     settingsWindow?.show()
   })
 

--- a/desktop/src/main/document/index.ts
+++ b/desktop/src/main/document/index.ts
@@ -9,85 +9,82 @@ import {
   DocumentsWrite,
 } from '../../preload/types'
 import { rewriteHtml } from '../local-protocol'
-import { removeChannelHandlers } from '../utils/handler'
+import { makeHandlers, removeChannelHandlers } from '../utils/handler'
 import { handle } from '../utils/ipc'
 import { DOCUMENT_CHANNEL } from './channel'
 
-export const registerDocumentHandlers = () => {
-  try {
-    handle<DocumentsOpen>(CHANNEL.DOCUMENTS_OPEN, async (_event, filePath) =>
-      dispatch.documents.open(filePath)
-    )
+const registerDocumentHandlers = () => {
+  handle<DocumentsOpen>(CHANNEL.DOCUMENTS_OPEN, async (_event, filePath) =>
+    dispatch.documents.open(filePath)
+  )
 
-    handle<DocumentsClose>(
-      CHANNEL.DOCUMENTS_CLOSE,
-      async (_event, documentId) => {
-        return dispatch.documents.close(documentId)
-      }
-    )
+  handle<DocumentsClose>(
+    CHANNEL.DOCUMENTS_CLOSE,
+    async (_event, documentId) => {
+      return dispatch.documents.close(documentId)
+    }
+  )
 
-    handle<DocumentsUnsubscribe>(
-      CHANNEL.DOCUMENTS_UNSUBSCRIBE,
-      async (_event, documentId, topics) => {
-        return dispatch.documents.unsubscribe(documentId, topics)
-      }
-    )
+  handle<DocumentsUnsubscribe>(
+    CHANNEL.DOCUMENTS_UNSUBSCRIBE,
+    async (_event, documentId, topics) => {
+      return dispatch.documents.unsubscribe(documentId, topics)
+    }
+  )
 
-    handle<DocumentsDump>(
-      CHANNEL.DOCUMENTS_DUMP,
-      async (ipcEvent, documentId) => {
-        documents.subscribe(documentId, ['modified'], (_topic, docEvent) => {
-          ipcEvent.sender.send(CHANNEL.DOCUMENTS_DUMP, docEvent)
-        })
+  handle<DocumentsDump>(
+    CHANNEL.DOCUMENTS_DUMP,
+    async (ipcEvent, documentId) => {
+      documents.subscribe(documentId, ['modified'], (_topic, docEvent) => {
+        ipcEvent.sender.send(CHANNEL.DOCUMENTS_DUMP, docEvent)
+      })
 
-        // Use `dump` to get document content, rather than `read`, to avoid
-        // (a) a re-read of the file (that is done on open) (b) re-encoding for
-        // each subscriber.
-        return dispatch.documents.dump(documentId)
-      }
-    )
+      // Use `dump` to get document content, rather than `read`, to avoid
+      // (a) a re-read of the file (that is done on open) (b) re-encoding for
+      // each subscriber.
+      return dispatch.documents.dump(documentId)
+    }
+  )
 
-    handle<DocumentsPreview>(
-      CHANNEL.DOCUMENTS_PREVIEW,
-      async (ipcEvent, documentId) => {
-        documents.subscribe(
-          documentId,
-          ['encoded:html'],
-          (_topic, docEvent) => {
-            const event = {
-              ...docEvent,
-              content: rewriteHtml(docEvent.content ?? ''),
-            }
-
-            ipcEvent.sender.send(CHANNEL.DOCUMENTS_PREVIEW, event)
-          }
-        )
-
-        const results = dispatch.documents.dump(documentId, 'html')
-
-        if (results.ok) {
-          return {
-            ok: results.ok,
-            value: rewriteHtml(results.value),
-            errors: results.errors,
-          }
-        } else {
-          return results
+  handle<DocumentsPreview>(
+    CHANNEL.DOCUMENTS_PREVIEW,
+    async (ipcEvent, documentId) => {
+      documents.subscribe(documentId, ['encoded:html'], (_topic, docEvent) => {
+        const event = {
+          ...docEvent,
+          content: rewriteHtml(docEvent.content ?? ''),
         }
-      }
-    )
 
-    handle<DocumentsWrite>(
-      CHANNEL.DOCUMENTS_WRITE,
-      async (_event, documentId, content) => {
-        return dispatch.documents.write(documentId, content)
+        ipcEvent.sender.send(CHANNEL.DOCUMENTS_PREVIEW, event)
+      })
+
+      const results = dispatch.documents.dump(documentId, 'html')
+
+      if (results.ok) {
+        return {
+          ok: results.ok,
+          value: rewriteHtml(results.value),
+          errors: results.errors,
+        }
+      } else {
+        return results
       }
-    )
-  } catch {
-    // Handlers likely already registered
-  }
+    }
+  )
+
+  handle<DocumentsWrite>(
+    CHANNEL.DOCUMENTS_WRITE,
+    async (_event, documentId, content) => {
+      return dispatch.documents.write(documentId, content)
+    }
+  )
 }
 
-export const removeDocoumentHandlers = () => {
+const removeDocoumentHandlers = () => {
   removeChannelHandlers(DOCUMENT_CHANNEL)
 }
+
+export const documentHandlers = makeHandlers(
+  registerDocumentHandlers,
+  removeDocoumentHandlers
+)

--- a/desktop/src/main/global/index.ts
+++ b/desktop/src/main/global/index.ts
@@ -2,9 +2,11 @@ import { shell } from 'electron'
 import { CHANNEL } from '../../preload/channels'
 import { captureError } from '../../preload/errors'
 import { CaptureError, OpenLink } from '../../preload/types'
+import { makeHandlers, removeChannelHandlers } from '../utils/handler'
 import { handle, valueToSuccessResult } from '../utils/ipc'
+import { GLOBAL_CHANNEL } from './channels'
 
-export const registerGlobalHandlers = () => {
+const registerGlobalHandlers = () => {
   handle<OpenLink>(CHANNEL.OPEN_LINK_IN_DEFAULT_BROWSER, (_event, link) =>
     shell.openExternal(link).then(() => valueToSuccessResult())
   )
@@ -13,3 +15,12 @@ export const registerGlobalHandlers = () => {
     return valueToSuccessResult(captureError(payload))
   })
 }
+
+const removeGlobalHandlers = () => {
+  removeChannelHandlers(GLOBAL_CHANNEL)
+}
+
+export const globalHandlers = makeHandlers(
+  registerGlobalHandlers,
+  removeGlobalHandlers
+)

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,13 +1,15 @@
-import { registerGlobalHandlers } from './global'
+import { globalHandlers } from './global'
+import { launcherHandlers } from './launcher'
 import { registerMenu } from './menu'
-import { registerAppConfigStoreHandlers } from './store'
+import { appStoreHandlers } from './store'
 import { setErrorReportingId } from './utils/errors'
 import { checkForUpdates } from './utils/update'
 
 export const main = () => {
   setErrorReportingId()
   checkForUpdates()
-  registerAppConfigStoreHandlers()
-  registerGlobalHandlers()
+  appStoreHandlers.register(null)
+  globalHandlers.register(null)
+  launcherHandlers.register(null)
   registerMenu()
 }

--- a/desktop/src/main/launcher/index.ts
+++ b/desktop/src/main/launcher/index.ts
@@ -1,26 +1,27 @@
 import { CHANNEL } from '../../preload/channels'
 import { LauncherWindowClose, LauncherWindowOpen } from '../../preload/types'
-import { removeChannelHandlers } from '../utils/handler'
+import { makeHandlers, removeChannelHandlers } from '../utils/handler'
 import { handle, valueToSuccessResult } from '../utils/ipc'
 import { LAUNCHER_CHANNEL } from './channels'
 import { closeLauncherWindow, openLauncherWindow } from './window'
 
-export const registerLauncherHandlers = () => {
-  try {
-    handle<LauncherWindowOpen>(CHANNEL.LAUNCHER_WINDOW_OPEN, async () => {
-      openLauncherWindow()
-      return valueToSuccessResult()
-    })
+const registerLauncherHandlers = () => {
+  handle<LauncherWindowOpen>(CHANNEL.LAUNCHER_WINDOW_OPEN, async () => {
+    openLauncherWindow()
+    return valueToSuccessResult()
+  })
 
-    handle<LauncherWindowClose>(CHANNEL.LAUNCHER_WINDOW_CLOSE, async () => {
-      closeLauncherWindow()
-      return valueToSuccessResult()
-    })
-  } catch {
-    // Handlers likely already registered
-  }
+  handle<LauncherWindowClose>(CHANNEL.LAUNCHER_WINDOW_CLOSE, async () => {
+    closeLauncherWindow()
+    return valueToSuccessResult()
+  })
 }
 
-export const removeLauncherHandlers = () => {
+const removeLauncherHandlers = () => {
   removeChannelHandlers(LAUNCHER_CHANNEL)
 }
+
+export const launcherHandlers = makeHandlers(
+  registerLauncherHandlers,
+  removeLauncherHandlers
+)

--- a/desktop/src/main/launcher/window.ts
+++ b/desktop/src/main/launcher/window.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow } from 'electron'
-import { registerLauncherHandlers, removeLauncherHandlers } from '.'
-import { registerConfigHandlers, removeConfigHandlers } from '../config'
-import { registerProjectHandlers } from '../project'
+import { launcherHandlers } from '.'
+import { configHandlers } from '../config'
+import { projectHandlers } from '../project'
 import { createWindow } from '../window'
 
 let launcherWindow: BrowserWindow | null
@@ -24,16 +24,20 @@ export const openLauncherWindow = () => {
     center: true,
   })
 
+  // The ID needs to be stored separately from the window object. Otherwise an error
+  // is thrown because the time remove handlers are called the window object is already destroyed.
+  const windowId = launcherWindow.id
+
   launcherWindow.on('closed', () => {
-    removeLauncherHandlers()
-    removeConfigHandlers()
+    launcherHandlers.remove(windowId)
+    configHandlers.remove(windowId)
     launcherWindow = null
   })
 
   launcherWindow.webContents.on('did-finish-load', () => {
-    registerConfigHandlers()
-    registerProjectHandlers()
-    registerLauncherHandlers()
+    configHandlers.register(windowId)
+    projectHandlers.register(windowId)
+    launcherHandlers.register(windowId)
     launcherWindow?.show()
   })
 
@@ -44,5 +48,4 @@ export const openLauncherWindow = () => {
 
 export const closeLauncherWindow = () => {
   launcherWindow?.close()
-  launcherWindow = null
 }

--- a/desktop/src/main/onboarding/index.ts
+++ b/desktop/src/main/onboarding/index.ts
@@ -3,27 +3,28 @@ import {
   OnboardingWindowClose,
   OnboardingWindowOpen,
 } from '../../preload/types'
-import { removeChannelHandlers } from '../utils/handler'
+import { makeHandlers, removeChannelHandlers } from '../utils/handler'
 import { handle, valueToSuccessResult } from '../utils/ipc'
 import { ONBOARDING_CHANNEL } from './channels'
 import { closeOnboardingWindow, openOnboardingWindow } from './window'
 
-export const registerOnboardingHandlers = () => {
-  try {
-    handle<OnboardingWindowOpen>(CHANNEL.ONBOARDING_WINDOW_OPEN, async () => {
-      openOnboardingWindow()
-      return valueToSuccessResult()
-    })
+const registerOnboardingHandlers = () => {
+  handle<OnboardingWindowOpen>(CHANNEL.ONBOARDING_WINDOW_OPEN, async () => {
+    openOnboardingWindow()
+    return valueToSuccessResult()
+  })
 
-    handle<OnboardingWindowClose>(CHANNEL.ONBOARDING_WINDOW_CLOSE, async () => {
-      closeOnboardingWindow()
-      return valueToSuccessResult()
-    })
-  } catch {
-    // Handlers likely already registered
-  }
+  handle<OnboardingWindowClose>(CHANNEL.ONBOARDING_WINDOW_CLOSE, async () => {
+    closeOnboardingWindow()
+    return valueToSuccessResult()
+  })
 }
 
-export const removeOnboaringHandlers = () => {
+const removeOnboaringHandlers = () => {
   removeChannelHandlers(ONBOARDING_CHANNEL)
 }
+
+export const onboardingHandlers = makeHandlers(
+  registerOnboardingHandlers,
+  removeOnboaringHandlers
+)

--- a/desktop/src/main/onboarding/window.ts
+++ b/desktop/src/main/onboarding/window.ts
@@ -1,8 +1,8 @@
 import { BrowserWindow } from 'electron'
-import { registerOnboardingHandlers, removeOnboaringHandlers } from '.'
+import { onboardingHandlers } from '.'
 import { i18n } from '../../i18n'
-import { registerConfigHandlers, removeConfigHandlers } from '../config'
-import { registerLauncherHandlers, removeLauncherHandlers } from '../launcher'
+import { configHandlers } from '../config'
+import { launcherHandlers } from '../launcher'
 import { createWindow } from '../window'
 
 let onboardingWindow: BrowserWindow | null
@@ -23,17 +23,21 @@ export const openOnboardingWindow = () => {
     center: true,
   })
 
+  // The ID needs to be stored separately from the window object. Otherwise an error
+  // is thrown because the time remove handlers are called the window object is already destroyed.
+  const windowId = onboardingWindow.id
+
   onboardingWindow.on('closed', () => {
-    removeLauncherHandlers()
-    removeConfigHandlers()
-    removeOnboaringHandlers()
+    launcherHandlers.remove(windowId)
+    configHandlers.remove(windowId)
+    onboardingHandlers.remove(windowId)
     onboardingWindow = null
   })
 
   onboardingWindow.webContents.on('did-finish-load', () => {
-    registerLauncherHandlers()
-    registerConfigHandlers()
-    registerOnboardingHandlers()
+    launcherHandlers.register(windowId)
+    configHandlers.register(windowId)
+    onboardingHandlers.register(windowId)
     onboardingWindow?.show()
   })
 

--- a/desktop/src/main/project/window.ts
+++ b/desktop/src/main/project/window.ts
@@ -1,7 +1,7 @@
 import { parse } from 'path'
 import { projects } from 'stencila'
-import { registerProjectHandlers, removeProjectHandlers } from '.'
-import { registerDocumentHandlers, removeDocoumentHandlers } from '../document'
+import { projectHandlers } from '.'
+import { documentHandlers } from '../document'
 import { createWindow } from '../window'
 
 const getProjectName = (path: string): string => parse(path).base
@@ -18,15 +18,20 @@ export const openProjectWindow = (directoryPath: string) => {
     title: getProjectName(directoryPath),
   })
 
+  // The ID needs to be stored separately from the window object. Otherwise an error
+  // is thrown because the time remove handlers are called the window object is already destroyed.
+  const windowId = projectWindow.id
+
   projectWindow.on('closed', () => {
     projects.close(directoryPath)
-    removeProjectHandlers()
-    removeDocoumentHandlers()
+
+    projectHandlers.remove(windowId)
+    documentHandlers.remove(windowId)
   })
 
   projectWindow.webContents.on('did-finish-load', () => {
-    registerProjectHandlers()
-    registerDocumentHandlers()
+    projectHandlers.register(windowId)
+    documentHandlers.register(windowId)
     projectWindow?.show()
   })
 

--- a/desktop/src/main/store/index.ts
+++ b/desktop/src/main/store/index.ts
@@ -1,9 +1,11 @@
 import { CHANNEL } from '../../preload/channels'
 import { GetAppConfig, ReadAppConfig, SetAppConfig } from '../../preload/types'
+import { makeHandlers, removeChannelHandlers } from '../utils/handler'
 import { handle, valueToSuccessResult } from '../utils/ipc'
+import { UNPROTECTED_STORE_CHANNEL } from './channels'
 import { getAppConfig, readAppConfig, setAppConfig } from './handlers'
 
-export const registerAppConfigStoreHandlers = () => {
+const registerAppConfigStoreHandlers = () => {
   handle<ReadAppConfig>(CHANNEL.CONFIG_APP_READ, async () => {
     const config = readAppConfig()
     return valueToSuccessResult({ ...config })
@@ -21,3 +23,12 @@ export const registerAppConfigStoreHandlers = () => {
     }
   )
 }
+
+const removeAppConfigStoreHandlers = () => {
+  removeChannelHandlers(UNPROTECTED_STORE_CHANNEL)
+}
+
+export const appStoreHandlers = makeHandlers(
+  registerAppConfigStoreHandlers,
+  removeAppConfigStoreHandlers
+)

--- a/desktop/src/main/utils/handler.ts
+++ b/desktop/src/main/utils/handler.ts
@@ -1,5 +1,33 @@
 import { ipcMain } from 'electron'
 
+/**
+ * A utility function for managing the registration and cleanup of IPC handler.
+ * Attempting to register a handler on the same channel multiple times will throw an error.
+ * Additionally, several windows can depend on a handler, so the handlers should only be
+ * cleaned up if no windows require it.
+
+ * For global handlers that need to be present regardless of a window (e.g. global
+ * keyboard shortcut listeners), you can pass `null` as the window id.
+ */
+export const makeHandlers = (registerFn: () => void, removeFn: () => void) => {
+  const attachedWindows = new Set<number | null>()
+
+  return {
+    register: (windowId: number | null): void => {
+      if (attachedWindows.size <= 0) {
+        registerFn()
+      }
+      attachedWindows.add(windowId)
+    },
+    remove: (windowId: number | null): void => {
+      attachedWindows.delete(windowId)
+      if (attachedWindows.size <= 0) {
+        removeFn()
+      }
+    },
+  }
+}
+
 export const removeChannelHandlers = (
   channelObject: Record<string, string>
 ) => {

--- a/desktop/src/preload/errors.ts
+++ b/desktop/src/preload/errors.ts
@@ -38,6 +38,6 @@ export interface LogHandler extends LogEvent {
   error?: Error
 }
 
-export const captureError = (error: LogHandler) => {
+export const captureError = (error: Error | PromiseRejectionEvent) => {
   Sentry.captureException(error)
 }

--- a/desktop/src/renderer/components/app-document/app-document-editor/app-document-editor.tsx
+++ b/desktop/src/renderer/components/app-document/app-document-editor/app-document-editor.tsx
@@ -145,7 +145,7 @@ export class AppDocumentEditor {
       })
   }
 
-  componentWillLoad() {
+  componentDidLoad() {
     return this.subscribeToDocument(this.documentId)
   }
 

--- a/desktop/src/renderer/utils/errors/index.ts
+++ b/desktop/src/renderer/utils/errors/index.ts
@@ -1,4 +1,5 @@
 import { Toast } from '@stencila/components'
+import { captureError } from '../../../preload/errors'
 import { isRPCError } from '../../client'
 
 const toastController = Toast.toastController({
@@ -26,6 +27,7 @@ export const errorToast = (error: unknown) => {
 
 export const showUnhandledErrors = () => {
   window.onunhandledrejection = (e: PromiseRejectionEvent) => {
+    captureError(e)
     errorToast(e.reason)
   }
 }


### PR DESCRIPTION
This PR contains several fixes for the desktop client.

Previously IPC handlers registered and removed upon creation/destruction of a window.
However since these handlers are shared between windows, and the fact that a user can open up multiple windows of the same type meant that we were incorrectly removing handlers which were still necessary.
To address this we now have a `makeHandlers` function which accepts a window ID and then tracks if the handlers are required by any windows or not.
The additional benefit of this approach is that I was able to remove try/catch wrapper when registering the handlers.

---

Another bug fixed was the editor state being lost when navigating between an image preview and a text document.
This was due to a race condition where the reference to the editor component was undefined when switching back.
This was addressed by using a different component lifecycle event, `componentDidLoad` instead of `componentWillLoad`.