### PR TITLE
chore(docs): review of manual cli install instructions for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To install a specific version, append `-s vX.X.X`. Or, if you'd prefer to do it 
 
 ```console
 tar xvf stencila-*.tar.xz
+cd stencila-*/
 sudo mv -f stencila /usr/local/bin # or wherever you prefer
 ```
 


### PR DESCRIPTION
- [x] review auto install script
- [x] review manual install via tarball
- [x] review docker (after amendment by @nokome )

This PR adds one line to `README.md` cli install instructions: Users need to `cd` into the recently extracted directory before moving the binary to `/usr/local/bin`. 
