### PR TITLE
fix(HTML encoding): Refinement to encoding of code dependencies

### DIFF
--- a/rust/codec-html/src/encode/blocks.rs
+++ b/rust/codec-html/src/encode/blocks.rs
@@ -151,7 +151,7 @@ impl ToHtml for CodeChunk {
         );
 
         let dependents = elem_placeholder(
-            "stencila-code-dependents",
+            "stencila-code-dependencies",
             &[attr_prop("code-dependents"), attr_slot("code-dependents")],
             &self.code_dependents,
             context,

--- a/rust/codec-html/src/encode/others.rs
+++ b/rust/codec-html/src/encode/others.rs
@@ -32,16 +32,17 @@ impl ToHtml for Date {
 impl ToHtml for CodeExecutableCodeDependencies {
     fn to_html(&self, _context: &EncodeContext) -> String {
         let (
-            node_type,
+            node_kind,
             id,
+            label,
+            programming_language,
             execute_auto,
             execute_required,
             execute_status,
-            programming_language,
-            name,
         ) = match self {
             CodeExecutableCodeDependencies::CodeChunk(CodeChunk {
                 id,
+                label,
                 programming_language,
                 execute_auto,
                 execute_required,
@@ -50,30 +51,36 @@ impl ToHtml for CodeExecutableCodeDependencies {
             }) => (
                 "CodeChunk",
                 id,
+                label.as_ref().map(|label| label.as_str()),
+                Some(programming_language),
                 execute_auto
                     .as_ref()
                     .map_or("Needed", |value| value.as_ref()),
                 execute_required,
                 execute_status,
-                Some(programming_language),
-                None,
             ),
             CodeExecutableCodeDependencies::Parameter(Parameter { id, name, .. }) => (
                 "Parameter",
                 id,
+                Some(name.as_str()),
+                None,
                 "Needed",
                 &None,
                 &None,
-                None,
-                Some(name.as_str()),
             ),
         };
         elem(
             "stencila-code-dependency",
             &[
-                attr("node-type", node_type),
+                attr("node-kind", node_kind),
                 id.as_ref()
                     .map_or("".to_string(), |value| attr("node-id", value.as_str())),
+                label
+                    .as_ref()
+                    .map_or("".to_string(), |value| attr("label", value.as_ref())),
+                programming_language
+                    .as_ref()
+                    .map_or("".to_string(), |value| attr("programming-language", value)),
                 attr("execute-auto", execute_auto),
                 execute_required.as_ref().map_or("".to_string(), |value| {
                     attr("execute-required", value.as_ref())
@@ -81,11 +88,6 @@ impl ToHtml for CodeExecutableCodeDependencies {
                 execute_status.as_ref().map_or("".to_string(), |value| {
                     attr("execute-status", value.as_ref())
                 }),
-                programming_language
-                    .as_ref()
-                    .map_or("".to_string(), |value| attr("programming-language", value)),
-                name.as_ref()
-                    .map_or("".to_string(), |value| attr("name", value)),
             ],
             "",
         )
@@ -95,46 +97,60 @@ impl ToHtml for CodeExecutableCodeDependencies {
 /// Encode a dependent of an executable code node
 impl ToHtml for CodeExecutableCodeDependents {
     fn to_html(&self, _context: &EncodeContext) -> String {
-        let (node_type, id, execute_auto, execute_required, execute_status, programming_language) =
-            match self {
-                CodeExecutableCodeDependents::CodeChunk(CodeChunk {
-                    id,
-                    programming_language,
-                    execute_auto,
-                    execute_required,
-                    execute_status,
-                    ..
-                }) => (
-                    "CodeChunk",
-                    id,
-                    execute_auto
-                        .as_ref()
-                        .map_or("Needed", |value| value.as_ref()),
-                    execute_required,
-                    execute_status,
-                    programming_language,
-                ),
-                CodeExecutableCodeDependents::CodeExpression(CodeExpression {
-                    id,
-                    programming_language,
-                    execute_required,
-                    execute_status,
-                    ..
-                }) => (
-                    "CodeExpression",
-                    id,
-                    "Needed",
-                    execute_required,
-                    execute_status,
-                    programming_language,
-                ),
-            };
+        let (
+            node_kind,
+            id,
+            label,
+            programming_language,
+            execute_auto,
+            execute_required,
+            execute_status,
+        ) = match self {
+            CodeExecutableCodeDependents::CodeChunk(CodeChunk {
+                id,
+                label,
+                programming_language,
+                execute_auto,
+                execute_required,
+                execute_status,
+                ..
+            }) => (
+                "CodeChunk",
+                id,
+                label,
+                programming_language,
+                execute_auto
+                    .as_ref()
+                    .map_or("Needed", |value| value.as_ref()),
+                execute_required,
+                execute_status,
+            ),
+            CodeExecutableCodeDependents::CodeExpression(CodeExpression {
+                id,
+                programming_language,
+                execute_required,
+                execute_status,
+                ..
+            }) => (
+                "CodeExpression",
+                id,
+                &None,
+                programming_language,
+                "Needed",
+                execute_required,
+                execute_status,
+            ),
+        };
         elem(
-            "stencila-code-dependent",
+            "stencila-code-dependency",
             &[
-                attr("node-type", node_type),
+                attr("node-kind", node_kind),
                 id.as_ref()
                     .map_or("".to_string(), |value| attr("node-id", value.as_str())),
+                label
+                    .as_ref()
+                    .map_or("".to_string(), |value| attr("label", value.as_ref())),
+                attr("programming-language", programming_language),
                 attr("execute-auto", execute_auto),
                 execute_required.as_ref().map_or("".to_string(), |value| {
                     attr("execute-required", value.as_ref())
@@ -142,7 +158,6 @@ impl ToHtml for CodeExecutableCodeDependents {
                 execute_status.as_ref().map_or("".to_string(), |value| {
                     attr("execute-status", value.as_ref())
                 }),
-                attr("programming-language", programming_language),
             ],
             "",
         )

--- a/rust/codec-html/src/snapshots/encode_nodes@code-chunk.json.snap
+++ b/rust/codec-html/src/snapshots/encode_nodes@code-chunk.json.snap
@@ -10,8 +10,8 @@ input_file: fixtures/nodes/code-chunk.json
   <pre data-itemprop="text" slot="text"># Some code</pre>
   <stencila-code-dependencies data-itemprop="codeDependencies" slot="code-dependencies">
   </stencila-code-dependencies>
-  <stencila-code-dependents data-itemprop="codeDependents" slot="code-dependents">
-  </stencila-code-dependents>
+  <stencila-code-dependencies data-itemprop="codeDependents" slot="code-dependents">
+  </stencila-code-dependencies>
   <div data-itemprop="outputs" slot="outputs">
     <span itemtype="http://schema.org/Text" itemscope>a string output</span>
     <span itemtype="http://schema.stenci.la/Boolean" itemscope>true</span>

--- a/rust/node-execute/src/compile.rs
+++ b/rust/node-execute/src/compile.rs
@@ -188,6 +188,7 @@ fn compile_patches_and_send(
                             Node::CodeChunk(dependency) => {
                                 Some(CodeExecutableCodeDependencies::CodeChunk(CodeChunk {
                                     id: dependency.id.clone(),
+                                    label: dependency.label.clone(),
                                     programming_language: dependency.programming_language.clone(),
                                     execute_auto: dependency.execute_auto.clone(),
                                     execute_required: Some(new_execute_required.clone()),
@@ -215,6 +216,7 @@ fn compile_patches_and_send(
                             Node::CodeChunk(dependant) => {
                                 Some(CodeExecutableCodeDependents::CodeChunk(CodeChunk {
                                     id: dependant.id.clone(),
+                                    label: dependant.label.clone(),
                                     programming_language: dependant.programming_language.clone(),
                                     execute_auto: dependant.execute_auto.clone(),
                                     execute_required: Some(new_execute_required.clone()),

--- a/themes/src/themes/wilmore/styles.css
+++ b/themes/src/themes/wilmore/styles.css
@@ -440,7 +440,6 @@ h6:--Heading {
   padding: 0.25em 1em;
 }
 
-:--Article a,
 :--Link {
   transition: color 125ms ease-in-out;
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -75,7 +75,7 @@ export const main = (
 
     documents.listen(client, clientId, document.id)
 
-    window.addEventListener('appload', initComponents)
+    initComponents()
 
     return [client, document, session]
   }


### PR DESCRIPTION
Makes several changes to HTML encoding of the `code_dependencies` and `code_dependents` properties of `CodeChunk`s, and the `code_dependencies` property of `CodeExpression`s (they have no dependents):

- Use `<stencila-code-dependencies>` and `<stencila-code-dependency>` custom elements for both properties but keep as separate lists distinguishable by `slot` attribute

- Use `node-kind` instead of `node-type` to avoid conflict with native DOM attribute name

- Add `label` property and use for `CodeChunk.label` and `Parameter.name` e.g.

```html
<stencila-code-dependency node-kind="Parameter" node-id="pa-1" label="c" execute-auto="Needed">
</stencila-code-dependency>
```
