### PR TITLE
feat(views/source): add in doc search key mappings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -888,6 +888,16 @@
         "crelt": "^1.0.5"
       }
     },
+    "node_modules/@codemirror/search": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.5.tgz",
+      "integrity": "sha512-PIEN3Ke1buPod2EHbJsoQwlbpkz30qGZKcnmH1eihq9+bPQx8gelauUwLYaY4vBOuBAuEhmpDLii4rj/uO0yMA==",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "crelt": "^1.0.5"
+      }
+    },
     "node_modules/@codemirror/state": {
       "version": "6.3.3",
       "license": "MIT"
@@ -10467,6 +10477,7 @@
         "@codemirror/lang-xml": "6.0.2",
         "@codemirror/language": "6.9.3",
         "@codemirror/legacy-modes": "6.3.3",
+        "@codemirror/search": "^6.5.5",
         "@codemirror/state": "6.3.3",
         "@codemirror/view": "6.22.2",
         "@lit/context": "1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -56,6 +56,7 @@
     "@codemirror/lang-xml": "6.0.2",
     "@codemirror/language": "6.9.3",
     "@codemirror/legacy-modes": "6.3.3",
+    "@codemirror/search": "^6.5.5",
     "@codemirror/state": "6.3.3",
     "@codemirror/view": "6.22.2",
     "@lit/context": "1.1.0",

--- a/web/src/views/source.ts
+++ b/web/src/views/source.ts
@@ -14,7 +14,7 @@ import {
   syntaxHighlighting,
   StreamLanguage,
 } from "@codemirror/language";
-import { searchKeymap, search } from '@codemirror/search'
+import { searchKeymap, search } from "@codemirror/search";
 import { Extension, Compartment, StateEffect } from "@codemirror/state";
 import {
   dropCursor,

--- a/web/src/views/source.ts
+++ b/web/src/views/source.ts
@@ -14,6 +14,7 @@ import {
   syntaxHighlighting,
   StreamLanguage,
 } from "@codemirror/language";
+import { searchKeymap, search } from '@codemirror/search'
 import { Extension, Compartment, StateEffect } from "@codemirror/state";
 import {
   dropCursor,
@@ -197,6 +198,7 @@ export class SourceView extends LitElement {
       indentWithTab,
       ...historyKeymap,
       ...completionKeymap,
+      ...searchKeymap,
       { key: "Ctrl-Space", run: startCompletion },
     ]);
 
@@ -204,6 +206,7 @@ export class SourceView extends LitElement {
       langExt,
       keyMaps,
       history(),
+      search({ top: true }),
       lineNumbers(),
       foldGutter(),
       lineWrapping,
@@ -277,7 +280,7 @@ export class SourceView extends LitElement {
 
   private renderControls() {
     return html`
-      <div class="mt-4 flex">
+      <div class="mb-4 flex">
         <div>${this.renderFormatSelect()} ${this.renderLineWrapCheckbox()}</div>
       </div>
     `;


### PR DESCRIPTION
**details**

add the search key mappings from @codemirror/search to enable the crtl-F

have set the search interface controls to appear at the top.

currently using default options for keyMappings and search config,

The codemirror search options will only open if the editor is in focus, otherwise it will default the browser search. if we want to set this that is always focuses on the I suggest creating this in another issues.

The key mappings and the further config options can be found here: https://codemirror.net/docs/ref/#search

**related issues**: closes#1807 
