### PR TITLE
feat(prompts): add the document and any specific node to context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,11 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 name = "agent"
 version = "0.0.0"
 dependencies = [
+ "codecs",
  "common",
  "minijinja",
  "rust-embed",
+ "schema",
  "self_cell",
 ]
 

--- a/prompts/context/document.md
+++ b/prompts/context/document.md
@@ -1,0 +1,5 @@
+Nulla eu proident culpa anim commodo ex do. Dolor laborum reprehenderit amet ex voluptate ut anim cupidatat est cupidatat adipisicing tempor. In eiusmod consectetur eu ullamco irure. Nisi aute qui in commodo non enim proident duis ea eu adipisicing dolore. Tempor Lorem do magna culpa cillum ut deserunt ut Lorem aliquip esse id. Cupidatat proident reprehenderit ipsum proident.
+
+Dolore anim ut consequat consequat non commodo. Enim ex ad ipsum eiusmod exercitation tempor excepteur laboris sint mollit enim in aliquip fugiat. Dolor occaecat enim dolor pariatur amet dolore.
+
+Pariatur amet laboris aliquip est enim reprehenderit ea ullamco aute anim. Sit consectetur incididunt et dolore anim magna dolor elit eu. Ad incididunt esse proident est ullamco qui.

--- a/prompts/context/node.yaml
+++ b/prompts/context/node.yaml
@@ -1,0 +1,5 @@
+type: CodeChunk
+programmingLanguage: python
+code: |-
+  # Some python code
+  a = 3

--- a/prompts/test/echo.md
+++ b/prompts/test/echo.md
@@ -10,6 +10,13 @@ The following is an example.
 Input:
 
 <user-instruction>What is the highest mountain on Earth?</user-instruction>
+
+<document-type>Article</document-type>
+<document-content><p>The highest mountain</p></document-content>
+
+<node-type>CodeBlock</node-type>
+<node-content><pre>height = 8848.86</pre></node-content>
+
 <agent-name>mountain-agent</agent-name>
 <provider-name>mountain-provider</provider-name>
 <model-name>mountain-model</model-name>
@@ -19,6 +26,13 @@ Input:
 Output:
 
 user-instruction: What is the highest mountain on Earth?
+
+document-type: Article
+document-content: <p>The highest mountain</p>
+
+node-type: CodeBlock
+node-content: <pre>height = 8848.86</pre>
+
 agent-name: mountain-agent
 provider-name: mountain-provider
 model-name: mountain-model
@@ -28,6 +42,13 @@ current-timestamp: 2023-12-14T00:04:42.822319855+00:00
 ---
 
 <user-instruction>{{ user_instruction }}</user-instruction>
+
+<document-type>{{ document.type }}</document-type>
+<document-content>{{ document_content }}</document-content>
+
+<node-type>{{ node.type }}</node-type>
+<node-content>{{ node_content }}</node-content>
+
 <agent-name>{{ agent_name }}</agent-name>
 <provider-name>{{ provider_name }}</provider-name>
 <model-name>{{ model_name }}</model-name>

--- a/rust/agent-custom/src/lib.rs
+++ b/rust/agent-custom/src/lib.rs
@@ -12,7 +12,7 @@ use agent::{
         async_trait::async_trait,
         eyre::{bail, Result},
     },
-    Agent, AgentIO, GenerateOptions,
+    Agent, AgentIO, GenerateOptions, GenerateContext,
 };
 use agent_ollama::OllamaAgent;
 use agent_openai::OpenAIAgent;
@@ -93,14 +93,14 @@ impl Agent for CustomAgent {
         &[AgentIO::Text]
     }
 
-    async fn text_to_text(&self, instruction: &str, options: &GenerateOptions) -> Result<String> {
+    async fn text_to_text(&self, context: GenerateContext, options: &GenerateOptions) -> Result<String> {
         // TODO: Work out how best to merge supplied options with self.options
         let mut options = options.clone();
         if options.prompt_name.is_none() {
             options.prompt_name = Some(self.prompt.clone());
         }
 
-        self.base.text_to_text(instruction, &options).await
+        self.base.text_to_text(context, &options).await
     }
 }
 

--- a/rust/agent-ollama/src/lib.rs
+++ b/rust/agent-ollama/src/lib.rs
@@ -9,10 +9,9 @@ use agent::{
     common::{
         async_trait::async_trait,
         eyre::{eyre, Result},
-        serde_json::json,
         tracing,
     },
-    Agent, AgentIO, GenerateOptions,
+    Agent, AgentIO, GenerateContext, GenerateOptions,
 };
 
 /// An agent running on a Ollama (https://github.com/jmorganca/ollama/) server
