### PR TITLE
Fix #1916 modify blocks

### DIFF
--- a/rust/assistant/src/lib.rs
+++ b/rust/assistant/src/lib.rs
@@ -792,8 +792,14 @@ impl GenerateOutput {
 
     /// Create a `SuggestionInlineType` from the output that can be used for the `suggestion`
     /// property of the instruction
-    pub fn to_suggestion_inline(self) -> SuggestionInlineType {
-        SuggestionInlineType::InsertInline(InsertInline {
+    pub fn to_suggestion_inline(self, insert: bool) -> SuggestionInlineType {
+        if insert {
+            return SuggestionInlineType::InsertInline(InsertInline {
+                content: self.nodes.into_inlines(),
+                ..Default::default()
+            });
+        }
+        SuggestionInlineType::ReplaceInline(ReplaceInline {
             content: self.nodes.into_inlines(),
             ..Default::default()
         })
@@ -801,11 +807,17 @@ impl GenerateOutput {
 
     /// Create a `SuggestionBlockType` from the output that can be used for the `suggestion`
     /// property of the instruction
-    pub fn to_suggestion_block(self) -> SuggestionBlockType {
-        SuggestionBlockType::InsertBlock(InsertBlock {
+    pub fn to_suggestion_block(self, insert: bool) -> SuggestionBlockType {
+        if insert {
+            return SuggestionBlockType::InsertBlock(InsertBlock {
+                content: self.nodes.into_blocks(),
+                ..Default::default()
+            });
+        }
+        return SuggestionBlockType::ReplaceBlock(ReplaceBlock {
             content: self.nodes.into_blocks(),
             ..Default::default()
-        })
+        });
     }
 
     /// Display the generated output as Markdown

--- a/rust/assistant/src/lib.rs
+++ b/rust/assistant/src/lib.rs
@@ -795,30 +795,32 @@ impl GenerateOutput {
     /// property of the instruction
     pub fn to_suggestion_inline(self, insert: bool) -> SuggestionInlineType {
         if insert {
-            return SuggestionInlineType::InsertInline(InsertInline {
+            SuggestionInlineType::InsertInline(InsertInline {
                 content: self.nodes.into_inlines(),
                 ..Default::default()
-            });
+            })
+        } else {
+            SuggestionInlineType::ReplaceInline(ReplaceInline {
+                replacement: self.nodes.into_inlines(),
+                ..Default::default()
+            })
         }
-        SuggestionInlineType::ReplaceInline(ReplaceInline {
-            replacement: self.nodes.into_inlines(),
-            ..Default::default()
-        })
     }
 
     /// Create a `SuggestionBlockType` from the output that can be used for the `suggestion`
     /// property of the instruction
     pub fn to_suggestion_block(self, insert: bool) -> SuggestionBlockType {
         if insert {
-            return SuggestionBlockType::InsertBlock(InsertBlock {
+            SuggestionBlockType::InsertBlock(InsertBlock {
                 content: self.nodes.into_blocks(),
                 ..Default::default()
-            });
+            })
+        } else {
+            SuggestionBlockType::ReplaceBlock(ReplaceBlock {
+                replacement: self.nodes.into_blocks(),
+                ..Default::default()
+            })
         }
-        return SuggestionBlockType::ReplaceBlock(ReplaceBlock {
-            replacement: self.nodes.into_blocks(),
-            ..Default::default()
-        });
     }
 
     /// Display the generated output as Markdown

--- a/rust/assistant/src/lib.rs
+++ b/rust/assistant/src/lib.rs
@@ -29,8 +29,9 @@ use schema::{
     Article, AudioObject, AuthorRole, AuthorRoleName, Block, ImageObject, Inline, InsertBlock,
     InsertInline, InstructionBlock, InstructionInline, Link, Message, MessagePart, Node, NodeType,
     Organization, OrganizationOptions, PersonOrOrganization,
-    PersonOrOrganizationOrSoftwareApplication, SoftwareApplication, SoftwareApplicationOptions,
-    StringOrNumber, SuggestionBlockType, SuggestionInlineType, VideoObject,
+    PersonOrOrganizationOrSoftwareApplication, ReplaceBlock, ReplaceInline, SoftwareApplication,
+    SoftwareApplicationOptions, StringOrNumber, SuggestionBlockType, SuggestionInlineType,
+    VideoObject,
 };
 
 // Export crates for the convenience of dependant crates
@@ -800,7 +801,7 @@ impl GenerateOutput {
             });
         }
         SuggestionInlineType::ReplaceInline(ReplaceInline {
-            content: self.nodes.into_inlines(),
+            replacement: self.nodes.into_inlines(),
             ..Default::default()
         })
     }
@@ -815,7 +816,7 @@ impl GenerateOutput {
             });
         }
         return SuggestionBlockType::ReplaceBlock(ReplaceBlock {
-            content: self.nodes.into_blocks(),
+            replacement: self.nodes.into_blocks(),
             ..Default::default()
         });
     }

--- a/rust/assistants/src/lib.rs
+++ b/rust/assistants/src/lib.rs
@@ -239,7 +239,8 @@ impl VisitorMut for ResultApplier {
                 match result {
                     Ok(output) => {
                         instruction.messages.push(output.to_message());
-                        instruction.options.suggestion = Some(output.to_suggestion_inline());
+                        instruction.options.suggestion =
+                            Some(output.to_suggestion_inline(instruction.content.is_none()));
 
                         instruction.options.execution_status = Some(ExecutionStatus::Succeeded);
                     }
@@ -267,7 +268,8 @@ impl VisitorMut for ResultApplier {
                 match result {
                     Ok(output) => {
                         instruction.messages.push(output.to_message());
-                        instruction.options.suggestion = Some(output.to_suggestion_block());
+                        instruction.options.suggestion =
+                            Some(output.to_suggestion_block(instruction.content.is_none()));
 
                         instruction.options.execution_status = Some(ExecutionStatus::Succeeded);
                     }


### PR DESCRIPTION
This partially fixes #1916.
We still need to merge the instructions and the original text for a markdown.
