### PR TITLE
Enable patching of article (and other creative works) properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ version = "0.0.0"
 dependencies = [
  "Inflector",
  "base64 0.13.0",
+ "chrono",
  "codec",
  "codec-txt",
  "html-escape",

--- a/rust/codec-html/Cargo.toml
+++ b/rust/codec-html/Cargo.toml
@@ -10,6 +10,7 @@ decode = ["kuchiki", "markup5ever"]
 encode = [
     "Inflector",
     "base64",
+    "chrono",
     "html-escape",
     "itertools",
     "mime_guess",
@@ -22,6 +23,7 @@ encode = [
 [dependencies]
 Inflector = { version = "0.11.4", optional = true }
 base64 = { version = "0.13.0", optional = true }
+chrono = {version = "0.4.19", optional = true }
 codec = { path = "../codec", version = "0.0.0" }
 codec-txt = { path = "../codec-txt", version = "0.0.0" }
 html-escape = { version = "0.2.9", optional = true }

--- a/rust/codec-html/src/encode.rs
+++ b/rust/codec-html/src/encode.rs
@@ -338,6 +338,7 @@ mod boxes;
 mod inlines;
 mod nodes;
 mod options;
+mod others;
 mod primitives;
 mod vecs;
 #[allow(clippy::deprecated_cfg_attr)]

--- a/rust/codec-html/src/encode/others.rs
+++ b/rust/codec-html/src/encode/others.rs
@@ -1,0 +1,25 @@
+use super::{attr, elem, EncodeContext, ToHtml};
+use chrono::{DateTime, Datelike};
+use stencila_schema::*;
+
+/// Encode a `Date` to HTML
+///
+/// Takes a similar approach to the encoding of `Cite` nodes in that it encodes parts
+/// of the date as spans which the theme can choose to reorder and/or hide.
+impl ToHtml for Date {
+    fn to_html(&self, _context: &EncodeContext) -> String {
+        let content = match DateTime::parse_from_rfc3339(&self.value) {
+            Ok(datetime) => [
+                elem("span", &[], &datetime.year().to_string()),
+                elem("span", &[], &datetime.month().to_string()),
+                elem("span", &[], &datetime.day().to_string()),
+            ]
+            .concat(),
+            Err(error) => {
+                tracing::warn!("While parsing date `{}`: {}", self.value, error);
+                self.value.clone()
+            }
+        };
+        elem("time", &[attr("datetime", &self.value)], &content)
+    }
+}

--- a/rust/stencila/src/patches/mod.rs
+++ b/rust/stencila/src/patches/mod.rs
@@ -515,6 +515,11 @@ impl Operation {
             Node
             CodeError
 
+            // Properties of creative works
+            Date
+            Person
+            Organization
+
             // Primitives
             String
             Number
@@ -537,7 +542,7 @@ impl Operation {
             return value.serialize(serializer);
         }
 
-        tracing::error!("Unhandled `value` type when serializing patch `Operation`");
+        tracing::error!("Unhandled value type when serializing patch operation");
         "<unserialized type>".serialize(serializer)
     }
 
@@ -585,6 +590,9 @@ impl Operation {
             CodeChunkCaption
             Node
             CodeError
+
+            // Properties of creative works
+            Date
 
             // Primitives
             String
@@ -1022,6 +1030,7 @@ mod vecs;
 mod blocks;
 mod inlines;
 mod nodes;
+mod others;
 mod works;
 
 #[allow(dead_code)]

--- a/rust/stencila/src/patches/others.rs
+++ b/rust/stencila/src/patches/others.rs
@@ -1,0 +1,52 @@
+use super::prelude::*;
+use stencila_schema::*;
+
+replaceable_struct!(Date, value);
+
+patchable_struct!(
+    Organization,
+    // All properties except `id` (as at 2021-11-18)
+    // Commented out properties have types that do not yet have a `impl Patchable`.
+
+    //address,
+    alternate_names,
+    //brands,
+    //contact_points,
+    departments,
+    //description,
+    //funders,
+    id,
+    //identifiers,
+    //images,
+    legal_name,
+    //logo,
+    //members,
+    name,
+    parent_organization,
+    url
+);
+
+patchable_struct!(
+    Person,
+    // All properties except `id` (as at 2021-11-18)
+    // Commented out properties have types that do not yet have a `impl Patchable`.
+
+    //address,
+    affiliations,
+    alternate_names,
+    //description,
+    emails,
+    family_names,
+    //funders,
+    given_names,
+    honorific_prefix,
+    honorific_suffix,
+    id,
+    //identifiers,
+    //images,
+    job_title,
+    member_of,
+    name,
+    telephone_numbers,
+    url
+);

--- a/rust/stencila/src/patches/structs.rs
+++ b/rust/stencila/src/patches/structs.rs
@@ -228,7 +228,9 @@ macro_rules! replaceable_struct {
             patchable_diff!();
 
             fn diff_same(&self, differ: &mut Differ, other: &Self) {
-                differ.replace(other);
+                if !self.is_equal(other).is_ok() {
+                    differ.replace(other)
+                }
             }
 
             patchable_struct_apply_replace!($( $field )*);

--- a/rust/stencila/src/patches/works.rs
+++ b/rust/stencila/src/patches/works.rs
@@ -1,12 +1,307 @@
 use super::prelude::*;
-use stencila_schema::{Article, CreativeWorkContent};
+use stencila_schema::*;
 
-patchable_struct!(Article, content);
+patchable_variants!(
+    CreativeWorkTypes,
+    CreativeWorkTypes::Article,
+    CreativeWorkTypes::CreativeWork,
+    CreativeWorkTypes::Periodical,
+    CreativeWorkTypes::PublicationIssue,
+    CreativeWorkTypes::PublicationVolume
+);
+
+// The follow structs has all properties (as at 2021-11-18) except `id`
+// Commented out properties have types that do not yet have a `impl Patchable`.
+// In the future is is likely that this code will be generated directly from
+// schema definitions
+
+patchable_struct!(
+    CreativeWork,
+    //about,
+    alternate_names,
+    authors,
+    //comments,
+    content,
+    date_accepted,
+    date_created,
+    date_modified,
+    date_published,
+    date_received,
+    description,
+    editors,
+    //funded_by,
+    funders,
+    genre,
+    //identifiers,
+    //images,
+    is_part_of,
+    keywords,
+    licenses,
+    maintainers,
+    name,
+    parts,
+    publisher,
+    references,
+    text,
+    title,
+    url,
+    version
+);
+
+patchable_struct!(
+    Article,
+    //about,
+    alternate_names,
+    authors,
+    //comments,
+    content,
+    date_accepted,
+    date_created,
+    date_modified,
+    date_published,
+    date_received,
+    description,
+    editors,
+    //funded_by,
+    funders,
+    genre,
+    //identifiers,
+    //images,
+    is_part_of,
+    keywords,
+    licenses,
+    maintainers,
+    name,
+    page_end,
+    page_start,
+    pagination,
+    parts,
+    publisher,
+    references,
+    text,
+    title,
+    url,
+    version
+);
+
+patchable_struct!(
+    Periodical,
+    //about,
+    alternate_names,
+    authors,
+    //comments,
+    content,
+    date_accepted,
+    date_created,
+    date_modified,
+    date_published,
+    date_received,
+    description,
+    editors,
+    //funded_by,
+    funders,
+    genre,
+    //identifiers,
+    //images,
+    is_part_of,
+    issns,
+    keywords,
+    licenses,
+    maintainers,
+    name,
+    parts,
+    publisher,
+    references,
+    text,
+    title,
+    url,
+    version
+);
+
+patchable_struct!(
+    PublicationIssue,
+    //about,
+    alternate_names,
+    authors,
+    //comments,
+    content,
+    date_accepted,
+    date_created,
+    date_modified,
+    date_published,
+    date_received,
+    description,
+    editors,
+    //funded_by,
+    funders,
+    genre,
+    //identifiers,
+    //images,
+    is_part_of,
+    issue_number,
+    keywords,
+    licenses,
+    maintainers,
+    name,
+    page_end,
+    page_start,
+    pagination,
+    parts,
+    publisher,
+    references,
+    text,
+    title,
+    url,
+    version
+);
+
+patchable_struct!(
+    PublicationVolume,
+    //about,
+    alternate_names,
+    authors,
+    //comments,
+    content,
+    date_accepted,
+    date_created,
+    date_modified,
+    date_published,
+    date_received,
+    description,
+    editors,
+    //funded_by,
+    funders,
+    genre,
+    //identifiers,
+    //images,
+    is_part_of,
+    keywords,
+    licenses,
+    maintainers,
+    name,
+    page_end,
+    page_start,
+    pagination,
+    parts,
+    publisher,
+    references,
+    text,
+    title,
+    url,
+    version,
+    volume_number
+);
+
+// To avoid bloat it is likely that a lot of these enums
+// will be generalized e.g. `OrganizationOrPerson`. `CreativeWorkTypesOrString`
+
+patchable_variants!(
+    CreativeWorkAuthors,
+    CreativeWorkAuthors::Organization,
+    CreativeWorkAuthors::Person
+);
+
+patchable_variants!(
+    CreativeWorkFunders,
+    CreativeWorkFunders::Organization,
+    CreativeWorkFunders::Person
+);
+
+patchable_variants!(
+    CreativeWorkMaintainers,
+    CreativeWorkMaintainers::Organization,
+    CreativeWorkMaintainers::Person
+);
+
+patchable_variants!(
+    CreativeWorkPublisher,
+    CreativeWorkPublisher::Organization,
+    CreativeWorkPublisher::Person
+);
 
 patchable_variants!(
     CreativeWorkContent,
     CreativeWorkContent::VecNode,
     CreativeWorkContent::String
+);
+
+patchable_variants!(
+    CreativeWorkLicenses,
+    CreativeWorkLicenses::CreativeWorkTypes,
+    CreativeWorkLicenses::String
+);
+
+patchable_variants!(
+    CreativeWorkReferences,
+    CreativeWorkReferences::CreativeWorkTypes,
+    CreativeWorkReferences::String
+);
+
+patchable_variants!(
+    CreativeWorkTitle,
+    CreativeWorkTitle::VecInlineContent,
+    CreativeWorkTitle::String
+);
+
+patchable_variants!(
+    CreativeWorkVersion,
+    CreativeWorkVersion::String,
+    CreativeWorkVersion::Number
+);
+
+patchable_variants!(
+    ArticlePageStart,
+    ArticlePageStart::String,
+    ArticlePageStart::Integer
+);
+
+patchable_variants!(
+    ArticlePageEnd,
+    ArticlePageEnd::String,
+    ArticlePageEnd::Integer
+);
+
+patchable_variants!(
+    PublicationIssuePageStart,
+    PublicationIssuePageStart::String,
+    PublicationIssuePageStart::Integer
+);
+
+patchable_variants!(
+    PublicationIssuePageEnd,
+    PublicationIssuePageEnd::String,
+    PublicationIssuePageEnd::Integer
+);
+
+patchable_variants!(
+    PublicationVolumePageStart,
+    PublicationVolumePageStart::String,
+    PublicationVolumePageStart::Integer
+);
+
+patchable_variants!(
+    PublicationVolumePageEnd,
+    PublicationVolumePageEnd::String,
+    PublicationVolumePageEnd::Integer
+);
+
+patchable_variants!(
+    PublicationIssueIssueNumber,
+    PublicationIssueIssueNumber::String,
+    PublicationIssueIssueNumber::Integer
+);
+
+patchable_variants!(
+    PublicationVolumeVolumeNumber,
+    PublicationVolumeVolumeNumber::String,
+    PublicationVolumeVolumeNumber::Integer
+);
+
+patchable_variants!(
+    ThingDescription,
+    ThingDescription::VecInlineContent,
+    ThingDescription::VecBlockContent,
+    ThingDescription::String
 );
 
 #[cfg(test)]

--- a/web/src/patches/checks.ts
+++ b/web/src/patches/checks.ts
@@ -74,7 +74,7 @@ export function isElement(node: Node | undefined): node is Element {
 /**
  * Assert that a DOM node is an element
  */
-export function assertElement(node: Node): asserts node is Element {
+export function assertElement(node: Node | undefined): asserts node is Element {
   assert(isElement(node), 'Expected element node')
 }
 

--- a/web/src/patches/dom/move.ts
+++ b/web/src/patches/dom/move.ts
@@ -16,6 +16,21 @@ export function applyMove(op: OperationMove, target?: ElementId): void {
   const [fromParent, fromSlot] = resolveParent(from, target)
   const [toParent, toSlot] = resolveParent(to, target)
 
+  if (fromParent === undefined) {
+    return console.warn(
+      `Unable to resolve address '${from.join(
+        ','
+      )}'; 'Move' operation will be ignored'`
+    )
+  }
+  if (toParent === undefined) {
+    return console.warn(
+      `Unable to resolve address '${to.join(
+        ','
+      )}'; 'Move' operation will be ignored'`
+    )
+  }
+
   assert(
     toParent.isSameNode(fromParent),
     'Expected the from and to addresses to have the same parent'

--- a/web/src/patches/dom/remove.ts
+++ b/web/src/patches/dom/remove.ts
@@ -20,7 +20,13 @@ export function applyRemove(op: OperationRemove, target?: ElementId): void {
 
   const [parent, slot] = resolveParent(address, target)
 
-  if (isElement(parent)) {
+  if (parent === undefined) {
+    console.warn(
+      `Unable to resolve address '${address.join(
+        ','
+      )}'; 'Remove' operation will be ignored'`
+    )
+  } else if (isElement(parent)) {
     if (isName(slot)) applyRemoveStruct(parent, slot, items)
     else applyRemoveVec(parent, slot, items)
   } else applyRemoveText(parent, slot, items)

--- a/web/src/patches/dom/replace.ts
+++ b/web/src/patches/dom/replace.ts
@@ -26,7 +26,13 @@ export function applyReplace(op: OperationReplace, target?: ElementId): void {
 
   const [parent, slot] = resolveParent(address, target)
 
-  if (isElement(parent)) {
+  if (parent === undefined) {
+    console.warn(
+      `Unable to resolve address '${address.join(
+        ','
+      )}'; 'Replace' operation will be ignored'`
+    )
+  } else if (isElement(parent)) {
     assertString(html)
     if (isName(slot)) applyReplaceStruct(parent, slot, items, html)
     else applyReplaceVec(parent, slot, items, html)

--- a/web/src/patches/dom/resolve.ts
+++ b/web/src/patches/dom/resolve.ts
@@ -43,12 +43,13 @@ export function resolveTarget(target?: ElementId): Element {
  * Resolve a slot in a parent DOM node.
  *
  * Note that the `parent` must be an `Element` but that the returned
- * node may be an `Element`, `Attr`, or `Text` DOM node.
+ * node may be an `Element`, `Attr`, or `Text` DOM node or `null` if
+ * the slot could not be resolved.
  */
 export function resolveSlot(
   parent: Element,
   slot: Slot
-): Element | Attr | Text {
+): Element | Attr | Text | undefined {
   if (isName(slot)) {
     // Is the slot represented by an attribute with a different name? If so translate it.
     const alias = STRUCT_ATTRIBUTE_ALIASES[slot]
@@ -123,7 +124,7 @@ export function resolveSlot(
     )
       return parent
 
-    throw panic(`Unable to resolve slot '${slot}'`)
+    return undefined
   } else {
     // Select the child at the slot index.
     const child: ChildNode | undefined = parent.childNodes[slot]
@@ -165,7 +166,7 @@ export function resolveSlot(
 export function resolveParent(
   address: Address,
   target?: ElementId
-): [Element | Attr | Text, Slot] {
+): [Element | Attr | Text | undefined, Slot] {
   const targetElement = resolveTarget(target)
 
   if (address.length === 0) {
@@ -177,10 +178,11 @@ export function resolveParent(
     return [parentElement, slot]
   }
 
-  let parentNode: Element | Attr | Text = targetElement
+  let parentNode: Element | Attr | Text | undefined = targetElement
   for (const slot of address.slice(0, -1)) {
     assertElement(parentNode)
     parentNode = resolveSlot(parentNode, slot)
+    if (parentNode === undefined) break
   }
 
   const slot = address[address.length - 1]
@@ -195,12 +197,13 @@ export function resolveParent(
 export function resolveNode(
   address: Address,
   target?: ElementId
-): Element | Attr | Text {
-  let node: Element | Attr | Text = resolveTarget(target)
+): Element | Attr | Text | undefined {
+  let node: Element | Attr | Text | undefined = resolveTarget(target)
 
   for (const slot of address) {
     assertElement(node)
     node = resolveSlot(node, slot)
+    if (node === undefined) break
   }
 
   return node

--- a/web/src/patches/dom/transform.ts
+++ b/web/src/patches/dom/transform.ts
@@ -20,7 +20,14 @@ export function applyTransform(
   const { address, from, to } = op
 
   const node = resolveNode(address, target)
-  if (isText(node)) applyTransformString(node, from, to)
+
+  if (parent === undefined) {
+    console.warn(
+      `Unable to resolve address '${address.join(
+        ','
+      )}'; 'Transform' operation will be ignored'`
+    )
+  } else if (isText(node)) applyTransformString(node, from, to)
   else if (isElement(node)) applyTransformElem(node, from, to)
   else throw panic(`Unexpected transform node`)
 }


### PR DESCRIPTION
This enables patches for properties of `Article` (and other creative work node types) such as `authors`, `datePublished`, and `references`.

In the process it makes some improvements in the `web` module to avoid panics when addresses can not be resolved (e.g. when a property is not yet encoded to HTML e.g `datePublished` currently is not).

@alex-ketch I went ahead and did because I thought it would be less work than it ended up being (of course!) and I thought it would avoid confusion in the future ("why is the title not updating"). I also points towards some additional work that needs to be done for patches in general (which I will set up an issue for).

Will merge; mainly FYI.