### PR TITLE
fix(package.json): rolled back to tailwind/typography@0.5.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4488,20 +4488,6 @@
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
     },
-    "node_modules/@tailwindcss/typography": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.10.tgz",
-      "integrity": "sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==",
-      "dependencies": {
-        "lodash.castarray": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.merge": "^4.6.2",
-        "postcss-selector-parser": "6.0.10"
-      },
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
-    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -13198,7 +13184,7 @@
         "@lezer/highlight": "1.2.0",
         "@lezer/markdown": "1.2.0",
         "@stencila/types": "2.0.0-alpha.23",
-        "@tailwindcss/typography": "0.5.10",
+        "@tailwindcss/typography": "0.5.9",
         "@twind/core": "1.1.3",
         "@twind/preset-autoprefix": "1.0.7",
         "@twind/preset-tailwind": "1.1.4",
@@ -13220,6 +13206,20 @@
         "parcel": "2.11.0",
         "postcss-import": "15.1.0",
         "prosemirror-example-setup": "1.2.2"
+      }
+    },
+    "web/node_modules/@tailwindcss/typography": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.9.tgz",
+      "integrity": "sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "web/node_modules/@twind/core": {

--- a/web/package.json
+++ b/web/package.json
@@ -63,7 +63,7 @@
     "@lezer/highlight": "1.2.0",
     "@lezer/markdown": "1.2.0",
     "@stencila/types": "2.0.0-alpha.23",
-    "@tailwindcss/typography": "0.5.10",
+    "@tailwindcss/typography": "0.5.9",
     "@twind/core": "1.1.3",
     "@twind/preset-autoprefix": "1.0.7",
     "@twind/preset-tailwind": "1.1.4",


### PR DESCRIPTION
Digging into this @nokome, the issue is how paged.js splits up selectors:


```js
...
selector.split(",")
...
```

This doesn't work well with more modern css selectors like `:where` or `:has` or `:is`:

```css
[data-root] :where(p):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
  ...
}
```

It seems to be a known issue & the solution is to roll back to the previous patch:

https://github.com/pagedjs/pagedjs/issues/166#issuecomment-1854701340

I can confirm that this works.

---

Looking at the release notes for `0.5.10` there are some minor updates that are worth looking at patching in our code as well (PR 301 introduces the issue that affects us).

https://github.com/tailwindlabs/tailwindcss-typography/releases/tag/v0.5.10


![Image](https://github.com/stencila/stencila/assets/1104537/323bd11a-bb9e-4553-b68d-ee08aa91ce4d)

@nokome I've rolled back the version. I think when we get round to art direction / design review on this, we should look at those minor updates.