### PR TITLE
chore(Errors): Remove deprecated "sideband" error functions

### DIFF
--- a/node/src/dispatch.ts
+++ b/node/src/dispatch.ts
@@ -35,8 +35,6 @@ export type Result<V = unknown> = ResultSuccess<V> | ResultFailure
 export function dispatchFn<F extends AnyFunction>(
   callback: F
 ): Result<ReturnType<F>> {
-  addon.errorsStart()
-
   let ok = true
   let value
   let errors: Error[] = []
@@ -56,11 +54,6 @@ export function dispatchFn<F extends AnyFunction>(
       ]
     }
   }
-
-  try {
-    const sidebandErrors = JSON.parse(addon.errorsStop())
-    errors = [...sidebandErrors, ...errors]
-  } catch {}
 
   if (ok) {
     return { ok, value, errors }

--- a/node/src/errors.rs
+++ b/node/src/errors.rs
@@ -2,34 +2,19 @@ use neon::{
     context::{Context, FunctionContext},
     handle::Managed,
     result::JsResult,
-    types::{JsString, JsUndefined},
+    types::JsString,
 };
 use stencila::{
     errors::{self, Error},
     eyre, serde_json,
 };
 
-use crate::prelude::{to_json, to_json_or_throw};
+use crate::prelude::to_json_or_throw;
 
 /// Get the module's schemas
 pub fn schema(cx: FunctionContext) -> JsResult<JsString> {
     let schemas = errors::schema();
     to_json_or_throw(cx, schemas)
-}
-
-/// Start collecting errors
-pub fn start(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-    errors::start();
-    Ok(cx.undefined())
-}
-
-/// Stop collecting errors and return them as a JSON array
-pub fn stop(cx: FunctionContext) -> JsResult<JsString> {
-    let errors: Vec<serde_json::Value> = errors::stop()
-        .iter()
-        .map(|error| error_to_json(error))
-        .collect();
-    to_json(cx, errors)
 }
 
 /// Throw an error as JSON

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -83,8 +83,6 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
     cx.export_function("loggingTest", logging::test)?;
 
     cx.export_function("errorsSchema", errors::schema)?;
-    cx.export_function("errorsStart", errors::start)?;
-    cx.export_function("errorsStop", errors::stop)?;
 
     Ok(())
 }


### PR DESCRIPTION
The original intent here was to be able to associate non-fatal errors with user
actions in the desktop. But the use of the `attempt` function in Rust caused
confusion with  error propogation, particularly when using the CLI.
Furthermore, we alreading us`tracing:warn` and `tracing::error` for reporting
non-fatal errors so there was duplication and a lack of consistency on what
errors should go where.
