### PR TITLE
fix(Desktop): Remove duplicated Window Close menu item

### DIFF
--- a/desktop/src/main/menu/window.ts
+++ b/desktop/src/main/menu/window.ts
@@ -21,7 +21,7 @@ export const baseWindowSubMenu: MenuItemConstructorOptions[] = [
         { type: 'separator' as const },
         { role: 'window' as const },
       ]
-    : [{ role: 'close' as const }]),
+    : []),
   { type: 'separator' },
   {
     label: 'Advanced',


### PR DESCRIPTION
Close #1176

Issue was the `close` menu item was located in two places on non-Mac platforms, once in the `File` menu and once in the `Window` menu.
This PR removes the instance from the Window menu to keep behaviour consistent with other apps, and use logic for determining the Close item shortcut (`Ctrl-W` to close Launcher or active document tab in Project window, and `Ctrl-Shift-W` to close entire Project window).