### PR TITLE
DRAFT: feat(assistants): use embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,9 @@ dependencies = [
  "assistant-openai",
  "assistant-specialized",
  "codecs",
+ "serde",
+ "serde_yaml",
+ "tokio",
 ]
 
 [[package]]
@@ -1628,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "fastembed"
-version = "1.10.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dedca6ea454a21ad452db8534beb38b994427151151a705655061f854524139"
+checksum = "936413e2379d63f6c368d3fa534c0ef59e10b22c19423f80082fc8ae826688a4"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2483,16 +2486,6 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
@@ -2820,7 +2813,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
 dependencies = [
- "libloading 0.8.1",
+ "libloading",
 ]
 
 [[package]]
@@ -3172,23 +3165,26 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "1.16.3"
+version = "2.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889dca4c98efa21b1ba54ddb2bde44fd4920d910f492b618351f839d8428d79d"
+checksum = "8bdb7c4723330322ea09d508e730950e4fcf2116f2dc8394ca0f00dbb77e9e11"
 dependencies = [
- "flate2",
- "half",
- "lazy_static",
- "libc",
- "libloading 0.7.4",
  "ndarray",
- "tar",
+ "ort-sys",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd810ca950630046c7cd2d2ad67ab08404195cc0c566501a64b1c0f0c71ffc"
+dependencies = [
+ "flate2",
+ "sha2",
+ "tar",
  "ureq",
- "vswhom",
- "winapi",
- "zip",
 ]
 
 [[package]]
@@ -5280,26 +5276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "vswhom"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
-dependencies = [
- "libc",
- "vswhom-sys",
-]
-
-[[package]]
-name = "vswhom-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b17ae1f6c8a2b28506cd96d412eebf83b4a0ff2cbefeeb952f2f9dfa44ba18"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5736,18 +5712,6 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
-]
 
 [[package]]
 name = "zstd"

--- a/assistants/builtin/edit-blocks.md
+++ b/assistants/builtin/edit-blocks.md
@@ -2,6 +2,11 @@
 version: "0.1.0"
 
 instruction-type: modify-blocks
+instruction-examples:
+  - edit the text below
+  - modify the text below
+  - improve the text below
+  - correct the text below
 ---
 
 A generic assistant for editing block content (i.e. when a user creates an `InstructionBlock` with `content` to be edited by the assistant).

--- a/assistants/builtin/edit-code-chunk.md
+++ b/assistants/builtin/edit-code-chunk.md
@@ -3,11 +3,13 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: modify-blocks
-
-transform-nodes: CodeChunk
-filter-nodes: ^CodeChunk$
-take-nodes: 1
-assert-nodes: ^CodeChunk$
+instruction-examples:
+  - edit the code below
+  - modify the code below
+  - correct the coding errors below
+  - correct the code
+  - fix the bugs
+expected-nodes: CodeChunk
 ---
 
 An assistant specialized for editing an executable `CodeChunk`. Intended for when there is an existing code chunk in a document that the user wants an assistant to modify in some way.

--- a/assistants/builtin/edit-inlines.md
+++ b/assistants/builtin/edit-inlines.md
@@ -2,6 +2,10 @@
 version: "0.1.0"
 
 instruction-type: modify-inlines
+instruction-examples:
+  - edit the following
+  - make this clearer
+  - make this more concise
 ---
 
 A generic assistant for editing inline content (i.e. when a user creates an `InstructionInline` with `content` to be edited by the assistant).

--- a/assistants/builtin/insert-block-image.md
+++ b/assistants/builtin/insert-block-image.md
@@ -3,9 +3,9 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bimage\b
-
+instruction-examples:
+  - insert an inline image
+  - insert a inline picture
 delegates: [none]
 ---
 

--- a/assistants/builtin/insert-code-chunk.md
+++ b/assistants/builtin/insert-code-chunk.md
@@ -3,15 +3,11 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bexecutable code\b
-  - (?i)\bcode (chunk|cell)\b
-  - (?i)\bcode to\b
-
-transform-nodes: CodeChunk
-filter-nodes: ^CodeChunk$
-take-nodes: 1
-assert-nodes: ^CodeChunk$
+instruction-examples:
+  - insert a code chunk
+  - insert a code block
+  - insert code to
+expected-nodes: CodeChunk
 ---
 
 An assistant specialized for inserting a new executable `CodeChunk`. Note that other assistants are specialized for inserting code chunks that create figures and tables with captions (`insert-code-figure` and `insert-code-table`).

