### PR TITLE
feat(Web): Attempt to reconnect to server

### DIFF
--- a/web/src/client.ts
+++ b/web/src/client.ts
@@ -20,7 +20,10 @@ export async function connect(
   if (typeof token === 'string' && token.length > 0)
     connectUrl += `&token=${token}`
 
-  const client = new Client(connectUrl)
+  const client = new Client(connectUrl, {
+    reconnect_interval: 1000 + 3000 * Math.random(), // random interval between 1 and 4 seconds
+    max_reconnects: 300, // attempt to reconnect for ~5-15 minutes
+  })
   return new Promise<Client>((resolve) =>
     client.on('open', () => resolve(client))
   )


### PR DESCRIPTION
Close #1198

This PR deviates slightly from the plan outlined in the original issue.
> {
   reconnect_interval: 1000 + 4000 * Math.random() # 1-5 seconds
   max_reconnects: 0 # unlimited
}


I've adjusted the parameters so that reconnection attempts continue for around 5 to 15 minutes.
Intent here being that if a server is going to respond, it should hopefully do so within this time period. If it doesn't, then there's likely a bigger issue at hand, and we avoid an endless runaway process if a client is left open in a background tab or some similar scenario. This should also hopefully reduce the impact of the "thundering herd" mentioned in the issue description"

If you'd like @nokome, I can also engage the underlying `rpc-websockets` library maintainers to gauge their willingness to accept a PR to support passing a function to the `reconnect_interval`.