### PR TITLE
Desktop: Reduce number of themes, save changes to project settings

### DIFF
--- a/desktop/src/main/project/index.ts
+++ b/desktop/src/main/project/index.ts
@@ -7,6 +7,7 @@ import {
   ProjectsOpenUsingFilePicker,
   ProjectsUnsubscribe,
   ProjectsWindowOpen,
+  ProjectsWrite,
 } from '../../preload/types'
 import { makeHandlers, removeChannelHandlers } from '../utils/handler'
 import { handle, valueToSuccessResult } from '../utils/ipc'
@@ -75,6 +76,13 @@ const registerProjectHandlers = () => {
     CHANNEL.PROJECTS_UNSUBSCRIBE,
     async (_ipcEvent, directoryPath, topics) => {
       return dispatch.projects.unsubscribe(directoryPath, topics)
+    }
+  )
+
+  handle<ProjectsWrite>(
+    CHANNEL.PROJECTS_WRITE,
+    async (_ipcEvent, projectPath, settings) => {
+      return dispatch.projects.write(projectPath, settings)
     }
   )
 }

--- a/desktop/src/renderer/client.ts
+++ b/desktop/src/renderer/client.ts
@@ -1,5 +1,5 @@
 import { EntityId } from '@reduxjs/toolkit'
-import type { Result, ResultFailure, ResultSuccess } from 'stencila'
+import type { Project, Result, ResultFailure, ResultSuccess } from 'stencila'
 import { CHANNEL } from '../preload/channels'
 import { AppConfigStore, ConfigPaths } from '../preload/types'
 
@@ -204,6 +204,10 @@ export const client = {
         .invoke(CHANNEL.PROJECTS_OPEN_FROM_FILE_PICKER)
         .then(unwrapOrThrow),
     new: () => window.api.invoke(CHANNEL.PROJECTS_NEW).then(unwrapOrThrow),
+    write: (path: string, updates: Project) =>
+      window.api
+        .invoke(CHANNEL.PROJECTS_WRITE, path, updates)
+        .then(unwrapOrThrow),
     unsubscribe: (path: string, topics: string[]) =>
       window.api
         .invoke(CHANNEL.PROJECTS_UNSUBSCRIBE, path, topics)

--- a/desktop/src/renderer/components/app-document/app-document-preview/app-document-preview.tsx
+++ b/desktop/src/renderer/components/app-document/app-document-preview/app-document-preview.tsx
@@ -5,17 +5,15 @@ import { pipe } from 'fp-ts/function'
 import { File } from 'stencila'
 import { state } from '../../../store'
 import { selectDoc } from '../../../store/documentPane/documentPaneSelectors'
+import { updateProjectSettings } from '../../../store/project/projectSelectors'
 import { SessionsStoreKeys, sessionStore } from '../../../store/sessionStore'
 
 const themes = {
   elife: 'eLife',
-  f1000: 'f1000',
   giga: 'GigaScience',
-  latex: 'latex',
-  nature: 'nature',
-  plos: 'PLoS',
+  latex: 'LaTeX',
   stencila: 'Stencila',
-  tufte: 'tufte',
+  tufte: 'Tufte',
   wilmore: 'Wilmore',
 }
 
@@ -52,6 +50,7 @@ export class AppDocumentPreview {
 
   private onThemeChange = (e: Event) => {
     this.theme = (e.target as HTMLSelectElement).value
+    updateProjectSettings({ theme: this.theme })
   }
 
   private getServerUrl = (): URL | undefined =>

--- a/desktop/src/renderer/store/project/entities.ts
+++ b/desktop/src/renderer/store/project/entities.ts
@@ -1,4 +1,4 @@
-import { schema } from 'normalizr'
+import { schema, denormalize } from 'normalizr'
 import { Project } from '../../types'
 
 export type NormalizedProject = Omit<Project, 'files'> & {
@@ -22,3 +22,9 @@ export const projectEntity = new schema.Entity(
     idAttribute: 'path',
   }
 )
+
+export const denormalizeProject = (
+  normalizedProject: NormalizedProject
+): Project => {
+  return denormalize(normalizedProject, projectEntity, fileEntity)
+}


### PR DESCRIPTION
- From the list of available themes I've dropped F1000, Nature, and PLoS themes until we've had time to review and refine them.
- Changing the preview theme now persists the setting to the project.json file

Close #1248