--- a/assistants/builtin/insert-code-expression.md
+++ b/assistants/builtin/insert-code-expression.md
@@ -4,15 +4,12 @@ version: "0.1.0"
 preference-rank: 100
 instruction-type: insert-inlines
 instruction-regexes:
-  - (?i)\bexecutable code\b
-  - (?i)\bcode expr
-  - (?i)\bcode to\b
-  - (?i)^calculate\b
+  - insert code
+  - code to
+  - code for
+  - calculate
 
-transform-nodes: CodeExpression
-filter-nodes: ^CodeExpression$
-take-nodes: 1
-assert-nodes: ^CodeExpression$
+expected-nodes: CodeExpression
 ---
 
 An assistant specialized for inserting a new executable `CodeExpression` within a paragraph.

--- a/assistants/builtin/insert-code-figure.md
+++ b/assistants/builtin/insert-code-figure.md
@@ -3,13 +3,9 @@ version: "0.1.0"
 
 preference-rank: 150
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bfigure from code\b
-
-transform-nodes: CodeChunk
-filter-nodes: ^CodeChunk$
-take-nodes: 1
-assert-nodes: ^CodeChunk$
+instruction-examples:
+  - figure from code
+expected-nodes: CodeChunk
 ---
 
 An assistant specialized for inserting a new executable `CodeChunk` with `FigureLabel` `labelType` and caption.

--- a/assistants/builtin/insert-empty-table.md
+++ b/assistants/builtin/insert-empty-table.md
@@ -3,13 +3,11 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\btable\b
+instruction-examples:
+  - insert a table
+  - a table
 
-transform-nodes: Table
-filter-nodes: ^Table$
-take-nodes: 1
-assert-nodes: ^Table$
+expected-nodes: Table
 ---
 
 An assistant specialized for inserting a new, empty `Table`.

--- a/assistants/builtin/insert-figure-caption.md
+++ b/assistants/builtin/insert-figure-caption.md
@@ -3,17 +3,11 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bfigure caption\b
-
 instruction-examples:
   - write a figure caption
   - write a caption for a figure
   - add a figure caption
-
-transform-nodes: Paragraph
-filter-nodes: ^Paragraph$
-assert-nodes: ^(Paragraph,?)+$
+expected-nodes: Paragraph+
 ---
 
 An assistant specialized for inserting one or more `Paragraph`s for a figure caption.

--- a/assistants/builtin/insert-figure-caption.md
+++ b/assistants/builtin/insert-figure-caption.md
@@ -6,6 +6,11 @@ instruction-type: insert-blocks
 instruction-regexes:
   - (?i)\bfigure caption\b
 
+instruction-examples:
+  - write a figure caption
+  - write a caption for a figure
+  - add a figure caption
+
 transform-nodes: Paragraph
 filter-nodes: ^Paragraph$
 assert-nodes: ^(Paragraph,?)+$

--- a/assistants/builtin/insert-filled-table.md
+++ b/assistants/builtin/insert-filled-table.md
@@ -3,13 +3,12 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\btable\b
+instruction-examples:
+  - fill up a table
+  - make a table with values
+  - construct or build a table like
 
-transform-nodes: Table
-filter-nodes: ^Table$
-take-nodes: 1
-assert-nodes: ^Table$
+expected-nodes: Table
 ---
 
 An assistant specialized for inserting a new `Table` which has all cells filled with values.

--- a/assistants/builtin/insert-image-figure.md
+++ b/assistants/builtin/insert-image-figure.md
@@ -3,8 +3,8 @@ version: "0.1.0"
 
 preference-rank: 150
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bfigure with image\b
+instruction-examples:
+  - figure with image
 
 delegates: [none]
 ---

--- a/assistants/builtin/insert-inline-image.md
+++ b/assistants/builtin/insert-inline-image.md
@@ -3,15 +3,11 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-inlines
-instruction-regexes:
-  - (?i)\bimage\b
+instruction-examples:
+  - image
 
 task-output: image
-
-transform-nodes: ImageObject
-filter-nodes: ^ImageObject$
-take-nodes: 1
-assert-nodes: ^ImageObject$
+expected-nodes: ImageObject
 ---
 
 An assistant specialized for inserting an inline `ImageObject`.

