### PR TITLE
Project graph refinements

### DIFF
--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -305,9 +305,9 @@ export type Resource =
        */
       path: string
       /**
-       * The address of the node
+       * The id of the node with the document
        */
-      address: string
+      id: string
       /**
        * The type of node e.g. `Parameter`, `CodeChunk`
        */
@@ -352,24 +352,59 @@ export type Resource =
  * Some relations carry additional information such whether the relation is active (`Import` and `Convert`) or the range that they occur in code (`Assign`, `Use`, `Read`) etc
  */
 export type Relation =
-  | ('embed' | 'include' | 'link')
   | {
-      assign: [number, number, number, number]
+      type: 'Assign'
+      /**
+       * The range within code that the assignment is done
+       */
+      range: [number, number, number, number]
     }
   | {
-      convert: boolean
+      type: 'Convert'
+      /**
+       * Whether or not the conversion is automatically updated
+       */
+      auto: boolean
     }
   | {
-      import: boolean
+      type: 'Embed'
+      [k: string]: unknown
     }
   | {
-      read: [number, number, number, number]
+      type: 'Import'
+      /**
+       * Whether or not the import is automatically updated
+       */
+      auto: boolean
     }
   | {
-      use: [number, number, number, number]
+      type: 'Include'
+      [k: string]: unknown
     }
   | {
-      write: [number, number, number, number]
+      type: 'Link'
+      [k: string]: unknown
+    }
+  | {
+      type: 'Read'
+      /**
+       * The range within code that the read is declared
+       */
+      range: [number, number, number, number]
+    }
+  | {
+      type: 'Use'
+      /**
+       * The range within code that the use is declared
+       */
+      range: [number, number, number, number]
+    }
+  | {
+      type: 'Write'
+      /**
+       * The range within code that the write is declared
+       */
+      range: [number, number, number, number]
     }
 
 /**

--- a/rust/src/conversions.rs
+++ b/rust/src/conversions.rs
@@ -1,4 +1,4 @@
-use crate::graphs::{resources, Relation, Triple};
+use crate::graphs::{relations, resources, Triple};
 use defaults::Defaults;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ impl Conversion {
     pub fn triple(&self, project: &Path) -> Triple {
         (
             resources::file(&project.join(&self.input)),
-            Relation::Convert(self.active),
+            relations::converts(self.active),
             resources::file(&project.join(&self.output)),
         )
     }

--- a/rust/src/methods/compile/code/js.rs
+++ b/rust/src/methods/compile/code/js.rs
@@ -1,6 +1,6 @@
 use super::{apply_tags, remove_quotes, Capture, Compiler};
 use crate::{
-    graphs::{resources, Relation, Resource},
+    graphs::{relations, resources, Relation, Resource},
     utils::path::merge,
 };
 use once_cell::sync::Lazy;
@@ -117,19 +117,19 @@ pub(crate) fn handle_patterns(
             } else {
                 resources::module("javascript", &module)
             };
-            Some((Relation::Use(range), object))
+            Some((relations::uses(range), object))
         }
         3 => {
             // Reads a file
             Some((
-                Relation::Read(captures[1].range),
+                relations::reads(captures[1].range),
                 resources::file(&merge(path, remove_quotes(&captures[1].text))),
             ))
         }
         4 => {
             // Writes a file
             Some((
-                Relation::Write(captures[1].range),
+                relations::writes(captures[1].range),
                 resources::file(&merge(path, remove_quotes(&captures[1].text))),
             ))
         }
@@ -151,7 +151,7 @@ pub(crate) fn handle_patterns(
                 _ => unreachable!(),
             };
             Some((
-                Relation::Assign(range),
+                relations::assigns(range),
                 resources::symbol(path, &name, kind),
             ))
         }
@@ -213,7 +213,7 @@ pub(crate) fn handle_patterns(
                 parent = parent_node.parent();
             }
 
-            Some((Relation::Use(range), resources::symbol(path, &symbol, "")))
+            Some((relations::uses(range), resources::symbol(path, &symbol, "")))
         }
         _ => None,
     }

--- a/rust/src/methods/compile/code/mod.rs
+++ b/rust/src/methods/compile/code/mod.rs
@@ -2,7 +2,7 @@
 ///!
 ///! Uses `tree-sitter` to parse source code into a abstract syntax tree which is then used to
 ///! derive properties of a `CodeAnalysis`.
-use crate::graphs::{resources, Range, Relation, Resource};
+use crate::graphs::{relations, resources, Range, Relation, Resource};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{
@@ -327,11 +327,11 @@ fn parse_tags(
         if let Some(captures) = REGEX_TAG.captures(line) {
             let tag = captures[1].to_string();
             let relation = match tag.as_str() {
-                "imports" => Relation::Use(range),
-                "assigns" => Relation::Assign(range),
-                "uses" => Relation::Use(range),
-                "reads" => Relation::Read(range),
-                "writes" => Relation::Write(range),
+                "imports" => relations::uses(range),
+                "assigns" => relations::assigns(range),
+                "uses" => relations::uses(range),
+                "reads" => relations::reads(range),
+                "writes" => relations::writes(range),
                 _ => continue,
             };
 

--- a/rust/src/methods/compile/code/py.rs
+++ b/rust/src/methods/compile/code/py.rs
@@ -1,6 +1,6 @@
 use super::{apply_tags, captures_as_args_map, is_quoted, remove_quotes, Compiler};
 use crate::{
-    graphs::{resources, Relation, Resource},
+    graphs::{relations, resources, Relation, Resource},
     utils::path::merge,
 };
 use once_cell::sync::Lazy;
@@ -82,7 +82,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                     true => resources::file(&path),
                     false => resources::module("python", module),
                 };
-                Some((Relation::Use(range), object))
+                Some((relations::uses(range), object))
             }
             3 => {
                 // Opens a file for reading or writing
@@ -99,12 +99,12 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                         }
                         let mode = remove_quotes(&mode.text);
                         if mode.starts_with('w') || mode.starts_with('a') {
-                            Some((Relation::Write(range), resources::file(&path)))
+                            Some((relations::writes(range), resources::file(&path)))
                         } else {
-                            Some((Relation::Read(range), resources::file(&path)))
+                            Some((relations::reads(range), resources::file(&path)))
                         }
                     } else {
-                        Some((Relation::Read(range), resources::file(&path)))
+                        Some((relations::reads(range), resources::file(&path)))
                     }
                 } else {
                     None
@@ -129,7 +129,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                     _ => unreachable!(),
                 };
                 Some((
-                    Relation::Assign(range),
+                    relations::assigns(range),
                     resources::symbol(path, &name, kind),
                 ))
             }
@@ -206,7 +206,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                     parent = parent_node.parent();
                 }
 
-                Some((Relation::Use(range), resources::symbol(path, &symbol, "")))
+                Some((relations::uses(range), resources::symbol(path, &symbol, "")))
             }
             _ => None,
         })

--- a/rust/src/methods/compile/code/r.rs
+++ b/rust/src/methods/compile/code/r.rs
@@ -1,6 +1,6 @@
 use super::{apply_tags, captures_as_args_map, child_text, is_quoted, remove_quotes, Compiler};
 use crate::{
-    graphs::{resources, Relation, Resource},
+    graphs::{relations, resources, Relation, Resource},
     utils::path::merge,
 };
 use once_cell::sync::Lazy;
@@ -98,7 +98,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                             return None;
                         }
                         Some((
-                            Relation::Use(package.range),
+                            relations::uses(package.range),
                             resources::module("r", &remove_quotes(&package.text)),
                         ))
                     })
@@ -108,7 +108,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                 let args = captures_as_args_map(captures);
                 args.get("0").or_else(|| args.get("file")).map(|file| {
                     (
-                        Relation::Read(file.range),
+                        relations::reads(file.range),
                         resources::file(&merge(path, remove_quotes(&file.text))),
                     )
                 })
@@ -118,7 +118,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                 let args = captures_as_args_map(captures);
                 args.get("1").or_else(|| args.get("file")).map(|file| {
                     (
-                        Relation::Write(file.range),
+                        relations::writes(file.range),
                         resources::file(&merge(path, remove_quotes(&file.text))),
                     )
                 })
@@ -143,7 +143,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                     _ => "",
                 };
                 Some((
-                    Relation::Assign(range),
+                    relations::assigns(range),
                     resources::symbol(path, &name, kind),
                 ))
             }
@@ -219,7 +219,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                     None => resources::symbol(path, &symbol, ""),
                 };
 
-                Some((Relation::Use(range), resource))
+                Some((relations::uses(range), resource))
             }
             _ => None,
         })

--- a/rust/src/methods/compile/code/snapshots/js_fragments@assigns.js.snap
+++ b/rust/src/methods/compile/code/snapshots/js_fragments@assigns.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/assigns.js
 [
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         1,
         4,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         2,
         4,
         2,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         6,
         3,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         4,
         13,
         4,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         6,
         6,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         7,
         6,
         7,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         8,
         6,
         8,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         9,
         6,
         9,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         10,
         6,
         10,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         11,
         6,
         11,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         12,
         6,
         12,
@@ -199,7 +211,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         14,
         9,
         14,
@@ -215,7 +228,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         15,
         6,
         15,
@@ -231,7 +245,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         16,
         16,
         16,

--- a/rust/src/methods/compile/code/snapshots/js_fragments@imports.js.snap
+++ b/rust/src/methods/compile/code/snapshots/js_fragments@imports.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/imports.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         26,
         2,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         22,
         3,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         24,
         4,
@@ -52,7 +55,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         5,
         33,
         5,
@@ -67,7 +71,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         34,
         6,
@@ -82,7 +87,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         7,
         43,
         7,
@@ -97,7 +103,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         8,
         39,
         8,
@@ -112,7 +119,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         9,
         37,
         9,
@@ -127,7 +135,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         10,
         7,
         10,
@@ -142,7 +151,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         11,
         4,
         11,
@@ -158,7 +168,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         11,
         21,
         11,
@@ -173,7 +184,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         14,
         4,
         14,
@@ -189,7 +201,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         14,
         20,
         14,
@@ -205,7 +218,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         14,
         28,
         14,
@@ -220,7 +234,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         15,
         4,
         15,
@@ -236,7 +251,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         15,
         12,
         15,
@@ -252,7 +268,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         15,
         20,
         15,
@@ -267,7 +284,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         19,
         6,
         19,
@@ -283,7 +301,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         21,
         6,
         21,
@@ -299,7 +318,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         22,
         6,
         22,
@@ -315,7 +335,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         22,
         12,
         22,
@@ -331,7 +352,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         22,
         20,
         22,

--- a/rust/src/methods/compile/code/snapshots/js_fragments@reads.js.snap
+++ b/rust/src/methods/compile/code/snapshots/js_fragments@reads.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/reads.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         15,
         0,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         27,
         1,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         4,
         3,
@@ -53,7 +56,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -69,7 +73,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         3,
         23,
         3,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -99,7 +105,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         4,
         13,
         4,
@@ -113,7 +120,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         9,
         6,
@@ -129,7 +137,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         7,
         14,
         7,
@@ -143,7 +152,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         8,
         17,
         8,

--- a/rust/src/methods/compile/code/snapshots/js_fragments@tags.js.snap
+++ b/rust/src/methods/compile/code/snapshots/js_fragments@tags.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/tags.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -52,7 +55,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         2,
         0,
         2,
@@ -68,7 +72,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         0,
         3,
@@ -84,7 +89,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         5,
         0,
         5,
@@ -98,7 +104,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         5,
         0,
         5,
@@ -112,7 +119,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         6,
         0,
         6,

--- a/rust/src/methods/compile/code/snapshots/js_fragments@uses.js.snap
+++ b/rust/src/methods/compile/code/snapshots/js_fragments@uses.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/uses.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         7,
         1,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         0,
         2,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         0,
         3,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         5,
         3,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         5,
         4,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         4,
         6,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         11,
         6,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         7,
         13,
         7,
@@ -199,7 +211,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         12,
         19,
         12,
@@ -214,7 +227,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         13,
         21,
         13,
@@ -229,7 +243,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         17,
         15,
         17,
@@ -245,7 +260,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         18,
         4,
         18,
@@ -261,7 +277,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         21,
         26,
         21,
@@ -277,7 +294,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         27,
         0,
         27,
@@ -293,7 +311,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         28,
         0,
         28,
@@ -309,7 +328,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         29,
         0,
         29,
@@ -325,7 +345,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         29,
         13,
         29,
@@ -341,7 +362,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         34,
         9,
         34,
@@ -357,7 +379,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         38,
         6,
         38,
@@ -373,7 +396,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         42,
         0,
         42,
@@ -389,7 +413,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         43,
         4,
         43,
@@ -405,7 +430,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         44,
         4,
         44,
@@ -421,7 +447,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         45,
         6,
         45,

--- a/rust/src/methods/compile/code/snapshots/js_fragments@writes.js.snap
+++ b/rust/src/methods/compile/code/snapshots/js_fragments@writes.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/writes.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         15,
         0,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         28,
         1,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         4,
         3,
@@ -53,7 +56,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -69,7 +73,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         3,
         24,
         3,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         33,
         3,
@@ -99,7 +105,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -115,7 +122,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         4,
         14,
         4,
@@ -129,7 +137,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         23,
         4,
@@ -145,7 +154,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         9,
         6,
@@ -161,7 +171,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         7,
         15,
         7,

--- a/rust/src/methods/compile/code/snapshots/py_fragments@assigns.py.snap
+++ b/rust/src/methods/compile/code/snapshots/py_fragments@assigns.py.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/py/assigns.py
 [
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         1,
         0,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         4,
         3,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         4,
         0,
         4,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         0,
         6,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         7,
         0,
         7,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         8,
         0,
         8,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         9,
         0,
         9,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         10,
         0,
         10,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         11,
         0,
         11,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/py/assigns.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         12,
         0,
         12,

--- a/rust/src/methods/compile/code/snapshots/py_fragments@imports.py.snap
+++ b/rust/src/methods/compile/code/snapshots/py_fragments@imports.py.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/py/imports.py
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         7,
         0,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/py/imports.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         5,
         1,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/py/imports.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         5,
         2,
@@ -52,7 +55,8 @@ input_file: fixtures/fragments/py/imports.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         5,
         3,

--- a/rust/src/methods/compile/code/snapshots/py_fragments@reads.py.snap
+++ b/rust/src/methods/compile/code/snapshots/py_fragments@reads.py.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/py/reads.py
 [
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         0,
         12,
         0,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         2,
         10,
         2,
@@ -51,7 +54,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         5,
         5,
         5,
@@ -65,7 +69,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         7,
         10,
         7,
@@ -79,7 +84,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         9,
         5,
         9,
@@ -93,7 +99,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         11,
         10,
         11,
@@ -107,7 +114,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         13,
         10,
         13,
@@ -121,7 +129,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         16,
         4,
         16,
@@ -137,7 +146,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         17,
         9,
         17,
@@ -151,7 +161,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         22,
         5,
         22,
@@ -165,7 +176,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         23,
         5,
         23,
@@ -179,7 +191,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         24,
         10,
         24,
@@ -193,7 +206,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         28,
         0,
         28,
@@ -209,7 +223,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         29,
         5,
         29,
@@ -225,7 +240,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         30,
         5,
         30,
@@ -241,7 +257,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         31,
         5,
         31,
@@ -257,7 +274,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         33,
         0,
         33,
@@ -273,7 +291,8 @@ input_file: fixtures/fragments/py/reads.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         34,
         15,
         34,

--- a/rust/src/methods/compile/code/snapshots/py_fragments@tags.py.snap
+++ b/rust/src/methods/compile/code/snapshots/py_fragments@tags.py.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/py/tags.py
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/py/tags.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         2,
         0,
         2,
@@ -38,7 +40,8 @@ input_file: fixtures/fragments/py/tags.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -54,7 +57,8 @@ input_file: fixtures/fragments/py/tags.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         5,
         0,
         5,
@@ -68,7 +72,8 @@ input_file: fixtures/fragments/py/tags.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         5,
         0,
         5,
@@ -82,7 +87,8 @@ input_file: fixtures/fragments/py/tags.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         6,
         0,
         6,

--- a/rust/src/methods/compile/code/snapshots/py_fragments@uses.py.snap
+++ b/rust/src/methods/compile/code/snapshots/py_fragments@uses.py.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/py/uses.py
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         7,
         1,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         0,
         2,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         0,
         3,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         5,
         3,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         5,
         4,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         3,
         6,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         10,
         6,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         7,
         13,
         7,
@@ -199,7 +211,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         11,
         14,
         11,
@@ -215,7 +228,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         12,
         4,
         12,
@@ -231,7 +245,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         16,
         5,
         16,
@@ -247,7 +262,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         21,
         0,
         21,
@@ -263,7 +279,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         22,
         0,
         22,
@@ -279,7 +296,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         23,
         0,
         23,
@@ -295,7 +313,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         23,
         13,
         23,
@@ -311,7 +330,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         27,
         0,
         27,
@@ -327,7 +347,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         27,
         5,
         27,
@@ -343,7 +364,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         31,
         4,
         31,
@@ -359,7 +381,8 @@ input_file: fixtures/fragments/py/uses.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         38,
         0,
         38,

--- a/rust/src/methods/compile/code/snapshots/py_fragments@writes.py.snap
+++ b/rust/src/methods/compile/code/snapshots/py_fragments@writes.py.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/py/writes.py
 [
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         0,
         12,
         0,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         2,
         0,
         2,
@@ -53,7 +56,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         3,
         10,
         3,
@@ -67,7 +71,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         12,
         4,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         6,
         5,
         6,
@@ -97,7 +103,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         8,
         10,
         8,
@@ -111,7 +118,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         10,
         4,
         10,
@@ -127,7 +135,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         11,
         9,
         11,
@@ -141,7 +150,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         16,
         5,
         16,
@@ -155,7 +165,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         17,
         5,
         17,
@@ -169,7 +180,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         18,
         10,
         18,
@@ -183,7 +195,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         22,
         0,
         22,
@@ -199,7 +212,8 @@ input_file: fixtures/fragments/py/writes.py
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         23,
         5,
         23,

--- a/rust/src/methods/compile/code/snapshots/r_fragments@assigns.R.snap
+++ b/rust/src/methods/compile/code/snapshots/r_fragments@assigns.R.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/r/assigns.R
 [
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         1,
         0,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         0,
         3,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         5,
         4,
         5,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         10,
         4,
         10,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         13,
         0,
         13,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         15,
         0,
         15,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         16,
         0,
         16,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         17,
         0,
         17,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         18,
         0,
         18,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         19,
         0,
         19,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/r/assigns.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         20,
         0,
         20,

--- a/rust/src/methods/compile/code/snapshots/r_fragments@imports.R.snap
+++ b/rust/src/methods/compile/code/snapshots/r_fragments@imports.R.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/r/imports.R
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         8,
         1,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/r/imports.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         8,
         2,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/r/imports.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         5,
         8,
         5,
@@ -52,7 +55,8 @@ input_file: fixtures/fragments/r/imports.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         5,
         8,
         5,
@@ -67,7 +71,8 @@ input_file: fixtures/fragments/r/imports.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         8,
         0,
         8,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/r/imports.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         9,
         12,
         9,
@@ -98,7 +104,8 @@ input_file: fixtures/fragments/r/imports.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         16,
         0,
         16,

--- a/rust/src/methods/compile/code/snapshots/r_fragments@reads.R.snap
+++ b/rust/src/methods/compile/code/snapshots/r_fragments@reads.R.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/r/reads.R
 [
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         1,
         9,
         1,
@@ -21,7 +22,8 @@ input_file: fixtures/fragments/r/reads.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         4,
         0,
         4,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/r/reads.R
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         4,
         19,
         4,
@@ -51,7 +54,8 @@ input_file: fixtures/fragments/r/reads.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         7,
         0,
         7,
@@ -67,7 +71,8 @@ input_file: fixtures/fragments/r/reads.R
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         8,
         22,
         8,

--- a/rust/src/methods/compile/code/snapshots/r_fragments@tags.R.snap
+++ b/rust/src/methods/compile/code/snapshots/r_fragments@tags.R.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/r/tags.R
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -52,7 +55,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -67,7 +71,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         1,
         0,
         1,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         0,
         2,
@@ -99,7 +105,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         3,
         0,
         3,
@@ -113,7 +120,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         3,
         0,
         3,
@@ -127,7 +135,8 @@ input_file: fixtures/fragments/r/tags.R
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         4,
         0,
         4,

--- a/rust/src/methods/compile/code/snapshots/r_fragments@uses.R.snap
+++ b/rust/src/methods/compile/code/snapshots/r_fragments@uses.R.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/r/uses.R
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         0,
         2,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         7,
         2,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         0,
         3,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         5,
         3,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         5,
         4,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         4,
         6,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         11,
         6,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         7,
         14,
         7,
@@ -199,7 +211,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         12,
         15,
         12,
@@ -215,7 +228,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         13,
         4,
         13,
@@ -231,7 +245,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         18,
         7,
         18,
@@ -247,7 +262,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         22,
         0,
         22,
@@ -263,7 +279,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         23,
         0,
         23,
@@ -279,7 +296,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         24,
         0,
         24,
@@ -295,7 +313,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         24,
         13,
         24,
@@ -311,7 +330,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         34,
         0,
         34,
@@ -327,7 +347,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         35,
         0,
         35,
@@ -343,7 +364,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         36,
         0,
         36,
@@ -359,7 +381,8 @@ input_file: fixtures/fragments/r/uses.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         37,
         0,
         37,

--- a/rust/src/methods/compile/code/snapshots/r_fragments@writes.R.snap
+++ b/rust/src/methods/compile/code/snapshots/r_fragments@writes.R.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/r/writes.R
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         10,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         0,
         16,
         0,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         12,
         2,
@@ -53,7 +56,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         2,
         25,
         2,
@@ -67,7 +71,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         4,
         0,
         4,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         5,
         29,
         5,
@@ -97,7 +103,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         8,
         17,
         8,
@@ -113,7 +120,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         8,
         31,
         8,
@@ -127,7 +135,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         12,
         12,
         12,
@@ -143,7 +152,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         12,
         18,
         12,
@@ -159,7 +169,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         14,
         10,
         14,
@@ -175,7 +186,8 @@ input_file: fixtures/fragments/r/writes.R
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         14,
         23,
         14,

--- a/rust/src/methods/compile/code/snapshots/ts_fragments@assigns.js.snap
+++ b/rust/src/methods/compile/code/snapshots/ts_fragments@assigns.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/assigns.js
 [
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         1,
         4,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         2,
         4,
         2,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         6,
         3,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         4,
         13,
         4,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         6,
         6,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         7,
         6,
         7,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         8,
         6,
         8,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         9,
         6,
         9,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         10,
         6,
         10,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         11,
         6,
         11,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         12,
         6,
         12,
@@ -199,7 +211,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         14,
         9,
         14,
@@ -215,7 +228,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         15,
         6,
         15,
@@ -231,7 +245,8 @@ input_file: fixtures/fragments/js/assigns.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         16,
         16,
         16,

--- a/rust/src/methods/compile/code/snapshots/ts_fragments@assigns.ts.snap
+++ b/rust/src/methods/compile/code/snapshots/ts_fragments@assigns.ts.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/ts/assigns.ts
 [
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         1,
         4,
         1,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         2,
         4,
         2,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         4,
         3,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         5,
         6,
         5,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         13,
         6,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         9,
         6,
         9,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         10,
         6,
         10,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         11,
         6,
         11,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         12,
         6,
         12,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         13,
         6,
         13,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         14,
         6,
         14,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         15,
         6,
         15,
@@ -199,7 +211,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         17,
         9,
         17,
@@ -215,7 +228,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         18,
         6,
         18,
@@ -231,7 +245,8 @@ input_file: fixtures/fragments/ts/assigns.ts
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         19,
         16,
         19,

--- a/rust/src/methods/compile/code/snapshots/ts_fragments@imports.js.snap
+++ b/rust/src/methods/compile/code/snapshots/ts_fragments@imports.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/imports.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         26,
         2,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         22,
         3,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         24,
         4,
@@ -52,7 +55,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         5,
         33,
         5,
@@ -67,7 +71,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         34,
         6,
@@ -82,7 +87,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         7,
         43,
         7,
@@ -97,7 +103,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         8,
         39,
         8,
@@ -112,7 +119,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         9,
         37,
         9,
@@ -127,7 +135,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         11,
         4,
         11,
@@ -143,7 +152,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         11,
         21,
         11,
@@ -158,7 +168,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         14,
         4,
         14,
@@ -174,7 +185,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         14,
         20,
         14,
@@ -190,7 +202,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         14,
         28,
         14,
@@ -205,7 +218,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         15,
         4,
         15,
@@ -221,7 +235,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         15,
         12,
         15,
@@ -237,7 +252,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         15,
         20,
         15,
@@ -252,7 +268,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         19,
         6,
         19,
@@ -268,7 +285,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         21,
         6,
         21,
@@ -284,7 +302,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         22,
         6,
         22,
@@ -300,7 +319,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         22,
         12,
         22,
@@ -316,7 +336,8 @@ input_file: fixtures/fragments/js/imports.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         22,
         20,
         22,

--- a/rust/src/methods/compile/code/snapshots/ts_fragments@reads.js.snap
+++ b/rust/src/methods/compile/code/snapshots/ts_fragments@reads.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/reads.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         15,
         0,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         27,
         1,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         4,
         3,
@@ -53,7 +56,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -69,7 +73,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         3,
         23,
         3,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -99,7 +105,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         4,
         13,
         4,
@@ -113,7 +120,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         9,
         6,
@@ -129,7 +137,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         7,
         14,
         7,
@@ -143,7 +152,8 @@ input_file: fixtures/fragments/js/reads.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         8,
         17,
         8,

--- a/rust/src/methods/compile/code/snapshots/ts_fragments@tags.js.snap
+++ b/rust/src/methods/compile/code/snapshots/ts_fragments@tags.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/tags.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -52,7 +55,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         2,
         0,
         2,
@@ -68,7 +72,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         0,
         3,
@@ -84,7 +89,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         5,
         0,
         5,
@@ -98,7 +104,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "read": [
+      "type": "Read",
+      "range": [
         5,
         0,
         5,
@@ -112,7 +119,8 @@ input_file: fixtures/fragments/js/tags.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         6,
         0,
         6,

--- a/rust/src/methods/compile/code/snapshots/ts_fragments@uses.js.snap
+++ b/rust/src/methods/compile/code/snapshots/ts_fragments@uses.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/uses.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         0,
         0,
@@ -23,7 +24,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         0,
         1,
@@ -39,7 +41,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         7,
         1,
@@ -55,7 +58,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         2,
         0,
         2,
@@ -71,7 +75,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         0,
         3,
@@ -87,7 +92,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         5,
         3,
@@ -103,7 +109,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -119,7 +126,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -135,7 +143,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         5,
         4,
@@ -151,7 +160,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         4,
         6,
@@ -167,7 +177,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         6,
         11,
         6,
@@ -183,7 +194,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         7,
         13,
         7,
@@ -199,7 +211,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         12,
         19,
         12,
@@ -214,7 +227,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         13,
         21,
         13,
@@ -229,7 +243,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         17,
         15,
         17,
@@ -245,7 +260,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         18,
         4,
         18,
@@ -261,7 +277,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         21,
         26,
         21,
@@ -277,7 +294,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         27,
         0,
         27,
@@ -293,7 +311,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         28,
         0,
         28,
@@ -309,7 +328,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         29,
         0,
         29,
@@ -325,7 +345,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         29,
         13,
         29,
@@ -341,7 +362,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         34,
         9,
         34,
@@ -357,7 +379,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         38,
         6,
         38,
@@ -373,7 +396,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         42,
         0,
         42,
@@ -389,7 +413,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         43,
         4,
         43,
@@ -405,7 +430,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         44,
         4,
         44,
@@ -421,7 +447,8 @@ input_file: fixtures/fragments/js/uses.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         45,
         6,
         45,

--- a/rust/src/methods/compile/code/snapshots/ts_fragments@writes.js.snap
+++ b/rust/src/methods/compile/code/snapshots/ts_fragments@writes.js.snap
@@ -7,7 +7,8 @@ input_file: fixtures/fragments/js/writes.js
 [
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         0,
         15,
         0,
@@ -22,7 +23,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         1,
         28,
         1,
@@ -37,7 +39,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         3,
         4,
         3,
@@ -53,7 +56,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         11,
         3,
@@ -69,7 +73,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         3,
         24,
         3,
@@ -83,7 +88,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         3,
         33,
         3,
@@ -99,7 +105,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         0,
         4,
@@ -115,7 +122,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         4,
         14,
         4,
@@ -129,7 +137,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "use": [
+      "type": "Use",
+      "range": [
         4,
         23,
         4,
@@ -145,7 +154,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "assign": [
+      "type": "Assign",
+      "range": [
         6,
         9,
         6,
@@ -161,7 +171,8 @@ input_file: fixtures/fragments/js/writes.js
   ],
   [
     {
-      "write": [
+      "type": "Write",
+      "range": [
         7,
         15,
         7,

--- a/rust/src/methods/compile/code/ts.rs
+++ b/rust/src/methods/compile/code/ts.rs
@@ -3,7 +3,7 @@ use super::{
     js::{self, handle_patterns},
     Compiler,
 };
-use crate::graphs::{resources, Relation, Resource};
+use crate::graphs::{relations, resources, Relation, Resource};
 use once_cell::sync::Lazy;
 use std::path::Path;
 
@@ -80,7 +80,7 @@ pub fn compile(path: &Path, code: &str) -> Vec<(Relation, Resource)> {
                     }
                 };
                 Some((
-                    Relation::Assign(range),
+                    relations::assigns(range),
                     resources::symbol(path, &name, kind),
                 ))
             }

--- a/rust/src/methods/compile/mod.rs
+++ b/rust/src/methods/compile/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     documents::DOCUMENTS,
-    graphs::{resources, Relation, Resource, NULL_RANGE},
+    graphs::{relations, resources, Relation, Resource, NULL_RANGE},
     traits::ToVecBlockContent,
     utils::{hash::str_sha256_bytes, path::merge, uuids},
 };
@@ -52,14 +52,15 @@ trait Compile {
 
 /// Identify a node
 ///
-/// If the node does not have an id, generate and assign one.
+/// If the node does not have an id, generate and assign one with a
+/// leading "_" to indicate it is generated.
 /// Return the node's id.
 macro_rules! identify {
     ($node:expr) => {
         if let Some(id) = $node.id.as_deref() {
             id.clone()
         } else {
-            let id = uuids::generate(uuids::Family::Node);
+            let id = ["_", &uuids::generate_chars(20)].concat();
             $node.id = Some(Box::new(id.clone()));
             id
         }
@@ -465,7 +466,7 @@ impl Compile for Parameter {
 
         context
             .relations
-            .push((subject, vec![(Relation::Assign(NULL_RANGE), object)]));
+            .push((subject, vec![(relations::assigns(NULL_RANGE), object)]));
         Ok(())
     }
 }

--- a/rust/src/sources.rs
+++ b/rust/src/sources.rs
@@ -1,5 +1,5 @@
 use crate::{
-    graphs::{resources, Relation, Triple},
+    graphs::{relations, resources, Triple},
     utils::schemas,
 };
 use async_trait::async_trait;
@@ -124,7 +124,7 @@ impl SourceDestination {
                 .map(|file| {
                     (
                         resources::source(name),
-                        Relation::Import(self.active),
+                        relations::imports(self.active),
                         resources::file(&project.join(file)),
                     )
                 })

--- a/rust/src/utils/uuids.rs
+++ b/rust/src/utils/uuids.rs
@@ -55,15 +55,19 @@ const CHARACTERS: [char; 62] = [
     'v', 'w', 'x', 'y', 'z',
 ];
 
+// Generate random characters
+pub fn generate_chars(size: usize) -> String {
+    nanoid!(size, &CHARACTERS)
+}
+
 // Generate a universally unique identifier
 pub fn generate(family: Family) -> String {
     let diff = chrono::Utc::now().timestamp() - EPOCH;
     let seconds =
         u32::try_from(diff).expect("Unable to convert to u32 (must be waaaay in the future");
-    let rand = nanoid!(18, &CHARACTERS);
+    let rand = generate_chars(18);
     format!("{}.{:010x}.{}", family.to_string(), seconds, rand)
 }
-
 #[cfg(test)]
 mod tests {
     use eyre::Result;


### PR DESCRIPTION
@alex-ketch This makes the changes to the JSON serialization of project graphs that we discussed except for making paths relative to the project (which I didn't have time to complete). Feel free to merge and work off this.

Rather than add another id to nodes, I have added an `index` property. This is a stable integer that should not change as nodes are added and removed and corresponds to the integers in the `from` and `to` properties of edges.

The `index` is the internal, stable identifier used by nodes in Rust, so it seemed better to use that than to create a new string based one. Note though that it is an integer id that initially corresponds to the position of the node in the `nodes` list but if nodes are removed, may not after updates.

```json
    {
      "type": "File",
      "path": "/home/nokome/stencila/repos/stencila/fixtures/projects/daggy/article.xml.media/fig1-v1.jpg",
      "index": 33
    },
    {
      "type": "File",
      "path": "/home/nokome/stencila/repos/stencila/fixtures/projects/daggy/article.json",
      "index": 34
    }
  ],
  "edges": [
    {
      "from": 0,
      "to": 1,
      "relation": {
        "type": "Assign",
        "range": [
          0,
          0,
          0,
          0
        ]
      }
    },
    {
      "from": 2,
      "to": 3,
      "relation": {
        "type": "Assign",
        "range": [
          0,
          0,
          0,
          0
        ]
      }
    },
```