### PR TITLE
Feature/sourceview text functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12765,6 +12765,7 @@
       "version": "2.0.0-alpha.23",
       "license": "Apache-2.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.11.1",
         "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-html": "6.4.7",
         "@codemirror/lang-json": "6.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -903,6 +903,17 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/commands": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.2.tgz",
+      "integrity": "sha512-tjoi4MCWDNxgIpoLZ7+tezdS9OEB6pkiDKhfKx9ReJ/XBcs2G2RXIu+/FxXBlWsPTsz6C9q/r4gjzrsxpcnqCQ==",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.2.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
     "node_modules/@codemirror/lang-css": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.2.1.tgz",
@@ -12754,6 +12765,7 @@
       "version": "2.0.0-alpha.23",
       "license": "Apache-2.0",
       "dependencies": {
+        "@codemirror/commands": "^6.3.2",
         "@codemirror/lang-html": "6.4.7",
         "@codemirror/lang-json": "6.0.1",
         "@codemirror/lang-markdown": "6.2.3",

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
     "unused": "depcheck --quiet --ignores '@parcel/*,prosemirror-*' --ignore-patterns '.eslintrc*'"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.11.1",
     "@codemirror/commands": "^6.3.2",
     "@codemirror/lang-html": "6.4.7",
     "@codemirror/lang-json": "6.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -45,6 +45,7 @@
     "unused": "depcheck --quiet --ignores '@parcel/*,prosemirror-*' --ignore-patterns '.eslintrc*'"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.3.2",
     "@codemirror/lang-html": "6.4.7",
     "@codemirror/lang-json": "6.0.1",
     "@codemirror/lang-markdown": "6.2.3",

--- a/web/src/views/source.ts
+++ b/web/src/views/source.ts
@@ -254,7 +254,7 @@ export class SourceView extends LitElement {
    * 
    * Overrides some of the default styles used by CodeMirror.
    */
-  static css = css`
+  static styles = css`
     .cm-editor {
       border: 1px solid rgb(189, 186, 186);
       height: 30vh;

--- a/web/src/views/source.ts
+++ b/web/src/views/source.ts
@@ -70,7 +70,7 @@ export class SourceView extends LitElement {
   format: string = "markdown";
 
   /**
-   * property that sets editor line wrapping config
+   * Turn on/off editor line wrapping
    */
   @property({ attribute: "line-wrapping", type: Boolean })
   lineWrap: boolean = true;
@@ -212,11 +212,10 @@ export class SourceView extends LitElement {
 
 
   /**
-   * Components update function, 
-   * fires when a property value has been changed
-   * @param changedProperties 
+   * Override `LitElement.update` to dispatch any changes to editor config
+   * to the editor. 
    */
-  protected async update(changedProperties: Map<string, string | boolean>) {
+  override update(changedProperties: Map<string, string | boolean>) {
     super.update(changedProperties)
 
     if (changedProperties.has('lineWrap')) {
@@ -229,8 +228,8 @@ export class SourceView extends LitElement {
   }
 
   /**
-   * Override so that the `CodeMirrorView` is instantiated _after_ this
-   * element has a `renderRoot`.
+   * Override `LitElement.connectedCallback` so that the `CodeMirrorView` is instantiated
+   * _after_ this element has a `renderRoot`.
    */
   override connectedCallback() {
     super.connectedCallback();
@@ -261,6 +260,17 @@ export class SourceView extends LitElement {
     }
   `;
 
+  render() {
+    return html`
+      <div>
+        <div id="codemirror"></div>
+        <div>
+          ${this.renderControls()}
+        </div>
+      </div>
+    `;
+  }
+
   private renderControls() {
     return html`
       <div class="mt-4 flex">
@@ -283,16 +293,5 @@ export class SourceView extends LitElement {
         />
       </label>
     `
-  }
-
-  render() {
-    return html`
-      <div>
-        <div id="codemirror"></div>
-        <div>
-          ${this.renderControls()}
-        </div>
-      </div>
-    `;
   }
 }

--- a/web/src/views/source.ts
+++ b/web/src/views/source.ts
@@ -1,4 +1,9 @@
 import {
+  history,
+  historyKeymap,
+  indentWithTab,
+} from '@codemirror/commands'
+import {
   bracketMatching,
   defaultHighlightStyle,
   indentOnInput,
@@ -7,10 +12,16 @@ import {
   syntaxHighlighting,
   StreamLanguage,
 } from "@codemirror/language";
-import { Extension, Compartment, StateEffect } from "@codemirror/state";
+import { 
+  Extension,
+  Compartment,
+  StateEffect,
+  // EditorState
+} from "@codemirror/state";
 import {
   EditorView as CodeMirrorView,
   highlightActiveLineGutter,
+  keymap,
   lineNumbers,
 } from "@codemirror/view";
 import { LitElement, html, css } from "lit";
@@ -181,19 +192,17 @@ export class SourceView extends LitElement {
     const lineWrapping = this.lineWrappingConfig.of(CodeMirrorView.lineWrapping)
 
     return [
-      langExt,
-      bracketMatching(),
       indentOnInput(),
+      history(),
+      bracketMatching(),
       syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
       lineNumbers(),
       highlightActiveLineGutter(),
-      lineWrapping
+      keymap.of([indentWithTab, ...historyKeymap]), 
+      langExt,
+      lineWrapping,
     ];
   }
-
-
-
-
 
   /**
    * Override so that the `CodeMirrorView` is instantiated _after_ this


### PR DESCRIPTION
** details **

Add in word wrapping, with a checkbox to toggle on and off.

Add in histroy with default key mappings for undo/redo undo select/redo-select.

Add in the base autocomplete for code mirror, with some keymappings

Add in some more basic editor extensions: bracket highlighting, fold gutter, dropCursor

I have added the indentOnInput() to the extenions, however this soes not seem to have the desired effect, at least from what I was expecting ,we can discuss later.


** related issues ** #1791 