--- a/assistants/builtin/insert-math-block.md
+++ b/assistants/builtin/insert-math-block.md
@@ -3,15 +3,13 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bmaths?\b
-  - (?i)\bequation for\b
-  - (?i)\b(lat)?tex\b
-
-transform-nodes: MathBlock
-filter-nodes: ^MathBlock$
-take-nodes: 1
-assert-nodes: ^MathBlock$
+instruction-examples:
+- write an equation
+- write a math equation
+- write some math
+- insert a math equation
+- insert a LaTeX equation
+expected-nodes: MathBlock
 ---
 
 An assistant specialized for a new `MathBlock` node.

--- a/assistants/builtin/insert-math-block.md
+++ b/assistants/builtin/insert-math-block.md
@@ -4,11 +4,11 @@ version: "0.1.0"
 preference-rank: 100
 instruction-type: insert-blocks
 instruction-examples:
-- write an equation
-- write a math equation
-- write some math
-- insert a math equation
-- insert a LaTeX equation
+  - write an equation
+  - write a math equation
+  - write some math
+  - insert a math equation
+  - insert a LaTeX equation
 expected-nodes: MathBlock
 ---
 

--- a/assistants/builtin/insert-math-inline.md
+++ b/assistants/builtin/insert-math-inline.md
@@ -3,15 +3,12 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-inlines
-instruction-regexes:
-  - (?i)\bmaths?\b
-  - (?i)\bequation for\b
-  - (?i)\b(lat)?tex\b
+instruction-examples:
+  - maths for
+  - equation for
+  - latex for
 
-transform-nodes: MathInline
-filter-nodes: ^MathInline$
-take-nodes: 1
-assert-nodes: ^MathInline$
+expected-nodes: MathInline
 ---
 
 An assistant specialized for a new `MathInline` node (an inline math equation or symbol).

--- a/assistants/builtin/insert-ordered-list.md
+++ b/assistants/builtin/insert-ordered-list.md
@@ -3,13 +3,9 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bordered list\b
-
-transform-nodes: List
-filter-nodes: ^List$
-take-nodes: 1
-assert-nodes: ^List$
+instruction-examples:
+  - ordered list
+expected-nodes: List
 ---
 
 An assistant specialized for inserting a new ordered `List`.

--- a/assistants/builtin/insert-unordered-list.md
+++ b/assistants/builtin/insert-unordered-list.md
@@ -3,13 +3,13 @@ version: "0.1.0"
 
 preference-rank: 100
 instruction-type: insert-blocks
-instruction-regexes:
-  - (?i)\bunordered list\b
+instruction-examples:
+  - make a bullet list
+  - make bullets
+  - make a list
+  - list the following 
 
-transform-nodes: List
-filter-nodes: ^List$
-take-nodes: 1
-assert-nodes: ^List$
+expected-nodes: List
 ---
 
 An assistant specialized for inserting a new unordered `List`.

--- a/rust/assistant-specialized/src/lib.rs
+++ b/rust/assistant-specialized/src/lib.rs
@@ -146,6 +146,8 @@ const FORMAT: Format = Format::Markdown;
 /// Default maximum retries
 const MAX_RETRIES: u8 = 1;
 
+pub type Embeddings = Vec<Vec<f32>>;
+
 /// A custom assistant
 /// TODO: Remove this when the options are being used.
 #[allow(dead_code)]
@@ -155,7 +157,7 @@ const MAX_RETRIES: u8 = 1;
     deny_unknown_fields,
     crate = "assistant::common::serde"
 )]
