### PR TITLE
fix(Documents): Make serialization of relations more robust and less lossy

### DIFF
--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -71,7 +71,7 @@ export interface Document {
    */
   previewable: boolean
   /**
-   * The set of relations between nodes in this document and other resources.
+   * The set of relations between this document, or nodes in this document, and other resources.
    *
    * Relations may be external (e.g. this document links to another file) or internal (e.g. the second code chunk uses a variable defined in the first code chunk).
    */
@@ -775,6 +775,45 @@ export type Error =
       type: 'InvalidUUID'
       family: string
       id: string
+      message: string
+    }
+  | {
+      type: 'NotSame'
+      message: string
+      [k: string]: unknown
+    }
+  | {
+      type: 'NotEqual'
+      message: string
+      [k: string]: unknown
+    }
+  | {
+      type: 'InvalidPatchOperation'
+      op: string
+      type_name: string
+      message: string
+    }
+  | {
+      type: 'InvalidPatchAddress'
+      address: string
+      type_name: string
+      message: string
+    }
+  | {
+      type: 'InvalidPatchName'
+      name: string
+      type_name: string
+      message: string
+    }
+  | {
+      type: 'InvalidPatchIndex'
+      index: number
+      type_name: string
+      message: string
+    }
+  | {
+      type: 'InvalidPatchValue'
+      type_name: string
       message: string
     }
   | {


### PR DESCRIPTION
Bug #1118 was caused when serializing a document that had `Resource` other than a `Node` i.e. a code `File` that was the resource itself. This now serializes the `relations` property as a vector of subject-relation-object triples.

```sh
cargo run --manifest-path cli/Cargo.toml -- documents show fixtures/projects/daggy/article.json --display json
```

```json
{
  "id": "do-RDwWsyGOQAFhRvML1anD",
  "path": "/home/nokome/stencila/repos/stencila/fixtures/projects/daggy/article.json",
  "project": "/home/nokome/stencila/repos/stencila/fixtures/projects/daggy",
  "temporary": false,
  "status": "synced",
  "name": "article.json",
  "format": {
    "known": true,
    "name": "json",
    "binary": false,
    "preview": true,
    "extensions": []
  },
  "previewable": true,
  "relations": [
    [
      {
        "type": "Node",
        "path": "/home/nokome/stencila/repos/stencila/fixtures/projects/daggy/article.json",
        "id": "no-Ak4EogDGZIt9n56U5KNZ",
        "kind": "CodeChunk"
      },
      {
        "type": "Use",
        "range": [
          0,
          8,
          0,
          12
        ]
      },
      {
        "type": "Symbol",
        "path": "/home/nokome/stencila/repos/stencila/fixtures/projects/daggy/article.json",
        "name": "data",
        "kind": ""
      }
    ],
```