### PR TITLE
Fix: Jupyter Notebook / HTML patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,6 +4702,7 @@ dependencies = [
  "maplit",
  "mime_guess",
  "minidom",
+ "node-reshape",
  "notify",
  "once_cell",
  "parsers",

--- a/node/src/documents.rs
+++ b/node/src/documents.rs
@@ -73,7 +73,7 @@ pub fn read(mut cx: FunctionContext) -> JsResult<JsString> {
 
     let result = RUNTIME.block_on(async {
         match DOCUMENTS.get(id).await {
-            Ok(document) => document.lock().await.read().await,
+            Ok(document) => document.lock().await.read(true).await,
             Err(error) => Err(error),
         }
     });

--- a/rust/codec-html/src/encode.rs
+++ b/rust/codec-html/src/encode.rs
@@ -134,15 +134,14 @@ pub fn wrap_standalone(title: &str, theme: &str, html: &str) -> String {
 /// parent nodes when rendering themselves.
 pub struct EncodeContext<'a> {
     /// The root node being encoded
-    root: &'a Node,
+    pub root: &'a Node,
 
     /// Whether <img>, <audio> and <video> elements should use dataURIs
-    bundle: bool,
+    pub bundle: bool,
 }
 
-impl<'a> EncodeContext<'a> {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
+impl<'a> Default for EncodeContext<'a> {
+    fn default() -> Self {
         EncodeContext {
             root: &Node::Null(Null {}),
             bundle: false,

--- a/rust/stencila/Cargo.toml
+++ b/rust/stencila/Cargo.toml
@@ -175,6 +175,7 @@ graph = { path = "../graph", version = "0.0.0" }
 graph-triples = { path = "../graph-triples", version = "0.0.0" }
 kernels = { path = "../kernels", version = "0.0.0" }
 key-utils = { path = "../key-utils", version = "0.0.0" }
+node-reshape = { path = "../node-reshape", version = "0.0.0" }
 parsers = { path = "../parsers", version = "0.0.0" }
 path-utils = { path = "../path-utils", version = "0.0.0" }
 uuid-utils = { path = "../uuid-utils", version = "0.0.0" }

--- a/rust/stencila/src/documents.rs
+++ b/rust/stencila/src/documents.rs
@@ -14,6 +14,7 @@ use graph_triples::{Relation, Resource};
 use itertools::Itertools;
 use kernels::KernelSpace;
 use maplit::hashset;
+use node_reshape::reshape;
 use notify::DebouncedEvent;
 use once_cell::sync::Lazy;
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
@@ -449,14 +450,14 @@ impl Document {
     /// Read the document from the file system, update it and return its content.
     ///
     /// # Arguments
-    /// 
+    ///
     /// - `force_load`: if `false` then if the file is empty, or is the same as the existing
     ///                 content then do not load the content into the document
-    /// 
-    /// Using `force_load: false` is recommended when calling this function in response to 
+    ///
+    /// Using `force_load: false` is recommended when calling this function in response to
     /// file modification events as writes in quick succession can cause the file to be momentarily
     /// empty when read.
-    /// 
+    ///
     /// Sets `status` to `Synced`. For binary files, does not actually read the content
     /// but will update the document nonetheless (possibly delegating the actual read
     /// to a binary or plugin)
@@ -809,12 +810,9 @@ impl Document {
             return Ok(());
         };
 
-        #[cfg(feature = "reshape")]
-        {
-            // Reshape the `root` according to preferences
-            use crate::methods::reshape::{self, reshape};
-            reshape(&mut root, reshape::Options::default())?;
-        }
+        // Reshape the `root`
+        // TODO: Pass user options for reshaping through
+        reshape(&mut root, None)?;
 
         // Attempt to compile the `root` and update document intra- and inter- dependencies
         match compile(&mut root, &self.path, &self.project) {

--- a/rust/stencila/src/patches/inlines.rs
+++ b/rust/stencila/src/patches/inlines.rs
@@ -243,8 +243,24 @@ fn apply_transform(from: &InlineContent, to: &str) -> InlineContent {
 // Implementations for `InlineContent` structs, including related "full" structs
 // (e.g. `ImageObject` vs `ImageObjectSimple`) which are actually "works".
 
-patchable_struct!(Cite);
+replaceable_struct!(
+    Cite,
+    target,
+    citation_intent,
+    citation_mode,
+    citation_prefix,
+    citation_suffix,
+    content,
+    page_end,
+    page_start,
+    pagination
+);
+patchable_enum!(CitationIntentEnumeration);
+patchable_enum!(CiteCitationMode);
+patchable_enum!(CitePageEnd);
+patchable_enum!(CitePageStart);
 patchable_struct!(CiteGroup, items);
+
 patchable_struct!(CodeExpression, programming_language, text, output, errors);
 patchable_struct!(CodeFragment, programming_language, text);
 patchable_struct!(Delete, content);


### PR DESCRIPTION
This PR aims to fix any issues with rendering / patching (based on on-disk changes) HTML previews of Jupyter Notebooks (`.ipynb`).

Issues confirmed so far:

- patching of `Object` and `Array` code chunk outputs is not supported (this requires changes to the generation of the Rust types for these which in turn is waiting on merging the `schema` repo into this one).

- [x] rendering of Plotly and Altair images is broken (to do with HTML encoding).