### PR TITLE
feat(client): implement websocket connection logic

### DIFF
--- a/web/src/clients/codemirror.ts
+++ b/web/src/clients/codemirror.ts
@@ -67,7 +67,7 @@ export class CodeMirrorClient extends FormatClient {
    * @param format The format of the editor content (e.g. "markdown")
    */
   constructor(id: DocumentId, access: DocumentAccess, format: string) {
-    super(id, access, format)
+    super(id, access, format, 'codemirror')
   }
 
   /**

--- a/web/src/clients/format.ts
+++ b/web/src/clients/format.ts
@@ -141,8 +141,13 @@ export abstract class FormatClient extends Client {
    * @param access The access level of the client
    * @param format The format of the string (e.g. "html", "markdown")
    */
-  constructor(id: DocumentId, access: DocumentAccess, format: string) {
-    super(id, `${access}.${format}`)
+  constructor(
+    id: DocumentId,
+    access: DocumentAccess,
+    format: string,
+    clientType?: string
+  ) {
+    super(id, `${access}.${format}`, clientType ?? format)
   }
 
   /**

--- a/web/src/clients/nodes.ts
+++ b/web/src/clients/nodes.ts
@@ -58,8 +58,13 @@ export class NodesClient extends Client {
    * @param access The access level of the client
    * @param elem The element to which an event listener will be attached
    */
-  constructor(id: DocumentId, access: DocumentAccess, elem: HTMLElement) {
-    super(id, `${access}.nodes`)
+  constructor(
+    id: DocumentId,
+    access: DocumentAccess,
+    elem: HTMLElement,
+    clientType?: string
+  ) {
+    super(id, `${access}.nodes`, clientType ?? 'node')
 
     elem.addEventListener(NODE_PATCH_EVENT, (event: CustomEvent) => {
       this.sendMessage(event.detail)

--- a/web/src/clients/object.ts
+++ b/web/src/clients/object.ts
@@ -104,7 +104,7 @@ export class ObjectClient extends Client {
    * @param id The id of the document
    */
   constructor(id: DocumentId) {
-    super(id, 'read.object')
+    super(id, 'read.object', 'object')
   }
 
   /**

--- a/web/src/clients/prosemirror.ts
+++ b/web/src/clients/prosemirror.ts
@@ -20,7 +20,7 @@ export class ProseMirrorClient extends NodesClient {
    *             descendent Web Components)
    */
   constructor(id: DocumentId, access: DocumentAccess, elem: HTMLElement) {
-    super(id, access, elem)
+    super(id, access, elem, 'prosemirror')
   }
 
   /**

--- a/web/src/views/dynamic.ts
+++ b/web/src/views/dynamic.ts
@@ -67,7 +67,8 @@ export class DynamicView extends ThemedView {
     this.nodesClient = new NodesClient(
       this.doc,
       this.access,
-      this.renderRoot as HTMLElement
+      this.renderRoot as HTMLElement,
+      'dynamic'
     )
   }
 


### PR DESCRIPTION
**details**

re implement the ws connection logic in the abstract `Client` class
This implements events (based on the code in issue #1785) when connecting, reconnecting and disconnecting

Have added another optional parameter to the constructor called `clientType` to allow instances to pass a string to be used in the body class / event name

**related issues**:  #1785 