@@ -78,13 +77,12 @@ impl Agent for OllamaAgent {
         &[AgentIO::Text]
     }
 
-    async fn text_to_text(&self, instruction: &str, options: &GenerateOptions) -> Result<String> {
-        let (system_prompt, user_prompt) = self.render_prompt(
-            &options.prompt_name,
-            json!({
-                "user_instruction": instruction
-            }),
-        )?;
+    async fn text_to_text(
+        &self,
+        context: GenerateContext,
+        options: &GenerateOptions,
+    ) -> Result<String> {
+        let (system_prompt, user_prompt) = self.render_prompt(context, options).await?;
 
         let mut request = GenerationRequest::new(self.model.clone(), user_prompt);
 

--- a/rust/agent/Cargo.toml
+++ b/rust/agent/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+codecs = { path = "../codecs" }
 common = { path = "../common" }
 minijinja = { version = "1.0.10", features = ["loader"] }
 rust-embed = { version = "8.1.0", features = ["interpolate-folder-path", "include-exclude"] }
+schema = { path = "../schema" }
 
 # Upgrade a `minijinja` dependency to address https://rustsec.org/advisories/RUSTSEC-2023-0070
 self_cell = { version = "1.0.2" }

--- a/rust/agent/src/prompt.rs
+++ b/rust/agent/src/prompt.rs
@@ -11,7 +11,7 @@ use common::{
     serde::Serialize,
     serde_json::json,
 };
-use minijinja::Environment;
+use minijinja::{Environment, UndefinedBehavior};
 use rust_embed::RustEmbed;
 
 /// Builtin prompts
@@ -33,6 +33,9 @@ static ENV: Lazy<RwLock<Environment>> =
 /// Create a new environment with all prompts loaded into it
 fn new_env() -> Result<Environment<'static>> {
     let mut env = Environment::new();
+
+    // Make undefined behavior as permissive as possible
+    env.set_undefined_behavior(UndefinedBehavior::Chainable);
 
     // Add all builtin prompts, erroring if there is syntax errors in them
     for (file_name, content) in

--- a/rust/agents/src/lib.rs
+++ b/rust/agents/src/lib.rs
@@ -7,7 +7,7 @@ use agent::{
         eyre::{bail, Result},
         tracing,
     },
-    Agent, AgentIO, GenerateOptions,
+    Agent, AgentIO, GenerateContext, GenerateOptions,
 };
 
 pub use agent;
@@ -51,7 +51,7 @@ pub async fn list() -> Vec<Arc<dyn Agent>> {
 /// Returns a tuple of the agent that did the generation and
 /// the string it generated
 pub async fn text_to_text(
-    instruction: &str,
+    context: GenerateContext,
     agent_name: &Option<String>,
     options: &GenerateOptions,
 ) -> Result<(Arc<dyn Agent>, String)> {
@@ -63,10 +63,7 @@ pub async fn text_to_text(
         };
 
         if should_use {
-            return Ok((
-                agent.clone(),
-                agent.text_to_text(instruction, options).await?,
-            ));
+            return Ok((agent.clone(), agent.text_to_text(context, options).await?));
         }
     }
 

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use agents::agent::GenerateOptions;
+use agents::agent::{GenerateContext, GenerateOptions};
 use color_eyre::owo_colors::OwoColorize;
 use rustyline::{error::ReadlineError, DefaultEditor};
 use yansi::Color;
@@ -248,33 +248,25 @@ enum Command {
     /// List the available AI agents
     Agents,
 
-    /// Generate text using an AI agents
-    ///
-    /// Mainly intended for testing. This command runs the same code as when you
-    /// create an instruction within a document.
-    Generate {
-        /// An instruction of what the agent should generate
-        instruction: String,
-
-        /// Generate an image rather than text
-        #[arg(long, short)]
-        image: bool,
-
-        /// The name of the agent to use
-        #[arg(long, short)]
-        agent: Option<String>,
-
-        #[clap(flatten)]
-        options: GenerateOptions,
-    },
-
     /// A read-evaluate-print loop for AI agents
     ///
-    ///
+    /// Mainly intended for prompt engineering during development of Stencila.
     Repl {
         /// The name of the agent to interact with
         #[arg(long, short)]
         agent: Option<String>,
+
+        /// The path of the document to use in the context
+        ///
+        /// For testing, you probably want this to be an example Markdown file.
+        #[arg(long, short)]
+        document: Option<PathBuf>,
+
+        /// The path of a file to use as the node in the context
+        ///
+        /// This is probably best as a JSON or YAML file of the specific node type
+        #[arg(long, short)]
+        node: Option<PathBuf>,
 
         /// Whether to offer the option to record each evaluation trial
         ///
@@ -593,27 +585,10 @@ impl Cli {
                 }
             }
 
-            Command::Generate {
-                instruction,
-                image,
-                agent,
-                options,
-            } => match image {
-                false => {
-                    let (agent, text) =
-                        agents::text_to_text(&instruction, &agent, &options).await?;
-                    println!("{}:", agent.name().dimmed().cyan());
-                    display::highlighted(&text, Format::Markdown)?;
-                }
-                true => {
-                    let (agent, url) = agents::text_to_image(&instruction, agent, &options).await?;
-                    println!("{}:", agent.name().dimmed().cyan());
-                    println!("{}", url.blue());
-                }
-            },
-
             Command::Repl {
                 mut agent,
+                mut document,
+                mut node,
                 record,
                 options,
             } => {
@@ -642,6 +617,37 @@ impl Cli {
                                     "{}",
                                     agent.as_deref().unwrap_or("No specific agent chosen; use `--agent` to specify one").cyan()
                                 )
+                            } else if let Some(document_path) = line.strip_prefix("--document") {
+                                // Set the document to use
+                                document = Some(PathBuf::from(document_path.trim()));
+                            } else if line == "?document" {
+                                // Print the document being used
+                                println!(
+                                    "{}",
+                                    document
+                                        .as_ref()
+                                        .map_or(
+                                            "No context document; use `--document` to specify one"
+                                                .to_string(),
+                                            |path| path.to_str().unwrap_or_default().to_string()
+                                        )
+                                        .cyan()
+                                )
+                            } else if let Some(node_path) = line.strip_prefix("--node") {
+                                // Set the node to use
+                                node = Some(PathBuf::from(node_path.trim()));
+                            } else if line == "?node" {
+                                // Print the node being used
+                                println!(
+                                    "{}",
+                                    node.as_ref()
+                                        .map_or(
+                                            "No context node; use `--node` to specify one"
+                                                .to_string(),
+                                            |path| path.to_str().unwrap_or_default().to_string()
+                                        )
+                                        .cyan()
+                                )
                             } else if line.starts_with('-') {
                                 // Update option/s
                                 let mut args = vec!["options"];
@@ -667,9 +673,25 @@ impl Cli {
                                 let json = serde_json::to_string(&options_parser.options)?;
                                 display::highlighted(&json, Format::Json)?;
                             } else {
+                                // Import any document or node
+                                let document_imported = match &document {
+                                    Some(path) => Some(codecs::from_path(path, None).await?),
+                                    None => None,
+                                };
+                                let node_imported = match &node {
+                                    Some(path) => Some(codecs::from_path(path, None).await?),
+                                    None => None,
+                                };
+
+                                // Create a text generation context including the instruction from the user,
+                                // the containing document (if any), and the node to which the instruction
+                                // applies (if any)
+                                let context =
+                                    GenerateContext::new(line, document_imported, node_imported);
+
                                 // Generate a response
                                 let (agent, response) =
-                                    agents::text_to_text(line, &agent, &options_parser.options)
+                                    agents::text_to_text(context, &agent, &options_parser.options)
                                         .await?;
 
                                 // Give some details of the agent used since if the agent is not


### PR DESCRIPTION
This adds makes more context available to the the prompt rendering: the document and any specific node (e.g. for modify instructions e.g. "fix this paragraph"). With the REPL you can specify (at startup and in-session) the path for both document and node and I have created some examples.

The `echo` prompt is a good way to understand how these can be rendered in the prompt:

![image](https://github.com/stencila/stencila/assets/1152336/2d187269-efe0-4183-8ebf-1205423d6237)

I chose HTML as the default format for the rendering as I thought that would be most semantically understood by the AI model. But this is configurable in the options.

@hlm628 and @brettc could you look at the diffs in this PR to understand what these changes allow in terms of prompt engineering and then add to the `prompts/README.md` file accordingly. 