### PR TITLE
feat(secrets): add support for secrets management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +193,7 @@ dependencies = [
  "merge",
  "node-authorship",
  "schema",
+ "secrets",
  "serde",
 ]
 
@@ -257,12 +270,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 5.1.0",
+ "event-listener-strategy 0.5.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-convert"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
 dependencies = [
  "async-trait",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.0.1",
+ "futures-lite 2.2.0",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f97ab0c5b00a7cdbe5a371b9a782ee7be1316095885c8a4ea1daf490eb0ef65"
+dependencies = [
+ "async-lock 3.3.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.2.0",
+ "parking",
+ "polling 3.5.0",
+ "rustix 0.38.31",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -291,6 +412,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.31",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +437,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.50",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+dependencies = [
+ "async-io 2.3.1",
+ "async-lock 2.8.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.31",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -324,6 +480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +495,12 @@ dependencies = [
  "quote",
  "syn 2.0.50",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -567,6 +735,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-modes"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
+dependencies = [
+ "block-padding",
+ "cipher",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel",
+ "async-lock 3.3.0",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.2.0",
+ "piper",
+ "tracing",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +991,7 @@ dependencies = [
  "is-terminal",
  "node-strip",
  "rustyline",
+ "secrets",
  "server",
  "syntect",
  "tracing-error",
@@ -802,6 +1012,9 @@ name = "cli-utils"
 version = "0.0.0"
 dependencies = [
  "comfy-table",
+ "common",
+ "is-terminal",
+ "rpassword",
 ]
 
 [[package]]
@@ -1182,6 +1395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,7 +1572,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -1571,6 +1793,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1677,6 +1900,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1947,65 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ad6fd685ce13acd6d9541a30f6db6567a7a24c9ffd4ba2955d29e3f22c8b27"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.1.0",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "eventsource-stream"
@@ -1742,6 +2045,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
@@ -1753,7 +2065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93f7a0db71c99f68398f80653ed05afb0b00e062e1a20c7ff849c4edfabbbcc"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -1869,6 +2181,34 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2101,6 +2441,24 @@ dependencies = [
  "serde_json",
  "thiserror",
  "ureq",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -2486,6 +2844,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,7 +2980,7 @@ version = "0.0.0"
 dependencies = [
  "app",
  "kernel",
- "nix",
+ "nix 0.27.1",
  "which",
 ]
 
@@ -2653,6 +3022,20 @@ dependencies = [
  "kernel-node",
  "kernel-python",
  "kernel-rhai",
+]
+
+[[package]]
+name = "keyring"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be8bc4c6b6e9d85ecdad090fcf342a9216f53d747a537cc05e3452fd650ca46"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "linux-keyutils",
+ "secret-service",
+ "security-framework",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2734,6 +3117,22 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2847,6 +3246,15 @@ name = "memo-map"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374c335b2df19e62d4cb323103473cbc6510980253119180de862d89184f6a83"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -3054,6 +3462,18 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+]
+
+[[package]]
+name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -3230,6 +3650,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3245,6 +3690,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3325,6 +3793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,6 +3849,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "ort"
 version = "2.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3410,6 +3894,12 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -3580,6 +4070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3597,6 +4098,36 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.31",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3753,7 +4284,7 @@ dependencies = [
  "cfg-if",
  "indoc",
  "libc",
- "memoffset",
+ "memoffset 0.9.0",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -4138,6 +4669,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4190,6 +4742,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
@@ -4197,7 +4763,7 @@ dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.12",
  "windows-sys 0.52.0",
 ]
 
@@ -4276,7 +4842,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.27.1",
  "radix_trie",
  "unicode-segmentation",
  "unicode-width",
@@ -4403,6 +4969,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da1a5ad4d28c03536f82f77d9f36603f5e37d8869ac98f0a750d5b5686d8d95"
+dependencies = [
+ "aes",
+ "block-modes",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "secrets"
+version = "0.0.0"
+dependencies = [
+ "cli-utils",
+ "common",
+ "keyring",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4491,6 +5085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4566,6 +5171,7 @@ dependencies = [
  "format",
  "mime_guess",
  "rust-embed",
+ "secrets",
  "tower-http",
 ]
 
@@ -4830,6 +5436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4924,8 +5536,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if",
- "fastrand",
- "rustix",
+ "fastrand 2.0.1",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -4935,7 +5547,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -5446,6 +6058,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset 0.9.0",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5624,6 +6247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
 name = "walkdir"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5752,7 +6381,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
 
@@ -6020,8 +6649,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7dae5072fe1f8db8f8d29059189ac175196e410e40ba42d5d4684ae2f750995"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "linux-raw-sys 0.4.12",
+ "rustix 0.38.31",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -6038,6 +6677,72 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zbus"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "byteorder",
+ "derivative",
+ "enumflags2",
+ "event-listener 2.5.3",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.26.4",
+ "once_cell",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "winapi",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb80bb776dbda6e23d705cf0123c3b95df99c4ebeaec6c2599d4a5419902b4a9"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
 
 [[package]]
 name = "zerocopy"
@@ -6091,4 +6796,42 @@ checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44b291bee0d960c53170780af148dca5fa260a63cdd24f1962fa82e03e53338c"
+dependencies = [
+ "byteorder",
+ "enumflags2",
+ "libc",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934d7a7dfc310d6ee06c87ffe88ef4eca7d3e37bb251dece2ef93da8f17d8ecd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]

--- a/rust/assistant-mistral/src/lib.rs
+++ b/rust/assistant-mistral/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{env, sync::Arc};
+use std::sync::Arc;
 
 use cached::proc_macro::cached;
 
@@ -13,10 +13,13 @@ use assistant::{
         tracing,
     },
     schema::MessagePart,
-    Assistant, AssistantIO, GenerateOptions, GenerateOutput, GenerateTask, IsAssistantMessage,
+    secrets, Assistant, AssistantIO, GenerateOptions, GenerateOutput, GenerateTask,
+    IsAssistantMessage,
 };
 
 const BASE_URL: &str = "https://api.mistral.ai/v1";
+
+/// The name of the env var or secret for the API key
 const API_KEY: &str = "MISTRAL_API_KEY";
 
 struct MistralAssistant {
@@ -109,7 +112,7 @@ impl Assistant for MistralAssistant {
         let response = self
             .client
             .post(format!("{BASE_URL}/chat/completions"))
-            .bearer_auth(env::var(API_KEY)?)
+            .bearer_auth(secrets::env_or_get(API_KEY)?)
             .json(&request)
             .send()
             .await?;
@@ -205,8 +208,8 @@ enum ChatRole {
 /// remote API need to be called to get a list of available models.
 #[cached(time = 3600, result = true)]
 pub async fn list() -> Result<Vec<Arc<dyn Assistant>>> {
-    let Ok(key) = env::var(API_KEY) else {
-        tracing::debug!("The {API_KEY} environment variable is not set");
+    let Ok(key) = secrets::env_or_get(API_KEY) else {
+        tracing::debug!("The environment variable or secret `{API_KEY}` is not available");
         return Ok(vec![]);
     };
 
@@ -250,7 +253,7 @@ mod tests {
     async fn list_assistants() -> Result<()> {
         let list = list().await?;
 
-        if env::var(API_KEY).is_err() {
+        if secrets::env_or_get(API_KEY).is_err() {
             assert_eq!(list.len(), 0)
         } else {
             assert!(!list.is_empty())
@@ -261,7 +264,7 @@ mod tests {
 
     #[tokio::test]
     async fn perform_task() -> Result<()> {
-        if env::var(API_KEY).is_err() {
+        if secrets::env_or_get(API_KEY).is_err() {
             return Ok(());
         }
 

--- a/rust/assistant/Cargo.toml
+++ b/rust/assistant/Cargo.toml
@@ -12,4 +12,5 @@ format = { path = "../format" }
 merge = "0.1.0"
 node-authorship = { path = "../node-authorship" }
 schema = { path = "../schema" }
+secrets = { path = "../secrets" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/rust/assistant/src/lib.rs
+++ b/rust/assistant/src/lib.rs
@@ -42,6 +42,7 @@ pub use format;
 pub use merge;
 pub use node_authorship;
 pub use schema;
+pub use secrets;
 
 /// An instruction created within a document
 #[skip_serializing_none]

--- a/rust/cli-utils/Cargo.toml
+++ b/rust/cli-utils/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 comfy-table = "7.1.0"
+common = { path = "../common" }
+is-terminal = "0.4.12"
+rpassword = "7.3"

--- a/rust/cli-utils/src/lib.rs
+++ b/rust/cli-utils/src/lib.rs
@@ -3,4 +3,27 @@
 //! This little crate exists as a place to put CLI related things we
 //! want to re-use in sibling crates for both convenience and consistency.
 
+use std::fmt::Display;
+
+use is_terminal::IsTerminal;
+
+use common::{serde::Serialize, serde_json};
+
+pub use rpassword;
+
 pub mod table;
+
+/// A trait for displaying an object to stdout
+pub trait ToStdout: Serialize {
+    /// Print the object to stdout
+    fn to_stdout(&self) {
+        if std::io::stdout().is_terminal() {
+            println!("{}", self.to_terminal())
+        } else {
+            println!("{}", serde_json::to_string_pretty(self).unwrap_or_default())
+        }
+    }
+
+    /// Print the object to a terminal
+    fn to_terminal(&self) -> impl Display;
+}

--- a/rust/cli-utils/src/table.rs
+++ b/rust/cli-utils/src/table.rs
@@ -1,11 +1,10 @@
 use comfy_table::{
     modifiers::{UTF8_ROUND_CORNERS, UTF8_SOLID_INNER_BORDERS},
     presets::UTF8_FULL,
-    Table,
 };
 
 // Re-exports
-pub use comfy_table::{Attribute, Cell, Color};
+pub use comfy_table::{Attribute, Cell, CellAlignment, Color, Table};
 
 /// Create a new table for displaying data in the terminal
 ///

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -23,6 +23,7 @@ format = { path = "../format" }
 is-terminal = "0.4.12"
 node-strip = { path = "../node-strip" }
 rustyline = "13.0.0"
+secrets = { path = "../secrets" }
 server = { path = "../server" }
 syntect = "5.2.0"
 tracing-error = "0.2.0"

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -289,6 +289,8 @@ enum Command {
         reps: u16,
     },
 
+    Secrets(secrets::cli::Cli),
+
     Config(ConfigOptions),
 }
 
@@ -727,6 +729,8 @@ impl Cli {
             }
 
             Command::Test { path, reps } => assistants::testing::test_example(&path, reps).await?,
+
+            Command::Secrets(secrets) => secrets.run().await?,
 
             Command::Config(options) => {
                 // TODO: Make options.dir an option, and if it not there, show all folders.

--- a/rust/secrets/Cargo.toml
+++ b/rust/secrets/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "secrets"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+cli-utils = { path = "../cli-utils" }
+common = { path = "../common" }
+keyring = "2.3.2"

--- a/rust/secrets/src/cli.rs
+++ b/rust/secrets/src/cli.rs
@@ -1,0 +1,59 @@
+use cli_utils::{rpassword::prompt_password, ToStdout};
+use common::{
+    clap::{self, Args, Parser, Subcommand},
+    eyre::Result,
+};
+
+use crate::{delete, list, set};
+
+/// Secrets
+#[derive(Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+/// A command to perform with secrets
+#[derive(Subcommand)]
+enum Command {
+    /// List the secrets used by Stencila
+    List,
+
+    /// Set a secret used by Stencila
+    ///
+    /// You will be prompted for the secret
+    Set(Set),
+
+    /// Delete a secret previously set using Stencila
+    Delete(Delete),
+}
+
+#[derive(Args)]
+struct Set {
+    /// The name of the secret
+    name: String,
+}
+
+#[derive(Args)]
+struct Delete {
+    /// The name of the secret
+    name: String,
+}
+
+impl Cli {
+    // Run the CLI
+    pub async fn run(self) -> Result<()> {
+        let Some(command) = self.command else {
+            list()?.to_stdout();
+            return Ok(());
+        };
+
+        match command {
+            Command::List => list()?.to_stdout(),
+            Command::Set(Set { name }) => set(&name, &prompt_password("Enter secret: ")?)?,
+            Command::Delete(Delete { name }) => delete(&name)?,
+        }
+
+        Ok(())
+    }
+}

--- a/rust/secrets/src/cli.rs
+++ b/rust/secrets/src/cli.rs
@@ -6,15 +6,15 @@ use common::{
 
 use crate::{delete, list, set};
 
-/// Secrets
-#[derive(Parser)]
+/// Manage secrets used by Stencila (e.g. API keys)
+#[derive(Debug, Parser)]
 pub struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 }
 
 /// A command to perform with secrets
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 enum Command {
     /// List the secrets used by Stencila
     List,
@@ -28,13 +28,13 @@ enum Command {
     Delete(Delete),
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 struct Set {
     /// The name of the secret
     name: String,
 }
 
-#[derive(Args)]
+#[derive(Debug, Args)]
 struct Delete {
     /// The name of the secret
     name: String,

--- a/rust/secrets/src/cli.rs
+++ b/rust/secrets/src/cli.rs
@@ -4,7 +4,7 @@ use common::{
     eyre::Result,
 };
 
-use crate::{delete, list, set};
+use crate::{delete, list, name_validator, set};
 
 /// Manage secrets used by Stencila (e.g. API keys)
 #[derive(Debug, Parser)]
@@ -31,12 +31,14 @@ enum Command {
 #[derive(Debug, Args)]
 struct Set {
     /// The name of the secret
+    #[arg(value_parser = name_validator)]
     name: String,
 }
 
 #[derive(Debug, Args)]
 struct Delete {
     /// The name of the secret
+    #[arg(value_parser = name_validator)]
     name: String,
 }
 

--- a/rust/secrets/src/lib.rs
+++ b/rust/secrets/src/lib.rs
@@ -1,0 +1,157 @@
+use std::env;
+
+use cli_utils::{
+    table::{self, Attribute, Cell, CellAlignment, Color},
+    ToStdout,
+};
+use common::{
+    derive_more::Deref, eyre::Result, once_cell::sync::Lazy, serde::Serialize,
+    serde_with::skip_serializing_none,
+};
+
+pub mod cli;
+
+/// A category of secret
+#[derive(Clone, Serialize)]
+#[serde(crate = "common::serde")]
+enum SecretCategory {
+    AiApiKey,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Serialize)]
+#[serde(crate = "common::serde")]
+pub struct Secret {
+    /// The category of the secret
+    category: SecretCategory,
+
+    /// The category of the secret
+    name: String,
+
+    /// The title of the secret
+    title: String,
+
+    /// A description of the purpose of the secret
+    description: String,
+
+    /// A redacted version of the secret (last five characters only) if available
+    redacted: Option<String>,
+}
+
+impl Secret {
+    fn new(category: SecretCategory, name: &str, title: &str, description: &str) -> Self {
+        Self {
+            category,
+            name: name.into(),
+            title: title.into(),
+            description: description.into(),
+            redacted: None,
+        }
+    }
+}
+
+/// A list of secrets
+#[derive(Deref, Serialize)]
+#[serde(crate = "common::serde")]
+pub struct SecretList(Vec<Secret>);
+
+impl ToStdout for SecretList {
+    fn to_terminal(&self) -> impl std::fmt::Display {
+        let mut table = table::new();
+        table.set_header(["Name", "Value"]);
+        for secret in self.iter() {
+            table.add_row([
+                Cell::new(&secret.name).add_attribute(Attribute::Bold),
+                match &secret.redacted {
+                    Some(redacted) => Cell::new(redacted).fg(Color::Green),
+                    None => Cell::new(""),
+                }
+                .set_alignment(CellAlignment::Right),
+            ]);
+        }
+        table
+    }
+}
+
+/// A list of secrets used by Stencila
+static SECRETS: Lazy<Vec<Secret>> = Lazy::new(|| {
+    vec![
+        Secret::new(
+            SecretCategory::AiApiKey,
+            "ANTHROPIC_API_KEY",
+            "Anthropic API Key",
+            "Used to access the Anthropic API",
+        ),
+        Secret::new(
+            SecretCategory::AiApiKey,
+            "GOOGLE_AI_API_KEY",
+            "Google AI API Key",
+            "Used to access the Google AI API",
+        ),
+        Secret::new(
+            SecretCategory::AiApiKey,
+            "OPENAI_API_KEY",
+            "OpenAI API Key",
+            "Used to access the OpenAI API",
+        ),
+        Secret::new(
+            SecretCategory::AiApiKey,
+            "MISTRAL_API_KEY",
+            "Mistral API Key",
+            "Used to access the Mistral API",
+        ),
+    ]
+});
+
+/// Create a keyring entry for the secret
+fn entry(name: &str) -> Result<keyring::Entry> {
+    Ok(keyring::Entry::new(name, "stencila")?)
+}
+
+/// List secrets
+pub fn list() -> Result<SecretList> {
+    SECRETS
+        .iter()
+        .map(|secret| {
+            let redacted = entry(&secret.name)?.get_password().ok().map(|value| {
+                [
+                    "●".repeat(12),
+                    value
+                        .chars()
+                        .rev()
+                        .take(5)
+                        .collect::<String>()
+                        .chars()
+                        .rev()
+                        .collect::<String>(),
+                ]
+                .concat()
+            });
+            Ok(Secret {
+                redacted,
+                ..secret.clone()
+            })
+        })
+        .collect::<Result<Vec<Secret>>>()
+        .map(SecretList)
+}
+
+/// Set a secret
+pub fn set(name: &str, value: &str) -> Result<()> {
+    Ok(entry(name)?.set_password(value)?)
+}
+
+/// Get a secret
+pub fn get(name: &str) -> Result<String> {
+    Ok(entry(name)?.get_password()?)
+}
+
+/// Get an environment variable or secret
+pub fn env_or_get(name: &str) -> Result<String> {
+    env::var(name).or_else(|_| get(name))
+}
+
+/// Delete a secret
+pub fn delete(name: &str) -> Result<()> {
+    Ok(entry(name)?.delete_password()?)
+}

--- a/rust/secrets/src/lib.rs
+++ b/rust/secrets/src/lib.rs
@@ -58,10 +58,11 @@ pub struct SecretList(Vec<Secret>);
 impl ToStdout for SecretList {
     fn to_terminal(&self) -> impl std::fmt::Display {
         let mut table = table::new();
-        table.set_header(["Name", "Value"]);
+        table.set_header(["Name", "Description", "Value"]);
         for secret in self.iter() {
             table.add_row([
                 Cell::new(&secret.name).add_attribute(Attribute::Bold),
+                Cell::new(&secret.description),
                 match &secret.redacted {
                     Some(redacted) => Cell::new(redacted).fg(Color::Green),
                     None => Cell::new(""),

--- a/rust/secrets/src/main.rs
+++ b/rust/secrets/src/main.rs
@@ -1,0 +1,23 @@
+use common::{clap::Parser, eyre::Result, tokio};
+
+use secrets::cli::Cli;
+
+/// A mini command line interface just for secrets
+///
+/// Intended for use during development only. Example usage:
+///
+/// ```sh
+/// cargo run -p secrets list
+/// ```
+///
+/// The `Cli` struct is integrated into the main `stencila` CLI
+/// as the `secrets` subcommand e.g.
+///
+/// ```sh
+/// stencila secrets list
+/// ```
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    cli.run().await
+}

--- a/rust/server/Cargo.toml
+++ b/rust/server/Cargo.toml
@@ -12,6 +12,7 @@ document = { path = "../document" }
 format = { path = "../format" }
 mime_guess = "2.0.4"
 rust-embed = { version = "8.2.0", features = ["interpolate-folder-path", "include-exclude"] }
+secrets = { path = "../secrets" }
 tower-http = { version = "0.5.1", features = ["trace"] }
 
 [dev-dependencies]

--- a/rust/server/src/server.rs
+++ b/rust/server/src/server.rs
@@ -275,15 +275,19 @@ async fn list_secrets() -> Result<Response, InternalError> {
 /// Set a secret
 #[tracing::instrument]
 async fn set_secret(Path(name): Path<String>, value: String) -> Result<Response, InternalError> {
-    secrets::set(&name, &value).map_err(InternalError::new)?;
-    Ok(StatusCode::CREATED.into_response())
+    match secrets::set(&name, &value) {
+        Ok(..) => Ok(StatusCode::CREATED.into_response()),
+        Err(error) => Ok((StatusCode::BAD_REQUEST, error.to_string()).into_response()),
+    }
 }
 
 /// Delete a secret
 #[tracing::instrument]
 async fn delete_secret(Path(name): Path<String>) -> Result<Response, InternalError> {
-    secrets::delete(&name).map_err(InternalError::new)?;
-    Ok(StatusCode::NO_CONTENT.into_response())
+    match secrets::delete(&name) {
+        Ok(..) => Ok(StatusCode::NO_CONTENT.into_response()),
+        Err(error) => Ok((StatusCode::BAD_REQUEST, error.to_string()).into_response()),
+    }
 }
 
 /// Resolve a URL path into a file or directory path

--- a/rust/server/src/server.rs
+++ b/rust/server/src/server.rs
@@ -19,7 +19,7 @@ use axum::{
         HeaderMap, HeaderValue, StatusCode,
     },
     response::{Html, IntoResponse, Response},
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use document::{Document, DocumentId, SyncDirection};
@@ -155,10 +155,13 @@ pub async fn serve(
 
     let router = Router::new()
         .route("/~static/*path", get(serve_static))
-        .route("/~open/*path", get(serve_open))
-        .route("/~close/*id", post(serve_close))
-        .route("/~export/*id", get(serve_export))
-        .route("/~ws/*id", get(serve_ws))
+        .route("/~secrets", get(list_secrets))
+        .route("/~secrets/:name", post(set_secret))
+        .route("/~secrets/:name", delete(delete_secret))
+        .route("/~open/*path", get(open_document))
+        .route("/~close/:id", post(close_document))
+        .route("/~export/:id", get(export_document))
+        .route("/~ws/:id", get(serve_ws))
         .route("/*path", get(serve_document))
         .route("/", get(serve_home))
         .layer(TraceLayer::new_for_http())
@@ -263,6 +266,26 @@ async fn serve_static(
     Ok(StatusCode::NOT_FOUND.into_response())
 }
 
+/// List secrets
+#[tracing::instrument]
+async fn list_secrets() -> Result<Response, InternalError> {
+    Ok(Json(secrets::list().map_err(InternalError::new)?).into_response())
+}
+
+/// Set a secret
+#[tracing::instrument]
+async fn set_secret(Path(name): Path<String>, value: String) -> Result<Response, InternalError> {
+    secrets::set(&name, &value).map_err(InternalError::new)?;
+    Ok(StatusCode::CREATED.into_response())
+}
+
+/// Delete a secret
+#[tracing::instrument]
+async fn delete_secret(Path(name): Path<String>) -> Result<Response, InternalError> {
+    secrets::delete(&name).map_err(InternalError::new)?;
+    Ok(StatusCode::NO_CONTENT.into_response())
+}
+
 /// Resolve a URL path into a file or directory path
 ///
 /// This is an interim implementation and is likely to be replaced with
@@ -349,7 +372,7 @@ fn resolve_path(path: PathBuf) -> Result<Option<PathBuf>, InternalError> {
 
 /// Open a document and return its id
 #[tracing::instrument(skip(docs))]
-async fn serve_open(
+async fn open_document(
     State(ServerState {
         dir,
         raw,
@@ -587,7 +610,7 @@ async fn serve_home(
 }
 
 /// Handle a request to close a document
-async fn serve_close(
+async fn close_document(
     State(ServerState { docs, .. }): State<ServerState>,
     Path(id): Path<String>,
 ) -> Result<Response, InternalError> {
@@ -604,7 +627,7 @@ async fn serve_close(
 ///
 /// TODO: This should add correct MIME type to response
 /// and handle binary formats.
-async fn serve_export(
+async fn export_document(
     State(ServerState { docs, .. }): State<ServerState>,
     Path(id): Path<String>,
     Query(query): Query<HashMap<String, String>>,


### PR DESCRIPTION
Closes #1909

Still to do:

- [x] Add `Description` column to CLI table for `stencila secrets list`
- [x] Restrict setting and deleting of secrets to know secrets (in function and in CLI possible values)
~~- [ ] Add `SecretsClient` in `web` to use REST API exposed by server~~
- [ ] Implement UI as in #1909