### PR TITLE
feat(bottom-panel): style bottom panel controls

### DIFF
--- a/web/src/apps/main.ts
+++ b/web/src/apps/main.ts
@@ -113,11 +113,10 @@ export class App extends LitElement {
 
   private renderViewSelect() {
     const clickEvent = (e: UISelectorSelectedEvent['detail']) => {
-      console.log(e)
       this.view = e.item.value as DocumentView
     }
 
-    return html` <stencila-ui-selector
+    return html`<stencila-ui-selector
       label="View"
       target=${this.view}
       targetClass="view-selector"

--- a/web/src/images/lineWrap.svg
+++ b/web/src/images/lineWrap.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 7H20" stroke="#171817" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 17H9" stroke="#171817" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 12H17.5C18.8807 12 20 13.1193 20 14.5C20 15.8807 18.8807 17 17.5 17H12.5" stroke="#171817" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 15.5L12.5 17L15 18.5V15.5Z" stroke="#171817" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/src/twind.ts
+++ b/web/src/twind.ts
@@ -27,12 +27,16 @@ export const config = defineConfig({
           yellow: '#ecc94b',
         },
         gray: {
+          200: '#dedede',
           'wild-sand': '#f5f5f5',
           shady: '#9d9d9d',
           aluminium: '#999999',
           'mine-shaft': '#333333',
         },
         black: '#171817',
+        green: {
+          '000': '#f5fff5',
+        },
       },
     },
   },