-struct SpecializedAssistant {
+pub struct SpecializedAssistant {
     /// The id of the assistant
     #[serde(skip_deserializing)]
     id: String,
@@ -214,7 +216,7 @@ struct SpecializedAssistant {
     instruction_examples: Option<Vec<String>>,
 
     /// Embeddings of the instructions examples
-    instruction_embeddings: Option<Vec<Vec<f32>>>,
+    instruction_embeddings: Option<Embeddings>,
 
     /// A regex to match against a comma separated list of the
     /// node types in the instruction content
@@ -299,6 +301,17 @@ where
 }
 
 impl SpecializedAssistant {
+    /// Return some internals
+    /// TODO: Wrap this in test assert?
+    pub fn instruction_examples(&self) -> &Option<Vec<String>> {
+        &self.instruction_examples
+    }
+
+    pub fn instruction_embeddings(&self) -> &Option<Embeddings> {
+        &self.instruction_embeddings
+    }
+
+    /// Return
     /// Parse Markdown content into a custom assistant
     fn parse(id: &str, content: &str) -> Result<Self> {
         // Split a string into parts and ensure that there is at least a header
@@ -566,38 +579,7 @@ impl Assistant for SpecializedAssistant {
             return Ok(0.0);
         }
 
-        /*
-        TODO: Consider how these might be used
-
-        // If instruction regexes are specified then at least one must match
-        if let Some(regexes) = &self.instruction_regexes {
-            let text = task.instruction.text();
-            if !regexes.iter().any(|regex| regex.is_match(&text)) {
-                return false;
-            }
-        }
-
-        if let Some(content) = task.instruction.content() {
-            // If content node type regex specified then, create a comma
-            // separated list of node types, and ensure that the regex matches it
-            if let Some(regex) = &self.content_nodes {
-                let list = content.iter().map(|node| node.to_string()).join(",");
-                if !regex.is_match(&list) {
-                    return false;
-                }
-            }
-
-            // If context regexes are specified then, extract the text of the content, and
-            // ensure that at least one regex matches
-            if let Some(regexes) = &self.content_regexes {
-                let (text, ..) = content.to_text();
-                if !regexes.iter().any(|regex| regex.is_match(&text)) {
-                    return false;
-                }
-            }
-        }
-        */
-
+        // FIXME: Warning here? There SHOULD be embeddings if there were instruction_examples
         let Some(instruction_embeddings) = &self.instruction_embeddings else {
             return Ok(0.1);
         };
@@ -611,6 +593,13 @@ impl Assistant for SpecializedAssistant {
                 score = similarity
             }
         }
+        // TODO: Maybe this instead
+        // let score = instruction_embeddings
+        //     .iter()
+        //     .try_fold(0.0, |max, embedding| {
+        //         let similarity = task.instruction_similarity(embedding)?;
+        //         Ok(max.max(similarity))
+        //     })?;
 
         Ok(score)
     }
@@ -711,8 +700,9 @@ pub fn list() -> Result<Vec<Arc<dyn Assistant>>> {
     Ok(list)
 }
 
-/// Get a list of all builtin specialized assistants
-fn list_builtin() -> Result<Vec<Arc<dyn Assistant>>> {
+/// Get a list of the specialized assistants.
+/// Useful for testing.
+pub fn list_builtin_as_specialized() -> Result<Vec<SpecializedAssistant>> {
     let mut assistants = vec![];
 
     for (name, content) in
@@ -722,10 +712,19 @@ fn list_builtin() -> Result<Vec<Arc<dyn Assistant>>> {
         let content = String::from_utf8_lossy(&content);
         let assistant = SpecializedAssistant::parse(&id, &content)
             .map_err(|error| eyre!("While parsing `{name}`: {error}"))?;
-        assistants.push(Arc::new(assistant) as Arc<dyn Assistant>)
+        assistants.push(assistant)
     }
-
     Ok(assistants)
+}
+
+/// Get a list of all builtin specialized assistants as Assistant trait objects
+fn list_builtin() -> Result<Vec<Arc<dyn Assistant>>> {
+    list_builtin_as_specialized().map(|assistants| {
+        assistants
+            .into_iter()
+            .map(|assistant| Arc::new(assistant) as Arc<dyn Assistant>)
+            .collect()
+    })
 }
 
 /// Get a list of all local specialized assistants

--- a/rust/assistant-specialized/src/lib.rs
+++ b/rust/assistant-specialized/src/lib.rs
@@ -301,14 +301,18 @@ where
 }
 
 impl SpecializedAssistant {
-    /// Return some internals
-    /// TODO: Wrap this in test assert?
+    // Added for testing
+    // TODO: Wrap these in test / debug assertions?
     pub fn instruction_examples(&self) -> &Option<Vec<String>> {
         &self.instruction_examples
     }
 
     pub fn instruction_embeddings(&self) -> &Option<Embeddings> {
         &self.instruction_embeddings
+    }
+
+    pub fn instruction_type(&self) -> &Option<InstructionType> {
+        &self.instruction_type
     }
 
     /// Return

--- a/rust/assistant/Cargo.toml
+++ b/rust/assistant/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 app = { path = "../app" }
 codecs = { path = "../codecs" }
 common = { path = "../common" }
-fastembed = "1.10.0"
+fastembed = "2.0.1"
 format = { path = "../format" }
 merge = "0.1.0"
 node-authorship = { path = "../node-authorship" }

--- a/rust/assistants/Cargo.toml
+++ b/rust/assistants/Cargo.toml
@@ -12,3 +12,8 @@ assistant-ollama = { path = "../assistant-ollama" }
 assistant-openai = { path = "../assistant-openai" }
 assistant-specialized = { path = "../assistant-specialized" }
 codecs = { path = "../codecs" }
+
+[dev-dependencies]
+tokio = "1.35.1"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_yaml = "0.9.30"

--- a/rust/assistants/tests/assistants.yaml
+++ b/rust/assistants/tests/assistants.yaml
@@ -1,0 +1,32 @@
+# Testing for the embedding matching with instructions.
+insert-filled-table:
+  text: 
+    - put a table here
+    - insert a table with something interesting
+insert-unordered-list:
+  text:
+    - put a list here
+    - insert some bullet points below.
+edit-code-chunk:
+  text:
+    - edit the code below
+    - modify the code below
+    - correct the coding errors below
+    - correct the code
+    - fix the bugs
+insert-code-figure:
+  text:
+    - insert a graph here.
+#insert-blocks
+#edit-blocks
+#insert-math-block
+#insert-math-inline
+#insert-code-expression
+#edit-inlines
+#insert-figure-caption
+#insert-inline-image
+#insert-ordered-list
+#insert-code-chunk
+#insert-block-image
+#insert-empty-table
+#insert-image-figure

--- a/rust/assistants/tests/assistants.yaml
+++ b/rust/assistants/tests/assistants.yaml
@@ -3,10 +3,6 @@ insert-filled-table:
   text: 
     - put a table here
     - insert a table with something interesting
-insert-unordered-list:
-  text:
-    - put a list here
-    - insert some bullet points below.
 edit-code-chunk:
   text:
     - edit the code below
@@ -17,16 +13,65 @@ edit-code-chunk:
 insert-code-figure:
   text:
     - insert a graph here.
-#insert-blocks
-#edit-blocks
-#insert-math-block
-#insert-math-inline
-#insert-code-expression
-#edit-inlines
-#insert-figure-caption
-#insert-inline-image
-#insert-ordered-list
-#insert-code-chunk
-#insert-block-image
-#insert-empty-table
-#insert-image-figure
+insert-figure-caption:
+  text:
+    - add a caption here
+    - add a caption for the figure
+    - add a caption for the graph
+insert-math-block:
+  text:
+    - add some equations here
+    - add some math here
+    - write an equation for this.
+insert-math-inline:
+  text:
+    - add some math here
+    - write an equation for this.
+insert-code-expression:
+  text:
+    - add some code here to print the results
+    - add some code to calculate this.
+insert-blocks:
+  text:
+    - add some interesting paragraphs
+insert-empty-table:
+  text:
+    - add a table here with 3 rows.
+    - insert a table with columns for the following.
+insert-image-figure:
+  text:
+    - insert a picture of my dog here.
+    - insert an photo here.
+insert-code-chunk:
+  text:
+    - add some code here
+    - insert some code here
+    - add some code to calculate this.
+insert-ordered-list:
+  text:
+    - put a list of biggest cities here
+    - list the top five animals.
+insert-unordered-list:
+  text:
+    - put a list here
+    - insert some bullet points below.
+insert-inline-image:
+  text:
+    - insert a picture of my dog here.
+    - insert an photo here.
+insert-block-image:
+  text:
+    - insert a picture of my dog here.
+    - insert a photo of elvis here.
+edit-blocks:
+  text:
+    - edit the text below
+    - modify the text below
+    - correct the text below
+    - correct the text
+    - fix the text
+edit-inlines:
+  text:
+    - edit the following
+    - make this clearer
+    - make this more concise

--- a/rust/assistants/tests/specialized.rs
+++ b/rust/assistants/tests/specialized.rs
@@ -1,0 +1,125 @@
+use assistant::{common::eyre::Result, Assistant, GenerateTask, Instruction};
+use assistant_specialized::{Embeddings, SpecializedAssistant};
+use assistants::get_assistant;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+
+use assistant::common::{serde_yaml, tokio};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct AssistantTest {
+    text: Vec<String>,
+}
+
+// If your YAML file contains an array of tests
+#[derive(Debug, Deserialize)]
+struct TestCases(Vec<AssistantTest>);
+
+async fn local_get_assistant(text: String) -> Result<(String, f32)> {
+    let mut task = GenerateTask::new(Instruction::block_text(text));
+    let assistant = get_assistant(&mut task).await?;
+    let score = assistant.suitability_score(&mut task)?;
+    Ok((assistant.id(), score))
+}
+
+fn short_name(id: String) -> String {
+    id.split("/")
+        .nth(1)
+        .expect("should be a `/` in an id")
+        .to_string()
+}
+
+#[tokio::test]
+async fn check_we_get_the_right_assistant() -> Result<()> {
+    // Make a lookup of all special assistants built in to stencila.
+    let special_by_key: HashMap<String, SpecializedAssistant> =
+        assistant_specialized::list_builtin_as_specialized()?
+            .into_iter()
+            // Remove "stencila/"
+            .map(|a| (short_name(a.id()), a))
+            .collect();
+
+    let file_content =
+        fs::read_to_string("tests/assistants.yaml").expect("Unable to read the YAML file");
+
+    let test_cases: HashMap<String, AssistantTest> =
+        serde_yaml::from_str(&file_content).expect("Cannot parse test YAML");
+
+    // Iterate over the test cases
+    let mut found: HashSet<String> = HashSet::new();
+    for (id, tests) in test_cases {
+        println!("Testing {}", id);
+        assert!(special_by_key.contains_key(&id));
+        found.insert(id.clone());
+        // Here you can call the function to test with `case.challenge`
+        for txt in tests.text {
+            print!("-- Trying `{}`...", txt);
+            let (matched_id, score) = local_get_assistant(txt.clone()).await?;
+            // Test failure happens here.
+            assert_eq!(id, short_name(matched_id));
+            println!("OK with score {}", score);
+        }
+    }
+
+    // Check that all special assistants are tested
+    for (id, _) in special_by_key {
+        if found.contains(&id) {
+            continue;
+        }
+        println!("No tests found for {}", id);
+        // Let's not fail just yet.
+        // assert!(found.contains(&id));
+    }
+
+    Ok(())
+}
+
+// TODO: Remove this
+#[allow(unused_variables)]
+#[tokio::test]
+async fn ensure_assistants_are_distinct() -> Result<()> {
+    // Make a lookup of all special assistants built in to stencila.
+    let assistants = assistant_specialized::list_builtin_as_specialized()?;
+    let empty_instr: Vec<String> = vec![];
+    let empty_embed: Embeddings = vec![];
+    // EEK. I'm not sure I should be proud of this.
+    let asst_with_instr: Vec<_> = assistants
+        .iter()
+        .flat_map(|a| {
+            a.instruction_examples()
+                .as_ref()
+                .unwrap_or_else(|| &empty_instr)
+                .iter()
+                .zip(
+                    a.instruction_embeddings()
+                        .as_ref()
+                        .unwrap_or_else(|| &empty_embed),
+                )
+                .map(|i| (a, i))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    for (a1, (i1, e1)) in asst_with_instr.iter() {
+        for (a2, (i2, e2)) in asst_with_instr.iter() {
+            if a1.id() == a2.id() && i1 == i2 {
+                continue;
+            }
+            // TODO: Extract cosine similarity.
+            // I think the embeddings need to be refactored into a newtype struct: InstructionEmbeddings(Vec<Vec<f32>>)
+            // Then their creation and comparison can be done in a single place.
+            // let sim = e1.cosine_similarity(e2);
+            println!(
+                "{:<20} {:<20} / {:<20} {:<20}: {}",
+                short_name(a1.id()),
+                i1,
+                short_name(a2.id()),
+                i2,
+                0.0,
+            );
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This shifts the specialised assistants to using examples with embeddings rather than regexes for matching.

- [x] Clean up assistant markdown using instructions and "expected-nodes" to simplify definition.
- [ ] Write tests to see how well the matching works (in progress)
- [ ] Write a matrix of embedding comparisons to ensure our examples are distinct enough (in progress, but requires refactor below)
- [ ] Refactor embeddings / cosine similarity (to discuss)
- [ ] Refine text based on tests (maybe leave to later)
- [ ] Incorporate (or move) the tests to use the examples/assistants (to discuss)

