### PR TITLE
refactor(assistants): pull out embeddings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "merge",
  "node-authorship",
  "schema",
+ "serde",
 ]
 
 [[package]]

--- a/rust/assistant/Cargo.toml
+++ b/rust/assistant/Cargo.toml
@@ -12,3 +12,4 @@ format = { path = "../format" }
 merge = "0.1.0"
 node-authorship = { path = "../node-authorship" }
 schema = { path = "../schema" }
+serde = { version = "1.0.196", features = ["derive"] }


### PR DESCRIPTION
This isolates the embeddings, putting all the construction and comparison code and related data into one structure.

Some notes:
- The texts are now stored along the embeddings, making a copy. But I think this will make tuning / tracing etc far easier.
- I now calculate the instruction_text on construction of the Task, rather than doing it lazily (we need it all the time anyway).
- The full matrix comparison of instruction examples in now in the specialized.rs test (under assistants)