--- a/web/src/views/source/panels.ts
+++ b/web/src/views/source/panels.ts
@@ -64,8 +64,10 @@ class EditorPanelElement extends TWLitElement {
 
     const styles = apply(['w-28 h-full', 'mx-3 pl-2', 'bg-white', 'rounded-sm'])
 
+    const title = 'Select document format'
+
     return html`
-      <select title="Document format" class=${styles} @change=${changeEvent}>
+      <select title=${title} class=${styles} @change=${changeEvent}>
         ${Object.entries(FORMATS).map(
           ([format, name]) =>
             html`<option
@@ -83,11 +85,10 @@ class EditorPanelElement extends TWLitElement {
     const clickEvent = () => {
       this.sourceView.lineWrap = !this.sourceView.lineWrap
     }
-    const title = `Toggle line wrapping: ${this.sourceView.lineWrap ? 'ON' : 'OFF'}`
+    const title = `Turn ${this.sourceView.lineWrap ? 'off' : 'on'} line wrapping`
     const styles = apply([
       'h-4 w-4',
-      this.sourceView.lineWrap ? 'bg-gray-200' : '',
-      'hover:bg-green-000',
+      this.sourceView.lineWrap ? 'bg-gray-200' : 'hover:bg-green-000',
     ])
 
     return html`
@@ -145,7 +146,7 @@ const bottomPanel = (sourceView: SourceView): Extension => {
     // remove default border
     EditorView.baseTheme({
       '.cm-panels-bottom': {
-        borderTop: 'none',
+        borderTop: '1px solid #d3d3d3',
       },
     }),
   ]

--- a/web/src/views/source/panels.ts
+++ b/web/src/views/source/panels.ts
@@ -1,10 +1,11 @@
 import { Extension } from '@codemirror/state'
-import { showPanel, Panel } from '@codemirror/view'
+import { showPanel, Panel, EditorView } from '@codemirror/view'
+import { apply } from '@twind/core'
 import { html } from 'lit'
 import { customElement, property } from 'lit/decorators'
-// import { unsafeHTML } from 'lit/directives/unsafe-html.js'
 
 import { MappingEntry } from '../../clients/format'
+import icon from '../../images/lineWrap.svg'
 import { TWLitElement } from '../../ui/twind'
 import { SourceView } from '../source'
 
@@ -19,7 +20,7 @@ const FORMATS = {
   ...(process.env.NODE_ENV === 'development' ? { dom: 'DOM' } : {}),
 }
 
-const BREADCRUMB_SEPARATOR = ' > '
+const BREADCRUMB_SEPARATOR = '>'
 
 @customElement('stencila-editor-panel-bottom')
 class EditorPanelElement extends TWLitElement {
@@ -30,71 +31,81 @@ class EditorPanelElement extends TWLitElement {
   sourceView: SourceView
 
   render() {
+    const styles = apply([
+      'flex justify-between',
+      'h-6',
+      'px-4 py-0.5',
+      'bg-gray-wild-sand',
+    ])
+
     return html`
-      <div class="p-2 flex justify-between">
+      <div class=${styles}>
         ${this.renderControls()} ${this.renderBreadcrumbs()}
       </div>
     `
   }
 
   private renderControls() {
+    const styles = apply([
+      'flex flex-row items-center justify-start',
+      'text-sm',
+    ])
+
     return html`
-      <div
-        class="flex flex-row items-center justify-start bg-brand-white text-sm"
-      >
-        <div class="mr-2">${this.renderFormatSelect()}</div>
-        <div>${this.renderLineWrapCheckbox()}</div>
+      <div class=${styles}>
+        ${this.renderLineWrapButton()} ${this.renderFormatSelect()}
       </div>
     `
   }
 
   private renderFormatSelect() {
+    const changeEvent = (e: Event) =>
+      (this.sourceView.format = (e.target as HTMLSelectElement).value)
+
+    const styles = apply(['w-28 h-full', 'mx-3', 'bg-white', 'rounded-sm'])
+
     return html`
-      <label>
-        Format
-        <select
-          @change=${(e: Event) =>
-            (this.sourceView.format = (e.target as HTMLSelectElement).value)}
-        >
-          ${Object.entries(FORMATS).map(
-            ([format, name]) =>
-              html`<option
-                value=${format}
-                ?selected=${this.sourceView.format === format}
-              >
-                ${name}
-              </option>`
-          )}
-        </select>
-      </label>
+      <select title="Document format" class=${styles} @change=${changeEvent}>
+        ${Object.entries(FORMATS).map(
+          ([format, name]) =>
+            html`<option
+              value=${format}
+              ?selected=${this.sourceView.format === format}
+            >
+              ${name}
+            </option>`
+        )}
+      </select>
     `
   }
 
-  private renderLineWrapCheckbox() {
+  private renderLineWrapButton() {
+    const clickEvent = () => {
+      this.sourceView.lineWrap = !this.sourceView.lineWrap
+    }
+    const title = `Toggle line wrapping: ${this.sourceView.lineWrap ? 'ON' : 'OFF'}`
+    const styles = apply([
+      'h-4 w-4',
+      this.sourceView.lineWrap ? 'bg-gray-200' : '',
+      'hover:bg-green-000',
+    ])
+
     return html`
-      <label>
-        ${'Enable line wrapping'}
-        <input
-          type="checkbox"
-          class="ml-1"
-          ?checked="${this.sourceView.lineWrap}"
-          @change="${(e: Event) =>
-            (this.sourceView.lineWrap = (
-              e.target as HTMLInputElement
-            ).checked)}"
-        />
-      </label>
+      <button class=${styles} title=${title} @click=${clickEvent}>
+        <img src=${icon} width="100%" height="100%" />
+      </button>
     `
   }
 
   private renderBreadcrumbs() {
     return html`
-      <div>
+      <div class="text-xs leading-none flex items-center">
         ${this.breadcrumbs.reverse().map((entry, i, arr) => {
           const isLast = i === arr.length - 1
           return html`
-            <span class="${isLast ? 'font-bold' : ''}">${entry.nodeType}</span
-            >${!isLast ? html`<span>${BREADCRUMB_SEPARATOR}</span>` : ''}
+            <span>${entry.nodeType}</span>${!isLast
+              ? html`<span class="px-2">${BREADCRUMB_SEPARATOR}</span>`
+              : ''}
           `
         })}
       </div>
@@ -126,7 +137,15 @@ const nodeTreePanel = (sourceView: SourceView) => (): Panel => {
 }
 
 const bottomPanel = (sourceView: SourceView): Extension => {
-  return showPanel.of(nodeTreePanel(sourceView))
+  return [
+    showPanel.of(nodeTreePanel(sourceView)),
+    // remove default border
+    EditorView.baseTheme({
+      '.cm-panels-bottom': {
+        borderTop: 'none',
+      },
+    }),
+  ]
 }
 
 export { bottomPanel, EditorPanelElement }

--- a/web/src/views/source/panels.ts
+++ b/web/src/views/source/panels.ts
@@ -62,7 +62,7 @@ class EditorPanelElement extends TWLitElement {
     const changeEvent = (e: Event) =>
       (this.sourceView.format = (e.target as HTMLSelectElement).value)
 
-    const styles = apply(['w-28 h-full', 'mx-3', 'bg-white', 'rounded-sm'])
+    const styles = apply(['w-28 h-full', 'mx-3 pl-2', 'bg-white', 'rounded-sm'])
 
     return html`
       <select title="Document format" class=${styles} @change=${changeEvent}>
@@ -100,14 +100,17 @@ class EditorPanelElement extends TWLitElement {
   private renderBreadcrumbs() {
     return html`
       <div class="text-xs leading-none flex items-center">
-        ${this.breadcrumbs.reverse().map((entry, i, arr) => {
-          const isLast = i === arr.length - 1
-          return html`
-            <span>${entry.nodeType}</span>${!isLast
-              ? html`<span class="px-2">${BREADCRUMB_SEPARATOR}</span>`
-              : ''}
-          `
-        })}
+        ${this.breadcrumbs
+          .reverse()
+          .slice(1)
+          .map((entry, i, arr) => {
+            const isLast = i === arr.length - 1
+            return html`
+              <span>${entry.nodeType}</span>${!isLast
+                ? html`<span class="px-2">${BREADCRUMB_SEPARATOR}</span>`
+                : ''}
+            `
+          })}
       </div>
     `
   }


### PR DESCRIPTION
**details**

apply some styling to the bottom panel of the source editor, including toggle and active state for the word wrap button.

design:

![image](https://github.com/stencila/stencila/assets/73506758/21736822-ea05-4176-94c2-79c2633680ae)

implementation:

![image](https://github.com/stencila/stencila/assets/73506758/10435d21-c0c9-44d5-93e5-a0b329c92560)


related issues: closes #1958 
