### PR TITLE
feat(plugins): establish plugin registry and API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -95,6 +95,7 @@
         "rfind",
         "rhai",
         "rowspan",
+        "runtimes",
         "rustfmt",
         "schemars",
         "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ dependencies = [
  "kernel-python",
  "kernel-r",
  "kernel-rhai",
+ "plugins",
 ]
 
 [[package]]
@@ -4227,6 +4228,7 @@ dependencies = [
  "cli-utils",
  "common",
  "common-dev",
+ "kernel",
  "semver",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
+ "rand",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
  "tracing",
  "type-safe-id",
  "uuid",
+ "which",
  "xz2",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,7 +3040,6 @@ dependencies = [
  "app",
  "kernel",
  "nix 0.28.0",
- "which",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
  "is-terminal",
  "kernels",
  "node-strip",
+ "plugins",
  "rustyline",
  "secrets",
  "self-replace",
@@ -4215,6 +4216,17 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plugins"
+version = "0.0.0"
+dependencies = [
+ "app",
+ "cli-utils",
+ "common",
+ "common-dev",
+ "semver",
 ]
 
 [[package]]

--- a/node/src/__snapshots__/convert.test.ts.snap
+++ b/node/src/__snapshots__/convert.test.ts.snap
@@ -43,6 +43,11 @@ exports[`fromPath 1`] = `
    ],
    "authors": [
     {
+     "type": "SoftwareApplication",
+     "id": "super-editor",
+     "name": "Super-editor"
+    },
+    {
      "type": "Person",
      "familyNames": [
       "Baboon"
@@ -54,11 +59,6 @@ exports[`fromPath 1`] = `
     {
      "type": "Organization",
      "name": "Acme Corp"
-    },
-    {
-     "type": "SoftwareApplication",
-     "id": "super-editor",
-     "name": "Super-editor"
     }
    ]
   }
@@ -91,7 +91,7 @@ Paragraph two, has one person author.
 Paragraph three, has three authors or different types."
 `;
 
-exports[`fromTo 2`] = `"<article><p><span>This is paragraph one. It has two sentences.</span></p><p authors='[{"type":"Person","familyNames":["Aardvark"],"givenNames":["Ann"]}]'><span>Paragraph two, has one person author.</span></p><p authors='[{"type":"Person","familyNames":["Baboon"],"givenNames":["Bob"]},{"type":"Organization","name":"Acme Corp"},{"type":"SoftwareApplication","id":"super-editor","name":"Super-editor"}]'><span>Paragraph three, has three authors or different types.</span></p></article>"`;
+exports[`fromTo 2`] = `"<article><p><span>This is paragraph one. It has two sentences.</span></p><p authors='[{"type":"Person","familyNames":["Aardvark"],"givenNames":["Ann"]}]'><span>Paragraph two, has one person author.</span></p><p authors='[{"type":"SoftwareApplication","id":"super-editor","name":"Super-editor"},{"type":"Person","familyNames":["Baboon"],"givenNames":["Bob"]},{"type":"Organization","name":"Acme Corp"}]'><span>Paragraph three, has three authors or different types.</span></p></article>"`;
 
 exports[`toString 1`] = `
 "<article dtd-version="1.3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML">

--- a/node/src/convert.rs
+++ b/node/src/convert.rs
@@ -8,7 +8,7 @@ use napi_derive::napi;
 use codecs::{Format, LossesResponse};
 use common::{eyre, serde_json};
 
-use crate::utilities::{generic_failure, invalid_arg};
+use crate::utilities::generic_failure;
 
 /// Decoding options
 #[napi(object)]
@@ -28,10 +28,7 @@ impl TryInto<codecs::DecodeOptions> for DecodeOptions {
 
     fn try_into(self) -> Result<codecs::DecodeOptions> {
         Ok(codecs::DecodeOptions {
-            format: match self.format {
-                Some(format) => Some(Format::from_name(&format).map_err(invalid_arg)?),
-                None => None,
-            },
+            format: self.format.as_ref().map(|format| Format::from_name(format)),
             losses: self
                 .losses
                 .map(LossesResponse::from)
@@ -71,10 +68,7 @@ impl TryInto<codecs::EncodeOptions> for EncodeOptions {
 
     fn try_into(self) -> Result<codecs::EncodeOptions> {
         Ok(codecs::EncodeOptions {
-            format: match self.format {
-                Some(format) => Some(Format::from_name(&format).map_err(invalid_arg)?),
-                None => None,
-            },
+            format: self.format.as_ref().map(|format| Format::from_name(format)),
             standalone: self.standalone,
             compact: self.compact,
             losses: self

--- a/node/src/utilities.rs
+++ b/node/src/utilities.rs
@@ -8,6 +8,7 @@ pub(crate) fn generic_failure(report: eyre::Report) -> Error {
     Error::new(Status::GenericFailure, report.to_string())
 }
 
+#[allow(unused)]
 pub(crate) fn invalid_arg(report: eyre::Report) -> Error {
     Error::new(Status::InvalidArg, report.to_string())
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "stencila",
       "workspaces": [
         "node",
         "ts",
@@ -6657,13 +6658,14 @@
       }
     },
     "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+      "version": "0.10.63",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.63.tgz",
+      "integrity": "sha512-hUCZd2Byj/mNKjfP9jXrdVZ62B8KuA/VoK7X8nUh5qT+AxDmcbvZz041oDVZdbIN1qW6XY9VDNwzkvKnZvK2TQ==",
       "hasInstallScript": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
         "next-tick": "^1.1.0"
       },
       "engines": {
@@ -7056,6 +7058,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/type": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
     "node_modules/espree": {
       "version": "9.6.1",

--- a/plugins.toml
+++ b/plugins.toml
@@ -1,7 +1,7 @@
-# Add plugins name and the URL to its manifest file in alphabeical order of name.
+# Add plugin name, and the URL to its `stencila-plugin.toml` file, in alphabeical order of name.
 #
-# The plugin name used here, should be the same as its manifest file.
-# If it is not the plugin will be ignored.
+# The plugin name used here, should be the same as its `stencila-plugin.toml` file.
+# If it is not, the plugin will be ignored.
 
 node-example = "https://raw.githubusercontent.com/stencila/plugin-example-node/main/stencila-plugin.toml"
 python-example = "https://raw.githubusercontent.com/stencila/plugin-example-python/main/stencila-plugin.toml"

--- a/plugins.toml
+++ b/plugins.toml
@@ -3,5 +3,5 @@
 # The plugin name used here, should be the same as in the manifest file.
 # If it is not the plugin will be ignored.
 
-node-example = "https://raw.github.com/stencila/plugin-example-node/blob/main/manifest.toml"
-python-example = "https://raw.github.com/stencila/plugin-example-python/blob/main/manifest.toml"
+node-example = "https://raw.githubusercontent.com/stencila/plugin-example-node/main/manifest.toml"
+python-example = "https://raw.githubusercontent.com/stencila/plugin-example-python/main/manifest.toml"

--- a/plugins.toml
+++ b/plugins.toml
@@ -1,7 +1,7 @@
-# Add plugins name and URL to manifest file in alphabeical order of name.
+# Add plugins name and the URL to its manifest file in alphabeical order of name.
 #
-# The plugin name used here, should be the same as in the manifest file.
+# The plugin name used here, should be the same as its manifest file.
 # If it is not the plugin will be ignored.
 
-node-example = "https://raw.githubusercontent.com/stencila/plugin-example-node/main/manifest.toml"
-python-example = "https://raw.githubusercontent.com/stencila/plugin-example-python/main/manifest.toml"
+node-example = "https://raw.githubusercontent.com/stencila/plugin-example-node/main/stencila-plugin.toml"
+python-example = "https://raw.githubusercontent.com/stencila/plugin-example-python/main/stencila-plugin.toml"

--- a/plugins.toml
+++ b/plugins.toml
@@ -1,0 +1,7 @@
+# Add plugins name and URL to manifest file in alphabeical order of name.
+#
+# The plugin name used here, should be the same as in the manifest file.
+# If it is not the plugin will be ignored.
+
+node-example = "https://raw.github.com/stencila/plugin-example-node/blob/main/manifest.toml"
+python-example = "https://raw.github.com/stencila/plugin-example-python/blob/main/manifest.toml"

--- a/python/src/convert.rs
+++ b/python/src/convert.rs
@@ -34,10 +34,7 @@ impl TryInto<codecs::DecodeOptions> for DecodeOptions {
 
     fn try_into(self) -> PyResult<codecs::DecodeOptions> {
         Ok(codecs::DecodeOptions {
-            format: match self.format {
-                Some(format) => Some(Format::from_name(&format).map_err(value_error)?),
-                None => None,
-            },
+            format: self.format.as_ref().map(|format| Format::from_name(format)),
             ..Default::default()
         })
     }
@@ -70,10 +67,7 @@ impl TryInto<codecs::EncodeOptions> for EncodeOptions {
 
     fn try_into(self) -> PyResult<codecs::EncodeOptions> {
         Ok(codecs::EncodeOptions {
-            format: match self.format {
-                Some(format) => Some(Format::from_name(&format).map_err(value_error)?),
-                None => None,
-            },
+            format: self.format.as_ref().map(|format| Format::from_name(format)),
             standalone: self.standalone,
             compact: self.compact,
             ..Default::default()

--- a/rust/app/src/lib.rs
+++ b/rust/app/src/lib.rs
@@ -10,7 +10,8 @@ use common::{
     strum::{Display, EnumString},
 };
 
-fn project_dirs() -> Result<ProjectDirs> {
+/// Get a `ProjectDirs` struct for Stencila
+fn get_project_dirs() -> Result<ProjectDirs> {
     ProjectDirs::from("io", "stencila", "stencila").ok_or_eyre("unable to build project dirs")
 }
 
@@ -21,12 +22,13 @@ pub enum DirType {
     Config,
     Cache,
     Assistants,
+    Plugins,
     Kernels,
 }
 
 /// Get an application directory
 pub fn get_app_dir(dir_type: DirType, mut ensure: bool) -> Result<PathBuf> {
-    let dirs = project_dirs()?;
+    let dirs = get_project_dirs()?;
 
     let dir = {
         match dir_type {
@@ -40,11 +42,14 @@ pub fn get_app_dir(dir_type: DirType, mut ensure: bool) -> Result<PathBuf> {
                     dirs.config_dir().join("assistants")
                 }
             }
+            DirType::Plugins => dirs.config_dir().join("plugins"),
             DirType::Kernels => dirs.config_dir().join("kernels"),
         }
     };
+    
     if ensure && !dir.exists() {
         create_dir_all(dir.clone())?;
     }
+
     Ok(dir)
 }

--- a/rust/app/src/lib.rs
+++ b/rust/app/src/lib.rs
@@ -46,7 +46,7 @@ pub fn get_app_dir(dir_type: DirType, mut ensure: bool) -> Result<PathBuf> {
             DirType::Kernels => dirs.config_dir().join("kernels"),
         }
     };
-    
+
     if ensure && !dir.exists() {
         create_dir_all(dir.clone())?;
     }

--- a/rust/assistant-specialized/src/lib.rs
+++ b/rust/assistant-specialized/src/lib.rs
@@ -397,7 +397,11 @@ impl SpecializedAssistant {
             task.output = output;
         }
 
-        task.format = self.generated_format.or(self.format).unwrap_or(FORMAT);
+        task.format = self
+            .generated_format
+            .clone()
+            .or(self.format.clone())
+            .unwrap_or(FORMAT);
 
         task
     }
@@ -433,7 +437,11 @@ impl SpecializedAssistant {
                 codecs::to_string(
                     document,
                     Some(EncodeOptions {
-                        format: self.document_format.or(self.format).or(Some(FORMAT)),
+                        format: self
+                            .document_format
+                            .clone()
+                            .or(self.format.clone())
+                            .or(Some(FORMAT)),
                         ..encode_options.clone()
                     }),
                 )
@@ -446,7 +454,11 @@ impl SpecializedAssistant {
                 content += &codecs::to_string(
                     node,
                     Some(EncodeOptions {
-                        format: self.content_format.or(self.format).or(Some(FORMAT)),
+                        format: self
+                            .content_format
+                            .clone()
+                            .or(self.format.clone())
+                            .or(Some(FORMAT)),
                         ..encode_options.clone()
                     }),
                 )

--- a/rust/assistant/src/lib.rs
+++ b/rust/assistant/src/lib.rs
@@ -681,14 +681,14 @@ impl GenerateOutput {
     ) -> Result<Self> {
         let format = match task.format {
             Format::Unknown => Format::Markdown,
-            _ => task.format,
+            _ => task.format.clone(),
         };
 
         // Decode text to an article
         let node = codecs::from_str(
             &text,
             Some(DecodeOptions {
-                format: Some(format),
+                format: Some(format.clone()),
                 ..Default::default()
             }),
         )

--- a/rust/cli-utils/src/lib.rs
+++ b/rust/cli-utils/src/lib.rs
@@ -11,6 +11,9 @@ use common::{serde::Serialize, serde_json};
 
 pub use rpassword;
 
+mod message;
+pub use message::*;
+
 pub mod table;
 
 /// A trait for displaying an object to stdout

--- a/rust/cli-utils/src/message.rs
+++ b/rust/cli-utils/src/message.rs
@@ -1,0 +1,21 @@
+use common::serde::Serialize;
+
+use crate::ToStdout;
+
+/// A message for a user
+#[derive(Serialize)]
+#[serde(crate = "common::serde")]
+pub struct Message(pub String);
+
+#[macro_export]
+macro_rules! message {
+    ($str:literal, $($arg:tt)*) => {
+        Message(format!($str, $($arg)*))
+    };
+}
+
+impl ToStdout for Message {
+    fn to_terminal(&self) -> impl std::fmt::Display {
+        self.0.clone()
+    }
+}

--- a/rust/cli-utils/src/table.rs
+++ b/rust/cli-utils/src/table.rs
@@ -1,6 +1,7 @@
 use comfy_table::{
     modifiers::{UTF8_ROUND_CORNERS, UTF8_SOLID_INNER_BORDERS},
-    presets::UTF8_FULL, ContentArrangement,
+    presets::UTF8_FULL,
+    ContentArrangement,
 };
 
 // Re-exports

--- a/rust/cli-utils/src/table.rs
+++ b/rust/cli-utils/src/table.rs
@@ -1,6 +1,6 @@
 use comfy_table::{
     modifiers::{UTF8_ROUND_CORNERS, UTF8_SOLID_INNER_BORDERS},
-    presets::UTF8_FULL,
+    presets::UTF8_FULL, ContentArrangement,
 };
 
 // Re-exports
@@ -15,6 +15,7 @@ pub fn new() -> Table {
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .apply_modifier(UTF8_SOLID_INNER_BORDERS);
+        .apply_modifier(UTF8_SOLID_INNER_BORDERS)
+        .set_content_arrangement(ContentArrangement::Dynamic);
     table
 }

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -24,6 +24,7 @@ format = { path = "../format" }
 kernels = { path = "../kernels" }
 is-terminal = "0.4.12"
 node-strip = { path = "../node-strip" }
+plugins = { path = "../plugins" }
 rustyline = "13.0.0"
 secrets = { path = "../secrets" }
 self-replace = "1.3.7"

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -347,7 +347,10 @@ impl DecodeOptions {
         strip_options: StripOptions,
         losses: codecs::LossesResponse,
     ) -> codecs::DecodeOptions {
-        let (format, codec) = codecs::format_or_codec(format_or_codec);
+        let codec = format_or_codec
+            .as_ref()
+            .and_then(|name| codecs::codec_maybe(name));
+        let format = format_or_codec.map(|name| Format::from_name(&name));
 
         codecs::DecodeOptions {
             codec,
@@ -394,7 +397,10 @@ impl EncodeOptions {
         strip_options: StripOptions,
         losses: codecs::LossesResponse,
     ) -> codecs::EncodeOptions {
-        let (format, codec) = codecs::format_or_codec(format_or_codec);
+        let codec = format_or_codec
+            .as_ref()
+            .and_then(|name| codecs::codec_maybe(name));
+        let format = format_or_codec.map(|name| Format::from_name(&name));
 
         let compact = self
             .compact
@@ -487,7 +493,7 @@ impl Cli {
                 let doc = Document::open(&doc).await?;
 
                 let options = options.build(to, strip_options, losses);
-                let format = options.format.unwrap_or(Format::Text);
+                let format = options.format.clone().unwrap_or(Format::Text);
 
                 let content = doc.export(dest.as_deref(), Some(options)).await?;
                 if !content.is_empty() {
@@ -602,7 +608,7 @@ impl Cli {
                 doc.execute().await?;
 
                 let encode_options = codecs::EncodeOptions::default();
-                let format = encode_options.format.unwrap_or(Format::Text);
+                let format = encode_options.format.clone().unwrap_or(Format::Text);
 
                 let content = doc.export(output.as_deref(), Some(encode_options)).await?;
                 if !content.is_empty() {

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -305,7 +305,7 @@ enum Command {
     },
 
     Kernels(kernels::cli::Cli),
-
+    Plugins(plugins::cli::Cli),
     Secrets(secrets::cli::Cli),
 
     Config(ConfigOptions),
@@ -751,7 +751,7 @@ impl Cli {
             Command::Test { path, reps } => assistants::testing::test_example(&path, reps).await?,
 
             Command::Kernels(kernels) => kernels.run().await?,
-
+            Command::Plugins(plugins) => plugins.run().await?,
             Command::Secrets(secrets) => secrets.run().await?,
 
             Command::Config(options) => {

--- a/rust/cli/src/upgrade.rs
+++ b/rust/cli/src/upgrade.rs
@@ -88,7 +88,7 @@ pub fn check() -> JoinHandle<Option<String>> {
         match check.await {
             Ok(version) => version,
             Err(error) => {
-                tracing::warn!("While checking for upgrade: {error}");
+                tracing::debug!("While checking for upgrade: {error}");
                 None
             }
         }

--- a/rust/codec-cbor/src/lib.rs
+++ b/rust/codec-cbor/src/lib.rs
@@ -22,7 +22,7 @@ impl Codec for CborCodec {
         Status::Stable
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Cbor => CodecSupport::NoLoss,
             Format::CborZst => CodecSupport::NoLoss,
@@ -30,7 +30,7 @@ impl Codec for CborCodec {
         }
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Cbor => CodecSupport::NoLoss,
             Format::CborZst => CodecSupport::NoLoss,

--- a/rust/codec-debug/src/lib.rs
+++ b/rust/codec-debug/src/lib.rs
@@ -31,7 +31,7 @@ impl Codec for DebugCodec {
         false
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Debug => CodecSupport::LowLoss,
             _ => CodecSupport::None,

--- a/rust/codec-directory/src/lib.rs
+++ b/rust/codec-directory/src/lib.rs
@@ -29,14 +29,14 @@ impl Codec for DirectoryCodec {
         Status::UnderDevelopment
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Directory => CodecSupport::NoLoss,
             _ => CodecSupport::None,
         }
     }
 
-    fn supports_to_format(&self, _format: Format) -> CodecSupport {
+    fn supports_to_format(&self, _format: &Format) -> CodecSupport {
         CodecSupport::None
     }
 

--- a/rust/codec-dom/src/lib.rs
+++ b/rust/codec-dom/src/lib.rs
@@ -23,7 +23,7 @@ impl Codec for DomCodec {
         Status::UnderDevelopment
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Dom => CodecSupport::NoLoss,
             _ => CodecSupport::None,

--- a/rust/codec-html/src/lib.rs
+++ b/rust/codec-html/src/lib.rs
@@ -20,7 +20,7 @@ impl Codec for HtmlCodec {
         Status::UnderDevelopment
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Html => CodecSupport::LowLoss,
             _ => CodecSupport::None,

--- a/rust/codec-jats/src/lib.rs
+++ b/rust/codec-jats/src/lib.rs
@@ -25,7 +25,7 @@ impl Codec for JatsCodec {
         Status::UnderDevelopment
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         use CodecSupport::*;
         match format {
             Format::Jats => LowLoss,
@@ -33,7 +33,7 @@ impl Codec for JatsCodec {
         }
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         use CodecSupport::*;
         match format {
             Format::Jats => LowLoss,

--- a/rust/codec-json/src/lib.rs
+++ b/rust/codec-json/src/lib.rs
@@ -26,7 +26,7 @@ impl Codec for JsonCodec {
         Status::Stable
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Json => CodecSupport::NoLoss,
             _ => CodecSupport::None,
@@ -43,7 +43,7 @@ impl Codec for JsonCodec {
         Ok((node, Losses::none()))
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Json => CodecSupport::NoLoss,
             _ => CodecSupport::None,

--- a/rust/codec-json5/src/lib.rs
+++ b/rust/codec-json5/src/lib.rs
@@ -24,7 +24,7 @@ impl Codec for Json5Codec {
         Status::Stable
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Json5 => CodecSupport::NoLoss,
             _ => CodecSupport::None,
@@ -41,7 +41,7 @@ impl Codec for Json5Codec {
         Ok((node, Losses::none()))
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Json5 => CodecSupport::NoLoss,
             _ => CodecSupport::None,

--- a/rust/codec-jsonld/src/lib.rs
+++ b/rust/codec-jsonld/src/lib.rs
@@ -54,14 +54,14 @@ impl Codec for JsonLdCodec {
         Status::Beta
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::JsonLd => CodecSupport::NoLoss,
             _ => CodecSupport::None,
         }
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::JsonLd => CodecSupport::NoLoss,
             _ => CodecSupport::None,

--- a/rust/codec-markdown/src/decode/content.rs
+++ b/rust/codec-markdown/src/decode/content.rs
@@ -692,7 +692,7 @@ pub fn decode_blocks(
                     };
 
                     let content_url = current_url.to_string();
-                    let media_object = if let Ok(format) = Format::from_string(&content_url) {
+                    let media_object = if let Ok(format) = Format::from_url(&content_url) {
                         if format.is_audio() {
                             Inline::AudioObject(AudioObject {
                                 content_url,

--- a/rust/codec-markdown/src/lib.rs
+++ b/rust/codec-markdown/src/lib.rs
@@ -23,7 +23,7 @@ impl Codec for MarkdownCodec {
         Status::Alpha
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         use CodecSupport::*;
         match format {
             Format::Markdown => LowLoss,
@@ -31,7 +31,7 @@ impl Codec for MarkdownCodec {
         }
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         use CodecSupport::*;
         match format {
             Format::Markdown => LowLoss,

--- a/rust/codec-text/src/lib.rs
+++ b/rust/codec-text/src/lib.rs
@@ -21,7 +21,7 @@ impl Codec for TextCodec {
         Status::Alpha
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Text => CodecSupport::HighLoss,
             _ => CodecSupport::None,

--- a/rust/codec-yaml/src/lib.rs
+++ b/rust/codec-yaml/src/lib.rs
@@ -29,7 +29,7 @@ impl Codec for YamlCodec {
         Status::Stable
     }
 
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Yaml => CodecSupport::NoLoss,
             _ => CodecSupport::None,
@@ -46,7 +46,7 @@ impl Codec for YamlCodec {
         Ok((node, Losses::none()))
     }
 
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         match format {
             Format::Yaml => CodecSupport::NoLoss,
             _ => CodecSupport::None,

--- a/rust/codec/src/lib.rs
+++ b/rust/codec/src/lib.rs
@@ -50,7 +50,7 @@ pub trait Codec: Sync + Send {
 
     /// The level of support that the codec provides for decoding from a format
     #[allow(unused)]
-    fn supports_from_format(&self, format: Format) -> CodecSupport {
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
         CodecSupport::None
     }
 
@@ -58,7 +58,7 @@ pub trait Codec: Sync + Send {
     fn supports_from_formats(&self) -> BTreeMap<Format, CodecSupport> {
         Format::iter()
             .filter_map(|format| {
-                let support = self.supports_from_format(format);
+                let support = self.supports_from_format(&format);
                 support.is_supported().then_some((format, support))
             })
             .collect()
@@ -99,7 +99,7 @@ pub trait Codec: Sync + Send {
 
     /// The level of support that the codec provides for encoding to a format
     #[allow(unused)]
-    fn supports_to_format(&self, format: Format) -> CodecSupport {
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
         CodecSupport::None
     }
 
@@ -107,7 +107,7 @@ pub trait Codec: Sync + Send {
     fn supports_to_formats(&self) -> BTreeMap<Format, CodecSupport> {
         Format::iter()
             .filter_map(|format| {
-                let support = self.supports_to_format(format);
+                let support = self.supports_to_format(&format);
                 support.is_supported().then_some((format, support))
             })
             .collect()

--- a/rust/codecs/src/lib.rs
+++ b/rust/codecs/src/lib.rs
@@ -32,23 +32,18 @@ pub fn list() -> Vec<Box<dyn Codec>> {
     ]
 }
 
-/// Resolve whether an optional string is a format or codec name
-///
-/// If the string matches the name of a format then assume it is a format, otherwise assume it is a codec name
-pub fn format_or_codec(format_or_codec: Option<String>) -> (Option<Format>, Option<String>) {
-    match format_or_codec {
-        Some(format_or_codec) => match Format::from_string(format_or_codec.to_lowercase()) {
-            Ok(format) => (Some(format), None),
-            Err(..) => (None, Some(format_or_codec)),
-        },
-        None => (None, None),
-    }
+/// Resolve whether an optional string is a codec
+pub fn codec_maybe(name: &str) -> Option<String> {
+    list()
+        .iter()
+        .any(|codec| codec.name() == name)
+        .then(|| name.to_string())
 }
 
 /// Get the codec for a given format
 pub fn get(
     name: Option<&String>,
-    format: Option<Format>,
+    format: Option<&Format>,
     direction: Option<CodecDirection>,
 ) -> Result<Box<dyn Codec>> {
     if let Some(name) = name {
@@ -107,10 +102,10 @@ pub async fn from_str_with_losses(
 
     let format = options
         .as_ref()
-        .and_then(|options| options.format)
+        .and_then(|options| options.format.clone())
         .unwrap_or(Format::Json);
 
-    let codec = get(codec, Some(format), Some(CodecDirection::Decode))?;
+    let codec = get(codec, Some(&format), Some(CodecDirection::Decode))?;
 
     NodeUid::reset();
 
@@ -148,12 +143,12 @@ pub async fn from_path_with_losses(
 ) -> Result<(Node, Losses)> {
     let codec = options.as_ref().and_then(|options| options.codec.as_ref());
 
-    let format = match options.as_ref().and_then(|options| options.format) {
+    let format = match options.as_ref().and_then(|options| options.format.clone()) {
         Some(format) => format,
         None => Format::from_path(path)?,
     };
 
-    let codec = get(codec, Some(format), Some(CodecDirection::Decode))?;
+    let codec = get(codec, Some(&format), Some(CodecDirection::Decode))?;
 
     NodeUid::reset();
 
@@ -209,10 +204,10 @@ pub async fn to_string_with(
 
     let format = options
         .as_ref()
-        .and_then(|options| options.format)
+        .and_then(|options| options.format.clone())
         .unwrap_or(Format::Json);
 
-    let codec = get(codec, Some(format), Some(CodecDirection::Encode))?;
+    let codec = get(codec, Some(&format), Some(CodecDirection::Encode))?;
 
     let options = Some(EncodeOptions {
         format: Some(format),
@@ -259,12 +254,12 @@ pub async fn to_path_with_losses(
 ) -> Result<Losses> {
     let codec = options.as_ref().and_then(|options| options.codec.as_ref());
 
-    let format = match options.as_ref().and_then(|options| options.format) {
+    let format = match options.as_ref().and_then(|options| options.format.clone()) {
         Some(format) => format,
         None => Format::from_path(path)?,
     };
 
-    let codec = get(codec, Some(format), Some(CodecDirection::Encode))?;
+    let codec = get(codec, Some(&format), Some(CodecDirection::Encode))?;
 
     let options = Some(EncodeOptions {
         format: Some(format),

--- a/rust/codecs/tests/examples.rs
+++ b/rust/codecs/tests/examples.rs
@@ -341,7 +341,7 @@ async fn examples() -> Result<()> {
             let mut file = path.parent().expect("should have parent").join(prefix);
             file.set_extension(extension.as_str());
 
-            let codec = codecs::get(None, Some(config.format), None)?;
+            let codec = codecs::get(None, Some(&config.format), None)?;
 
             let mut original = node.clone();
 
@@ -358,7 +358,7 @@ async fn examples() -> Result<()> {
                 original.strip(&targets);
 
                 let encode_options = Some(EncodeOptions {
-                    format: Some(config.format),
+                    format: Some(config.format.clone()),
                     ..config.encode.options.clone()
                 });
 
@@ -415,7 +415,7 @@ async fn examples() -> Result<()> {
 
             if file.exists() && !config.decode.skip {
                 let decode_options = Some(DecodeOptions {
-                    format: Some(config.format),
+                    format: Some(config.format.clone()),
                     ..config.decode.options.clone()
                 });
 

--- a/rust/codecs/tests/proptests.rs
+++ b/rust/codecs/tests/proptests.rs
@@ -31,10 +31,10 @@ fn roundtrip(
     decode_options: Option<DecodeOptions>,
 ) -> Result<Node> {
     block_on(async {
-        let codec = codecs::get(None, Some(format), None)?;
+        let codec = codecs::get(None, Some(&format), None)?;
 
         let encode_options = Some(EncodeOptions {
-            format: Some(format),
+            format: Some(format.clone()),
             ..encode_options.unwrap_or_default()
         });
 

--- a/rust/common/Cargo.toml
+++ b/rust/common/Cargo.toml
@@ -42,5 +42,6 @@ toml = "0.8.10"
 tracing = { version = "0.1.40", features = ["log"] }
 type-safe-id = "0.2.1"
 uuid = "1.7.0"
+which = "6.0.0"
 xz2 = "0.1.7"
 zip = "0.6.6"

--- a/rust/common/Cargo.toml
+++ b/rust/common/Cargo.toml
@@ -23,6 +23,7 @@ maplit = "1.0.2"
 once_cell = "1.19.0"
 proc-macro2 = "1.0.78"
 quote = "1.0.35"
+rand = "0.8.5"
 regex = "1.10.3"
 reqwest = { version = "0.11.24", features = ["json"] }
 serde = { version = "1.0.197", features = ["derive", "rc"] }

--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -47,5 +47,6 @@ pub use toml;
 pub use tracing;
 pub use type_safe_id;
 pub use uuid;
+pub use which;
 pub use xz2;
 pub use zip;

--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -28,6 +28,7 @@ pub use maplit;
 pub use once_cell;
 pub use proc_macro2;
 pub use quote;
+pub use rand;
 pub use regex;
 pub use reqwest;
 pub use serde;

--- a/rust/format/src/lib.rs
+++ b/rust/format/src/lib.rs
@@ -1,6 +1,7 @@
 //! Provides the `Format` enum and utility functions for working with document formats
 
 use std::{
+    fmt::Display,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -8,12 +9,11 @@ use std::{
 use common::{
     eyre::{Report, Result},
     serde_with::{DeserializeFromStr, SerializeDisplay},
-    strum::{Display, EnumIter},
+    strum::EnumIter,
 };
 
 #[derive(
     Debug,
-    Display,
     Default,
     Clone,
     PartialOrd,
@@ -24,11 +24,7 @@ use common::{
     SerializeDisplay,
     DeserializeFromStr,
 )]
-#[strum(
-    serialize_all = "lowercase",
-    ascii_case_insensitive,
-    crate = "common::strum"
-)]
+#[strum(crate = "common::strum")]
 #[serde_with(crate = "common::serde_with")]
 pub enum Format {
     // Grouped and ordered as most appropriate for documentation
@@ -180,10 +176,10 @@ impl Format {
             "avi" => Avi,
             "bash" => Bash,
             "cbor" => Cbor,
-            "cborzst" => CborZst,
+            "cborzst" | "cbor.zstd" => CborZst,
             "debug" => Debug,
-            "directory" => Directory,
-            "dom" => Dom,
+            "directory" | "dir" => Directory,
+            "dom" | "dom.html" => Dom,
             "flac" => Flac,
             "gif" => Gif,
             "html" => Html,
@@ -204,12 +200,14 @@ impl Format {
             "r" => R,
             "rhai" => Rhai,
             "shell" | "sh" => Shell,
+            "sta" => Article,
             "svg" => Svg,
             "text" | "txt" => Text,
             "wav" => Wav,
             "webm" => WebM,
             "webp" => WebP,
             "yaml" | "yml" => Yaml,
+            "unknown" => Unknown,
             _ => Other(name.to_string()),
         }
     }
@@ -319,8 +317,55 @@ impl FromStr for Format {
     }
 }
 
+impl Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Format::*;
+        f.write_str(match self {
+            Aac => "aac",
+            Article => "sta",
+            Avi => "avi",
+            Bash => "bash",
+            Cbor => "cbor",
+            CborZst => "cbor.zstd",
+            Debug => "Debug",
+            Directory => "dir",
+            Dom => "dom.html",
+            Flac => "flac",
+            Gif => "gif",
+            Html => "html",
+            Jats => "jats",
+            JavaScript => "js",
+            Jpeg => "jpeg",
+            Json => "json",
+            Json5 => "json5",
+            JsonLd => "jsonld",
+            Markdown => "md",
+            Mkv => "mkv",
+            Mp3 => "mp3",
+            Mp4 => "mp4",
+            Ogg => "ogg",
+            Ogv => "ogv",
+            Png => "png",
+            Python => "py",
+            R => "r",
+            Rhai => "rhai",
+            Shell => "sh",
+            Svg => "svg",
+            Text => "txt",
+            Wav => "wav",
+            WebM => "webm",
+            WebP => "webp",
+            Yaml => "yaml",
+            Other(name) => name,
+            Unknown => "unknown",
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use common::strum::IntoEnumIterator;
+
     use super::*;
 
     #[test]
@@ -347,6 +392,15 @@ mod test {
             Format::Other("foo".to_string())
         );
         assert_eq!(Format::from_url("foo")?, Format::Other("foo".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn roundtrip() -> Result<()> {
+        for format in Format::iter() {
+            assert_eq!(format, Format::from_str(&format.to_string())?)
+        }
 
         Ok(())
     }

--- a/rust/kernel-micro/Cargo.toml
+++ b/rust/kernel-micro/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 app = { path = "../app" }
 kernel = { path = "../kernel" }
-which = "6.0.0"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28.0", features = ["fs", "signal"] }

--- a/rust/kernel-micro/src/lib.rs
+++ b/rust/kernel-micro/src/lib.rs
@@ -30,6 +30,7 @@ use kernel::{
             sync::{mpsc, watch},
         },
         tracing,
+        which
     },
     schema::{
         ExecutionMessage, MessageLevel, Node, Null, SoftwareApplication, SoftwareSourceCode,

--- a/rust/kernel-micro/src/lib.rs
+++ b/rust/kernel-micro/src/lib.rs
@@ -29,8 +29,7 @@ use kernel::{
             process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
             sync::{mpsc, watch},
         },
-        tracing,
-        which
+        tracing, which,
     },
     schema::{
         ExecutionMessage, MessageLevel, Node, Null, SoftwareApplication, SoftwareSourceCode,

--- a/rust/kernel/src/lib.rs
+++ b/rust/kernel/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use common::{
     async_trait::async_trait,
     eyre::{bail, Result},
+    serde::{Deserialize, Serialize},
     strum::Display,
     tokio::sync::{mpsc, watch},
 };
@@ -63,8 +64,9 @@ pub trait Kernel: Sync + Send {
 }
 
 /// The availability of a kernel on the current machine
-#[derive(Display)]
+#[derive(Debug, Display, Clone, Copy, Serialize, Deserialize)]
 #[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase", crate = "common::serde")]
 pub enum KernelAvailability {
     /// Available on this machine
     Available,
@@ -78,12 +80,14 @@ pub enum KernelAvailability {
 ///
 /// The interrupt signal is used to stop the execution task the
 /// kernel instance is current performing.
-#[derive(Display)]
+#[derive(Debug, Display, Default, Clone, Copy, Serialize, Deserialize)]
 #[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase", crate = "common::serde")]
 pub enum KernelInterrupt {
     /// Kernel supports interrupt signal on this machine
     Yes,
     /// Kernel does not support interrupt signal on this machine
+    #[default]
     No,
 }
 
@@ -91,12 +95,14 @@ pub enum KernelInterrupt {
 ///
 /// The terminate signal is used to stop the kernel instance gracefully
 /// (e.g. completing any current execution tasks)
-#[derive(Display)]
+#[derive(Debug, Display, Default, Clone, Copy, Serialize, Deserialize)]
 #[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase", crate = "common::serde")]
 pub enum KernelTerminate {
     /// Kernel supports terminate signal on this machine
     Yes,
     /// Kernel does not support terminate signal on this machine
+    #[default]
     No,
 }
 
@@ -104,22 +110,26 @@ pub enum KernelTerminate {
 ///
 /// The kill signal is used to stop the kernel instance forcefully
 /// (i.e. to exit immediately, aborting any current execution tasks)
-#[derive(Display)]
+#[derive(Debug, Display, Default, Clone, Copy, Serialize, Deserialize)]
 #[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase", crate = "common::serde")]
 pub enum KernelKill {
     /// Kernel supports kill signal on this machine
     Yes,
     /// Kernel does not support kill signal on this machine
+    #[default]
     No,
 }
 
 /// Whether a kernel supports forking on the current machine
-#[derive(Display)]
+#[derive(Debug, Display, Default, Clone, Copy, Serialize, Deserialize)]
 #[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase", crate = "common::serde")]
 pub enum KernelForks {
     /// Kernel supports forking on this machine
     Yes,
     /// Kernel does not support forking on this machine
+    #[default]
     No,
 }
 

--- a/rust/kernels/Cargo.toml
+++ b/rust/kernels/Cargo.toml
@@ -11,3 +11,4 @@ kernel-node = { path = "../kernel-node" }
 kernel-python = { path = "../kernel-python" }
 kernel-r = { path = "../kernel-r" }
 kernel-rhai = { path = "../kernel-rhai" }
+plugins = { path = "../plugins" }

--- a/rust/kernels/src/cli.rs
+++ b/rust/kernels/src/cli.rs
@@ -72,7 +72,7 @@ impl Cli {
                     "Kill",
                 ]);
 
-                for kernel in list() {
+                for kernel in list().await {
                     use KernelAvailability::*;
 
                     let availability = kernel.availability();

--- a/rust/kernels/src/lib.rs
+++ b/rust/kernels/src/lib.rs
@@ -15,14 +15,19 @@ use kernel_rhai::RhaiKernel;
 pub mod cli;
 
 /// Get a list of available kernels
-pub fn list() -> Vec<Box<dyn Kernel>> {
-    vec![
+pub async fn list() -> Vec<Box<dyn Kernel>> {
+    let mut kernels = vec![
         Box::<BashKernel>::default() as Box<dyn Kernel>,
         Box::<NodeKernel>::default() as Box<dyn Kernel>,
         Box::<PythonKernel>::default() as Box<dyn Kernel>,
         Box::<RKernel>::default() as Box<dyn Kernel>,
         Box::<RhaiKernel>::default() as Box<dyn Kernel>,
-    ]
+    ];
+
+    let provided_by_plugins = &mut plugins::kernels::list().await;
+    kernels.append(provided_by_plugins);
+
+    kernels
 }
 
 /// Get the default kernel (used when no language is specified)
@@ -52,7 +57,7 @@ impl Kernels {
             Some(language) => 'block: {
                 let format = Format::from_name(language).ok();
 
-                for kernel in list() {
+                for kernel in list().await {
                     if kernel.name() == language {
                         break 'block kernel;
                     }

--- a/rust/kernels/src/lib.rs
+++ b/rust/kernels/src/lib.rs
@@ -55,17 +55,15 @@ impl Kernels {
     async fn create_instance(&mut self, language: Option<&str>) -> Result<&mut dyn KernelInstance> {
         let kernel = match language {
             Some(language) => 'block: {
-                let format = Format::from_name(language).ok();
+                let format = Format::from_name(language);
 
                 for kernel in list().await {
                     if kernel.name() == language {
                         break 'block kernel;
                     }
 
-                    if let Some(format) = format {
-                        if kernel.supports_language(&format) && kernel.is_available() {
-                            break 'block kernel;
-                        }
+                    if kernel.supports_language(&format) && kernel.is_available() {
+                        break 'block kernel;
                     }
                 }
 
@@ -96,7 +94,7 @@ impl Kernels {
     /// If no language specified, and there is at least one kernel instance, returns the
     /// first instance.
     fn get_instance(&mut self, language: Option<&str>) -> Result<Option<&mut dyn KernelInstance>> {
-        let format = language.and_then(|lang| Format::from_name(lang).ok());
+        let format = language.map(Format::from_name);
 
         for (kernel, instance) in self.instances.iter_mut() {
             let Some(language) = language else {
@@ -107,8 +105,8 @@ impl Kernels {
                 return Ok(Some(instance.as_mut()));
             }
 
-            if let Some(format) = format {
-                if kernel.supports_language(&format) {
+            if let Some(format) = &format {
+                if kernel.supports_language(format) {
                     return Ok(Some(instance.as_mut()));
                 }
             }

--- a/rust/plugins/Cargo.toml
+++ b/rust/plugins/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "plugins"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+app = { path = "../app" }
+cli-utils = { path = "../cli-utils" }
+common = { path = "../common" }
+common-dev = { path = "../common-dev" }
+semver = { version = "1.0.21" }

--- a/rust/plugins/Cargo.toml
+++ b/rust/plugins/Cargo.toml
@@ -8,4 +8,5 @@ app = { path = "../app" }
 cli-utils = { path = "../cli-utils" }
 common = { path = "../common" }
 common-dev = { path = "../common-dev" }
+kernel = { path = "../kernel" }
 semver = { version = "1.0.21" }

--- a/rust/plugins/src/check.rs
+++ b/rust/plugins/src/check.rs
@@ -1,0 +1,41 @@
+use common::{
+    clap::{self, Args},
+    eyre::Result,
+    tracing,
+};
+
+use crate::{Plugin, PluginTransport};
+
+/// Install a plugin
+#[tracing::instrument]
+pub async fn check(name: &str, transport: Option<PluginTransport>) -> Result<()> {
+    tracing::debug!("Checking plugin `{name}`");
+
+    let plugin = Plugin::read_manifest(name)?;
+
+    // Start a plugin instance
+    let mut instance = plugin.start(transport).await?;
+
+    // Call all methods (with any args) and ensure they don't error
+    instance.health().await?;
+
+    // Stop the plugin instance
+    instance.stop().await?;
+
+    tracing::info!(
+        "Successfully checked plugin `{}` version `{}`",
+        plugin.name,
+        plugin.version,
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Default, Args)]
+pub struct CheckArgs {
+    /// The name of the plugin to install
+    pub name: String,
+
+    /// The message transport to check the plugin with
+    pub transport: Option<PluginTransport>,
+}

--- a/rust/plugins/src/check.rs
+++ b/rust/plugins/src/check.rs
@@ -23,7 +23,7 @@ pub async fn check(name: &str, transport: Option<PluginTransport>) -> Result<()>
     instance.stop().await?;
 
     tracing::info!(
-        "Successfully checked plugin `{}` version `{}`",
+        "💯 Successfully checked plugin `{}` version `{}`",
         plugin.name,
         plugin.version,
     );

--- a/rust/plugins/src/check.rs
+++ b/rust/plugins/src/check.rs
@@ -1,3 +1,4 @@
+use cli_utils::{message, Message};
 use common::{
     clap::{self, Args},
     eyre::Result,
@@ -6,9 +7,9 @@ use common::{
 
 use crate::{Plugin, PluginTransport};
 
-/// Install a plugin
+/// Check a plugin
 #[tracing::instrument]
-pub async fn check(name: &str, transport: Option<PluginTransport>) -> Result<()> {
+pub async fn check(name: &str, transport: Option<PluginTransport>) -> Result<Message> {
     tracing::debug!("Checking plugin `{name}`");
 
     let plugin = Plugin::read_manifest(name)?;
@@ -22,15 +23,14 @@ pub async fn check(name: &str, transport: Option<PluginTransport>) -> Result<()>
     // Stop the plugin instance
     instance.stop().await?;
 
-    tracing::info!(
+    Ok(message!(
         "💯 Successfully checked plugin `{}` version `{}`",
         plugin.name,
-        plugin.version,
-    );
-
-    Ok(())
+        plugin.version
+    ))
 }
 
+/// Check a plugin
 #[derive(Debug, Default, Args)]
 pub struct CheckArgs {
     /// The name of the plugin to install
@@ -38,4 +38,10 @@ pub struct CheckArgs {
 
     /// The message transport to check the plugin with
     pub transport: Option<PluginTransport>,
+}
+
+impl CheckArgs {
+    pub async fn run(self) -> Result<Message> {
+        check(&self.name, self.transport).await
+    }
 }

--- a/rust/plugins/src/cli.rs
+++ b/rust/plugins/src/cli.rs
@@ -6,7 +6,7 @@ use common::{
 
 use crate::{
     check::CheckArgs, disable::DisableArgs, enable::EnableArgs, install::InstallArgs,
-    link::LinkArgs, list::ListArgs, uninstall::UninstallArgs,
+    link::LinkArgs, list::ListArgs, show::ShowArgs, uninstall::UninstallArgs,
 };
 
 /// Manage plugins
@@ -24,6 +24,7 @@ enum Command {
     Link(LinkArgs),
     Enable(EnableArgs),
     Disable(DisableArgs),
+    Show(ShowArgs),
     Check(CheckArgs),
 }
 
@@ -41,6 +42,7 @@ impl Cli {
             Command::Link(args) => args.run().await?.to_stdout(),
             Command::Enable(args) => args.run().await?.to_stdout(),
             Command::Disable(args) => args.run().await?.to_stdout(),
+            Command::Show(args) => args.run().await?.to_stdout(),
             Command::Check(args) => args.run().await?.to_stdout(),
         }
 

--- a/rust/plugins/src/cli.rs
+++ b/rust/plugins/src/cli.rs
@@ -5,6 +5,7 @@ use common::{
 };
 
 use crate::{
+    check::{check, CheckArgs},
     install::{install, InstallArgs},
     list::{list, ListArgs},
     uninstall::{uninstall, UninstallArgs},
@@ -28,6 +29,9 @@ enum Command {
 
     /// Uninstall a plugin
     Uninstall(UninstallArgs),
+
+    /// Check a plugin
+    Check(CheckArgs),
 }
 
 impl Cli {
@@ -42,6 +46,7 @@ impl Cli {
             Command::List(options) => list(options).await?.to_stdout(),
             Command::Install(InstallArgs { name }) => install(&name).await?,
             Command::Uninstall(UninstallArgs { name }) => uninstall(&name).await?,
+            Command::Check(CheckArgs { name, transport }) => check(&name, transport).await?,
         }
 
         Ok(())

--- a/rust/plugins/src/cli.rs
+++ b/rust/plugins/src/cli.rs
@@ -1,0 +1,37 @@
+use cli_utils::ToStdout;
+use common::{
+    clap::{self, Parser, Subcommand},
+    eyre::Result,
+};
+
+use crate::list::{list, ListOptions};
+
+/// List, install, update, and uninstall plugins
+#[derive(Debug, Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+/// A command to perform with plugins
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// List plugins available and installed
+    List(ListOptions),
+}
+
+impl Cli {
+    // Run the CLI
+    pub async fn run(self) -> Result<()> {
+        let Some(command) = self.command else {
+            list(ListOptions::default()).await?.to_stdout();
+            return Ok(());
+        };
+
+        match command {
+            Command::List(options) => list(options).await?.to_stdout(),
+        }
+
+        Ok(())
+    }
+}

--- a/rust/plugins/src/cli.rs
+++ b/rust/plugins/src/cli.rs
@@ -4,7 +4,11 @@ use common::{
     eyre::Result,
 };
 
-use crate::list::{list, ListOptions};
+use crate::{
+    install::{install, InstallArgs},
+    list::{list, ListArgs},
+    uninstall::{uninstall, UninstallArgs},
+};
 
 /// List, install, update, and uninstall plugins
 #[derive(Debug, Parser)]
@@ -16,20 +20,28 @@ pub struct Cli {
 /// A command to perform with plugins
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// List plugins available and installed
-    List(ListOptions),
+    /// List plugins
+    List(ListArgs),
+
+    /// Install a plugin
+    Install(InstallArgs),
+
+    /// Uninstall a plugin
+    Uninstall(UninstallArgs),
 }
 
 impl Cli {
     // Run the CLI
     pub async fn run(self) -> Result<()> {
         let Some(command) = self.command else {
-            list(ListOptions::default()).await?.to_stdout();
+            list(ListArgs::default()).await?.to_stdout();
             return Ok(());
         };
 
         match command {
             Command::List(options) => list(options).await?.to_stdout(),
+            Command::Install(InstallArgs { name }) => install(&name).await?,
+            Command::Uninstall(UninstallArgs { name }) => uninstall(&name).await?,
         }
 
         Ok(())

--- a/rust/plugins/src/cli.rs
+++ b/rust/plugins/src/cli.rs
@@ -6,6 +6,8 @@ use common::{
 
 use crate::{
     check::{check, CheckArgs},
+    disable::{disable, DisableArgs},
+    enable::{enable, EnableArgs},
     install::{install, InstallArgs},
     list::{list, ListArgs},
     uninstall::{uninstall, UninstallArgs},
@@ -30,6 +32,12 @@ enum Command {
     /// Uninstall a plugin
     Uninstall(UninstallArgs),
 
+    /// Enable a plugin
+    Enable(EnableArgs),
+
+    /// Disable a plugin
+    Disable(DisableArgs),
+
     /// Check a plugin
     Check(CheckArgs),
 }
@@ -46,6 +54,8 @@ impl Cli {
             Command::List(options) => list(options).await?.to_stdout(),
             Command::Install(InstallArgs { name }) => install(&name).await?,
             Command::Uninstall(UninstallArgs { name }) => uninstall(&name).await?,
+            Command::Enable(EnableArgs { name }) => enable(&name).await?,
+            Command::Disable(DisableArgs { name }) => disable(&name).await?,
             Command::Check(CheckArgs { name, transport }) => check(&name, transport).await?,
         }
 

--- a/rust/plugins/src/cli.rs
+++ b/rust/plugins/src/cli.rs
@@ -5,58 +5,43 @@ use common::{
 };
 
 use crate::{
-    check::{check, CheckArgs},
-    disable::{disable, DisableArgs},
-    enable::{enable, EnableArgs},
-    install::{install, InstallArgs},
-    list::{list, ListArgs},
-    uninstall::{uninstall, UninstallArgs},
+    check::CheckArgs, disable::DisableArgs, enable::EnableArgs, install::InstallArgs,
+    link::LinkArgs, list::ListArgs, uninstall::UninstallArgs,
 };
 
-/// List, install, update, and uninstall plugins
+/// Manage plugins
 #[derive(Debug, Parser)]
 pub struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
 }
 
-/// A command to perform with plugins
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// List plugins
     List(ListArgs),
-
-    /// Install a plugin
     Install(InstallArgs),
-
-    /// Uninstall a plugin
     Uninstall(UninstallArgs),
-
-    /// Enable a plugin
+    Link(LinkArgs),
     Enable(EnableArgs),
-
-    /// Disable a plugin
     Disable(DisableArgs),
-
-    /// Check a plugin
     Check(CheckArgs),
 }
 
 impl Cli {
-    // Run the CLI
     pub async fn run(self) -> Result<()> {
         let Some(command) = self.command else {
-            list(ListArgs::default()).await?.to_stdout();
+            ListArgs::default().run().await?.to_stdout();
             return Ok(());
         };
 
         match command {
-            Command::List(options) => list(options).await?.to_stdout(),
-            Command::Install(InstallArgs { name }) => install(&name).await?,
-            Command::Uninstall(UninstallArgs { name }) => uninstall(&name).await?,
-            Command::Enable(EnableArgs { name }) => enable(&name).await?,
-            Command::Disable(DisableArgs { name }) => disable(&name).await?,
-            Command::Check(CheckArgs { name, transport }) => check(&name, transport).await?,
+            Command::List(args) => args.run().await?.to_stdout(),
+            Command::Install(args) => args.run().await?.to_stdout(),
+            Command::Uninstall(args) => args.run().await?.to_stdout(),
+            Command::Link(args) => args.run().await?.to_stdout(),
+            Command::Enable(args) => args.run().await?.to_stdout(),
+            Command::Disable(args) => args.run().await?.to_stdout(),
+            Command::Check(args) => args.run().await?.to_stdout(),
         }
 
         Ok(())

--- a/rust/plugins/src/disable.rs
+++ b/rust/plugins/src/disable.rs
@@ -1,0 +1,25 @@
+use common::{
+    clap::{self, Args},
+    eyre::Result,
+    tracing,
+};
+
+use crate::Plugin;
+
+/// Disable a plugin
+#[tracing::instrument]
+pub async fn disable(name: &str) -> Result<()> {
+    tracing::debug!("Disabling plugin `{name}`");
+
+    Plugin::disable(name)?;
+
+    tracing::info!("☑️ Successfully disabled plugin `{}`", name);
+
+    Ok(())
+}
+
+#[derive(Debug, Default, Args)]
+pub struct DisableArgs {
+    /// The name of the plugin to disable
+    pub name: String,
+}

--- a/rust/plugins/src/disable.rs
+++ b/rust/plugins/src/disable.rs
@@ -1,3 +1,4 @@
+use cli_utils::{message, Message};
 use common::{
     clap::{self, Args},
     eyre::Result,
@@ -8,18 +9,23 @@ use crate::Plugin;
 
 /// Disable a plugin
 #[tracing::instrument]
-pub async fn disable(name: &str) -> Result<()> {
+pub async fn disable(name: &str) -> Result<Message> {
     tracing::debug!("Disabling plugin `{name}`");
 
     Plugin::disable(name)?;
 
-    tracing::info!("☑️ Successfully disabled plugin `{}`", name);
-
-    Ok(())
+    Ok(message!("☑️ Successfully disabled plugin `{}`", name))
 }
 
+/// Disable a plugin
 #[derive(Debug, Default, Args)]
 pub struct DisableArgs {
     /// The name of the plugin to disable
     pub name: String,
+}
+
+impl DisableArgs {
+    pub async fn run(self) -> Result<Message> {
+        disable(&self.name).await
+    }
 }

--- a/rust/plugins/src/enable.rs
+++ b/rust/plugins/src/enable.rs
@@ -1,3 +1,4 @@
+use cli_utils::{message, Message};
 use common::{
     clap::{self, Args},
     eyre::Result,
@@ -8,18 +9,23 @@ use crate::Plugin;
 
 /// Enable a plugin
 #[tracing::instrument]
-pub async fn enable(name: &str) -> Result<()> {
+pub async fn enable(name: &str) -> Result<Message> {
     tracing::debug!("Enabling plugin `{name}`");
 
     Plugin::enable(name)?;
 
-    tracing::info!("✅ Successfully enabled plugin `{}`", name);
-
-    Ok(())
+    Ok(message!("✅ Successfully enabled plugin `{}`", name))
 }
 
+/// Enable a plugin
 #[derive(Debug, Default, Args)]
 pub struct EnableArgs {
     /// The name of the plugin to enable
     pub name: String,
+}
+
+impl EnableArgs {
+    pub async fn run(self) -> Result<Message> {
+        enable(&self.name).await
+    }
 }

--- a/rust/plugins/src/enable.rs
+++ b/rust/plugins/src/enable.rs
@@ -1,0 +1,25 @@
+use common::{
+    clap::{self, Args},
+    eyre::Result,
+    tracing,
+};
+
+use crate::Plugin;
+
+/// Enable a plugin
+#[tracing::instrument]
+pub async fn enable(name: &str) -> Result<()> {
+    tracing::debug!("Enabling plugin `{name}`");
+
+    Plugin::enable(name)?;
+
+    tracing::info!("✅ Successfully enabled plugin `{}`", name);
+
+    Ok(())
+}
+
+#[derive(Debug, Default, Args)]
+pub struct EnableArgs {
+    /// The name of the plugin to enable
+    pub name: String,
+}

--- a/rust/plugins/src/install.rs
+++ b/rust/plugins/src/install.rs
@@ -1,0 +1,48 @@
+use common::{
+    clap::{self, Args},
+    eyre::{bail, Result},
+    tokio::fs::{create_dir_all, remove_dir_all, write},
+    toml, tracing,
+};
+
+use crate::Plugin;
+
+/// Install a plugin
+#[tracing::instrument]
+pub async fn install(name: &str) -> Result<()> {
+    tracing::debug!("Installing plugin `{}`", name);
+
+    // Get the latest manifest for the plugin
+    let registry = Plugin::fetch_registry().await?;
+    let Some(url) = registry.get(name) else {
+        bail!("Plugin `{name}` not in registry");
+    };
+    let plugin = Plugin::fetch_manifest(name, url).await?;
+
+    // If the plugin directory already exists then uninstall it
+    let dir = Plugin::plugin_dir(name, true)?;
+    if dir.exists() {
+        remove_dir_all(&dir).await?;
+        create_dir_all(&dir).await?;
+    }
+
+    // Write the manifest into the dir
+    // Do this last, when everything else has succeeded, because if this
+    // file is present the plugin is assumed to be installed
+    let manifest = dir.join("manifest.toml");
+    write(&manifest, toml::to_string(&plugin)?).await?;
+
+    tracing::info!(
+        "Successfully installed plugin {}@{}",
+        plugin.name,
+        plugin.version,
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Default, Args)]
+pub struct InstallArgs {
+    /// The name of the plugin to install
+    pub name: String,
+}

--- a/rust/plugins/src/install.rs
+++ b/rust/plugins/src/install.rs
@@ -30,9 +30,6 @@ pub async fn install(name: &str) -> Result<Message> {
         remove_dir_all(&dir).await?;
     }
 
-    // Make sure the directory is present
-    create_dir_all(&dir).await?;
-
     // Do the install using the first compatible runtime
     for (runtime, version_req) in &plugin.runtimes {
         if !runtime.is_available(None) {
@@ -44,6 +41,9 @@ pub async fn install(name: &str) -> Result<Message> {
         if !version_req.matches(&runtime_version) {
             bail!("Unable to install plugin `{name}`: it requires {runtime}{version_req} but only {runtime_version} is available")
         }
+
+        // Make sure the directory is present
+        create_dir_all(&dir).await?;
 
         // Dispatch to the runtime to do the installation
         runtime.install(&plugin.install, &dir).await?;

--- a/rust/plugins/src/install.rs
+++ b/rust/plugins/src/install.rs
@@ -35,12 +35,12 @@ pub async fn install(name: &str) -> Result<Message> {
 
     // Do the install using the first compatible runtime
     for (runtime, version_req) in &plugin.runtimes {
-        if !runtime.is_available() {
+        if !runtime.is_available(None) {
             continue;
         }
 
         // Check that runtime version requirement for the plugin is met
-        let runtime_version = runtime.version()?;
+        let runtime_version = runtime.version(None)?;
         if !version_req.matches(&runtime_version) {
             bail!("Unable to install plugin `{name}`: it requires {runtime}{version_req} but only {runtime_version} is available")
         }

--- a/rust/plugins/src/install.rs
+++ b/rust/plugins/src/install.rs
@@ -49,7 +49,7 @@ pub async fn install(name: &str) -> Result<()> {
     write(&manifest, toml::to_string(&plugin)?).await?;
 
     tracing::info!(
-        "Successfully installed plugin `{}` version `{}`",
+        "🚀 Successfully installed plugin `{}` version `{}`",
         plugin.name,
         plugin.version,
     );

--- a/rust/plugins/src/kernels.rs
+++ b/rust/plugins/src/kernels.rs
@@ -1,0 +1,83 @@
+use common::{
+    eyre::Result,
+    serde::{Deserialize, Serialize},
+};
+use kernel::{
+    format::Format, Kernel, KernelAvailability, KernelForks, KernelInstance, KernelInterrupt,
+    KernelKill, KernelTerminate,
+};
+
+use crate::plugins;
+
+/// A kernel provided by a plugin
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(crate = "common::serde")]
+pub struct PluginKernel {
+    /// The name of the kernel
+    name: String,
+
+    /// The languages that the kernel supports
+    #[serde(default)]
+    languages: Vec<Format>,
+
+    /// Does the kernel support the interrupt signal?
+    #[serde(default)]
+    interrupt: KernelInterrupt,
+
+    /// Does the kernel support the terminate signal?
+    #[serde(default)]
+    terminate: KernelTerminate,
+
+    /// Does the kernel support the kill signal?
+    #[serde(default)]
+    kill: KernelKill,
+
+    /// Does the kernel support forks?
+    #[serde(default)]
+    forks: KernelForks,
+}
+
+impl Kernel for PluginKernel {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn availability(&self) -> KernelAvailability {
+        // Assume that the kernel is available if the plugin if available
+        KernelAvailability::Available
+    }
+
+    fn supports_languages(&self) -> Vec<Format> {
+        self.languages.clone()
+    }
+
+    fn supports_interrupt(&self) -> KernelInterrupt {
+        self.interrupt
+    }
+
+    fn supports_terminate(&self) -> KernelTerminate {
+        self.terminate
+    }
+
+    fn supports_kill(&self) -> KernelKill {
+        self.kill
+    }
+
+    fn supports_forks(&self) -> KernelForks {
+        self.forks
+    }
+
+    fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
+        todo!()
+    }
+}
+
+/// List all the kernels provided by plugins
+pub async fn list() -> Vec<Box<dyn Kernel>> {
+    plugins()
+        .await
+        .into_iter()
+        .flat_map(|plugin| plugin.kernels)
+        .map(|kernel| Box::new(kernel) as Box<dyn Kernel>)
+        .collect()
+}

--- a/rust/plugins/src/kernels.rs
+++ b/rust/plugins/src/kernels.rs
@@ -1,16 +1,22 @@
+use std::path::Path;
+
 use common::{
-    eyre::Result,
+    async_trait::async_trait,
+    eyre::{bail, Result},
     serde::{Deserialize, Serialize},
+    tokio::sync::{mpsc, watch},
 };
 use kernel::{
-    format::Format, Kernel, KernelAvailability, KernelForks, KernelInstance, KernelInterrupt,
-    KernelKill, KernelTerminate,
+    format::Format,
+    schema::{ExecutionMessage, Node, SoftwareApplication, SoftwareSourceCode, Variable},
+    Kernel, KernelAvailability, KernelForks, KernelInstance, KernelInterrupt, KernelKill,
+    KernelSignal, KernelStatus, KernelTerminate,
 };
 
-use crate::plugins;
+use crate::{plugins, Plugin, PluginInstance};
 
 /// A kernel provided by a plugin
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(crate = "common::serde")]
 pub struct PluginKernel {
     /// The name of the kernel
@@ -35,6 +41,20 @@ pub struct PluginKernel {
     /// Does the kernel support forks?
     #[serde(default)]
     forks: KernelForks,
+
+    /// The plugin that provides this kernel
+    ///
+    /// Used to be able to create a plugin instance, which in
+    /// turn is used to create a kernel instance.
+    #[serde(skip)]
+    plugin: Option<Plugin>,
+}
+
+impl PluginKernel {
+    /// Bind a plugin to this kernel so that it can be started (by starting the plugin first)
+    pub fn bind(&mut self, plugin: &Plugin) {
+        self.plugin = Some(plugin.clone());
+    }
 }
 
 impl Kernel for PluginKernel {
@@ -68,6 +88,283 @@ impl Kernel for PluginKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
+        let Some(plugin) = self.plugin.clone() else {
+            bail!("No plugin associated with this plugin kernel!")
+        };
+        Ok(Box::new(PluginKernelInstance::new(self.clone(), plugin)))
+    }
+}
+
+/// An instance of a microkernel
+pub struct PluginKernelInstance {
+    /// The kernel specification for this instance
+    kernel: PluginKernel,
+
+    /// The plugin that provides the kernel
+    plugin: Plugin,
+
+    /// The plugin instance started when this kernel is started
+    plugin_instance: Option<PluginInstance>,
+
+    /// The name of the kernel instance on the plugin instance
+    kernel_instance: Option<String>,
+}
+
+impl PluginKernelInstance {
+    fn new(kernel: PluginKernel, plugin: Plugin) -> Self {
+        Self {
+            kernel,
+            plugin,
+            plugin_instance: None,
+            kernel_instance: None,
+        }
+    }
+
+    /// Get the plugin instance and the name of the kernel instance in that plugin instance
+    fn details(&mut self) -> Result<(&mut PluginInstance, String)> {
+        match (self.plugin_instance.as_mut(), self.kernel_instance.as_ref()) {
+            (Some(instance), Some(name)) => Ok((instance, name.clone())),
+            _ => bail!("Kernel instance has no plugin instance, "),
+        }
+    }
+}
+
+#[async_trait]
+impl KernelInstance for PluginKernelInstance {
+    fn name(&self) -> String {
+        // This should only be called once the kernel has stated and
+        // has a name. But in case it has not, and because this method
+        // is infallible, default to "unnamed".
+        self.kernel_instance
+            .clone()
+            .unwrap_or_else(|| String::from("unnamed"))
+    }
+
+    async fn status(&self) -> Result<KernelStatus> {
+        todo!()
+    }
+
+    fn watcher(&self) -> Result<watch::Receiver<KernelStatus>> {
+        todo!()
+    }
+
+    fn signaller(&self) -> Result<mpsc::Sender<KernelSignal>> {
+        todo!()
+    }
+
+    async fn start(&mut self, directory: &Path) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            kernel: String,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(crate = "common::serde")]
+        struct Result {
+            instance: String,
+        }
+
+        // TODO: consider starting in directory
+        let mut plugin_instance = self.plugin.start(None).await?;
+
+        let Result {
+            instance: kernel_instance,
+        } = plugin_instance
+            .call(
+                "kernel_start",
+                Params {
+                    kernel: self.kernel.name(),
+                },
+            )
+            .await?;
+
+        self.plugin_instance = Some(plugin_instance);
+        self.kernel_instance = Some(kernel_instance);
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            instance: String,
+        }
+
+        if let Some(plugin_instance) = self.plugin_instance.as_mut() {
+            if let Some(instance) = self.kernel_instance.take() {
+                plugin_instance
+                    .call("kernel_stop", Params { instance })
+                    .await?;
+            }
+            plugin_instance.stop().await?;
+        };
+
+        self.plugin_instance = None;
+        self.kernel_instance = None;
+
+        Ok(())
+    }
+
+    // In the following methods, for brevity, we use:
+    //  - `plugin` to refer to `self.plugin_instance`
+    //  - `instance` to refer to `self.kernel_instance`
+
+    async fn execute(&mut self, code: &str) -> Result<(Vec<Node>, Vec<ExecutionMessage>)> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            code: String,
+            instance: String,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(crate = "common::serde")]
+        struct Result {
+            outputs: Vec<Node>,
+            messages: Vec<ExecutionMessage>,
+        }
+
+        let (plugin, instance) = self.details()?;
+        let result: Result = plugin
+            .call(
+                "kernel_execute",
+                Params {
+                    code: code.to_string(),
+                    instance,
+                },
+            )
+            .await?;
+
+        Ok((result.outputs, result.messages))
+    }
+
+    async fn evaluate(&mut self, code: &str) -> Result<(Node, Vec<ExecutionMessage>)> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            code: String,
+            instance: String,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(crate = "common::serde")]
+        struct Result {
+            output: Node,
+            messages: Vec<ExecutionMessage>,
+        }
+
+        let (plugin, instance) = self.details()?;
+        let result: Result = plugin
+            .call(
+                "kernel_evaluate",
+                Params {
+                    code: code.to_string(),
+                    instance,
+                },
+            )
+            .await?;
+
+        Ok((result.output, result.messages))
+    }
+
+    async fn info(&mut self) -> Result<SoftwareApplication> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            instance: String,
+        }
+
+        let (plugin, instance) = self.details()?;
+        plugin.call("kernel_info", Params { instance }).await
+    }
+
+    async fn packages(&mut self) -> Result<Vec<SoftwareSourceCode>> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            instance: String,
+        }
+
+        let (plugin, instance) = self.details()?;
+        plugin.call("kernel_packages", Params { instance }).await
+    }
+
+    async fn list(&mut self) -> Result<Vec<Variable>> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            instance: String,
+        }
+
+        let (plugin, instance) = self.details()?;
+        plugin.call("kernel_list", Params { instance }).await
+    }
+
+    async fn get(&mut self, name: &str) -> Result<Option<Node>> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            name: String,
+            instance: String,
+        }
+
+        let (plugin, instance) = self.details()?;
+        plugin
+            .call(
+                "kernel_get",
+                Params {
+                    name: name.to_string(),
+                    instance,
+                },
+            )
+            .await
+    }
+
+    async fn set(&mut self, name: &str, value: &Node) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            name: String,
+            value: Node,
+            instance: String,
+        }
+
+        let (plugin, instance) = self.details()?;
+        plugin
+            .call(
+                "kernel_set",
+                Params {
+                    name: name.to_string(),
+                    value: value.clone(),
+                    instance,
+                },
+            )
+            .await
+    }
+
+    async fn remove(&mut self, name: &str) -> Result<()> {
+        #[derive(Serialize)]
+        #[serde(crate = "common::serde")]
+        struct Params {
+            name: String,
+            instance: String,
+        }
+
+        let (plugin, instance) = self.details()?;
+        plugin
+            .call(
+                "kernel_remove",
+                Params {
+                    name: name.to_string(),
+                    instance,
+                },
+            )
+            .await
+    }
+
+    async fn fork(&mut self) -> Result<Box<dyn KernelInstance>> {
         todo!()
     }
 }
@@ -77,7 +374,6 @@ pub async fn list() -> Vec<Box<dyn Kernel>> {
     plugins()
         .await
         .into_iter()
-        .flat_map(|plugin| plugin.kernels)
-        .map(|kernel| Box::new(kernel) as Box<dyn Kernel>)
+        .flat_map(|plugin| plugin.kernels())
         .collect()
 }

--- a/rust/plugins/src/lib.rs
+++ b/rust/plugins/src/lib.rs
@@ -1,0 +1,289 @@
+use std::str::FromStr;
+
+use semver::{Version, VersionReq};
+
+use common::{
+    eyre::Result,
+    itertools::Itertools,
+    reqwest::Url,
+    serde::{self, Deserialize, Deserializer, Serialize, Serializer},
+    serde_with::{DeserializeFromStr, SerializeDisplay},
+    strum::{Display, EnumString},
+};
+
+pub mod cli;
+mod list;
+
+/// The specification of a plugin
+///
+/// This specification
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(crate = "common::serde")]
+pub struct Plugin {
+    /// The name of the plugin, should be unique across all plugins
+    name: String,
+
+    /// The version of the plugin
+    #[serde(
+        deserialize_with = "Plugin::deserialize_version",
+        serialize_with = "Plugin::serialize_version"
+    )]
+    version: Version,
+
+    /// A brief description of the plugin
+    description: String,
+
+    /// The home page for the plugin
+    #[serde(
+        deserialize_with = "Plugin::deserialize_url",
+        serialize_with = "Plugin::serialize_url"
+    )]
+    home: Url,
+
+    /// The installation URL for the plugin
+    #[serde(
+        deserialize_with = "Plugin::deserialize_url",
+        serialize_with = "Plugin::serialize_url"
+    )]
+    install: Url,
+
+    /// The name of the language runtimes that the plugin supports
+    ///
+    /// If empty, assumed to not require any runtime, i.e. installed as
+    /// an standalone executable binary.
+    #[serde(
+        alias = "runtime",
+        deserialize_with = "Plugin::deserialize_runtimes",
+        serialize_with = "Plugin::serialize_runtimes"
+    )]
+    runtimes: Vec<(PluginRuntime, VersionReq)>,
+
+    /// The name of the operating system platforms that the plugin supports
+    ///
+    /// If empty, assumed to work on all platforms.
+    #[serde(alias = "platform", deserialize_with = "Plugin::deserialize_platforms")]
+    platforms: Vec<PluginPlatform>,
+}
+
+impl Plugin {
+    /// Deserialize the version string for a plugin
+    fn deserialize_version<'de, D>(deserializer: D) -> Result<Version, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let string = String::deserialize(deserializer)?;
+        Version::parse(&string)
+            .map_err(|error| Error::custom(format!("invalid plugin version: {error}")))
+    }
+
+    /// Serialize the version of a plugin
+    fn serialize_version<S>(version: &Version, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&version.to_string())
+    }
+
+    /// Deserialize a URL for a plugin
+    fn deserialize_url<'de, D>(deserializer: D) -> Result<Url, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let string = String::deserialize(deserializer)?;
+        Url::parse(&string).map_err(|error| Error::custom(format!("invalid plugin URL: {error}")))
+    }
+
+    /// Serialize a URL for a plugin
+    fn serialize_url<S>(url: &Url, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&url.to_string())
+    }
+
+    /// Deserialize the supported runtimes specifications for a plugin
+    ///
+    /// Supports the following TOML syntaxes (and the equivalents for JSON and YAML):
+    ///
+    ///   runtime = "python"
+    ///   runtimes = "Python >=3"
+    ///   runtimes = ["node 20.1"]
+    fn deserialize_runtimes<'de, D>(
+        deserializer: D,
+    ) -> Result<Vec<(PluginRuntime, VersionReq)>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        #[derive(Deserialize)]
+        #[serde(untagged, crate = "common::serde")]
+        enum OneOrMany {
+            One(String),
+            Many(Vec<String>),
+        }
+
+        let mut runtimes = Vec::new();
+        for string in match Option::<OneOrMany>::deserialize(deserializer)? {
+            None => vec![],
+            Some(OneOrMany::One(one)) => vec![one],
+            Some(OneOrMany::Many(many)) => many,
+        } {
+            let index = string
+                .find(|c: char| !c.is_alphanumeric())
+                .unwrap_or(string.len());
+            let (first, second) = string.split_at(index);
+
+            let runtime = PluginRuntime::from_str(first)
+                .map_err(|error| Error::custom(format!("invalid runtime time: {error}")))?;
+
+            let version_req = if !second.trim().is_empty() {
+                VersionReq::parse(second).map_err(|error| {
+                    Error::custom(format!(
+                        "invalid runtime version requirement `{second}`: {error}"
+                    ))
+                })?
+            } else {
+                VersionReq::STAR
+            };
+
+            runtimes.push((runtime, version_req));
+        }
+
+        Ok(runtimes)
+    }
+
+    /// Serialize the supported runtimes specifications for a plugin
+    fn serialize_runtimes<S>(
+        runtimes: &Vec<(PluginRuntime, VersionReq)>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        runtimes
+            .iter()
+            .map(|(runtime, version_req)| format!("{runtime} {version_req}"))
+            .collect_vec()
+            .serialize(serializer)
+    }
+
+    /// Deserialize the supported platforms for a plugin
+    fn deserialize_platforms<'de, D>(deserializer: D) -> Result<Vec<PluginPlatform>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged, crate = "common::serde")]
+        enum OneOrMany {
+            One(PluginPlatform),
+            Many(Vec<PluginPlatform>),
+        }
+
+        Ok(match Option::<OneOrMany>::deserialize(deserializer)? {
+            None => vec![],
+            Some(OneOrMany::One(one)) => vec![one],
+            Some(OneOrMany::Many(many)) => many,
+        })
+    }
+}
+
+/// A runtime that a plugin supports
+#[derive(Debug, Display, EnumString, PartialEq, Eq)]
+#[strum(
+    ascii_case_insensitive,
+    serialize_all = "lowercase",
+    crate = "common::strum"
+)]
+pub enum PluginRuntime {
+    Python,
+    Node,
+}
+
+/// An operating system platform that a plugin supports
+#[derive(Debug, Display, EnumString, DeserializeFromStr, SerializeDisplay, PartialEq, Eq)]
+#[strum(
+    ascii_case_insensitive,
+    serialize_all = "lowercase",
+    crate = "common::strum"
+)]
+#[serde_with(crate = "common::serde_with")]
+pub enum PluginPlatform {
+    Linux,
+    MacOS,
+    Windows,
+}
+
+/// The availability of a plugin on the current machine
+///
+/// Determined based on the `runtimes` and `platforms` properties
+/// of the plugin and the runtimes and platform of the current machine.
+#[derive(Debug, Display, PartialEq, Eq)]
+#[strum(serialize_all = "lowercase")]
+pub enum PluginAvailability {
+    /// Available on this machine
+    Installed,
+    /// Available on this machine but requires installation
+    Installable,
+    /// Not available on this machine (e.g. language runtime not available)
+    Unavailable,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use common::toml;
+    use common_dev::pretty_assertions::assert_eq;
+
+    #[test]
+    fn deserialization() -> Result<()> {
+        let plugin: Plugin = toml::from_str(
+            r#"
+name = "super-plugin"
+version = "0.1.0"
+description = "Does super stuff"
+home = "https://examples.org/stencila-super-plugin"
+install = "https://pypi.org/project/stencila-super-plugin"
+runtime = "python >=3,<4"
+platforms = ["Linux", "MacOS"]
+"#,
+        )?;
+        assert_eq!(plugin.name, "super-plugin");
+        assert_eq!(plugin.description, "Does super stuff");
+        assert_eq!(
+            plugin.runtimes,
+            vec![(PluginRuntime::Python, VersionReq::parse(">=3,<4")?)]
+        );
+        assert_eq!(
+            plugin.platforms,
+            vec![PluginPlatform::Linux, PluginPlatform::MacOS]
+        );
+
+        let plugin: Plugin = toml::from_str(
+            r#"
+name = "windows-only"
+version = "1.0.0-alpha.23"
+description = "Only available under Python on Windows"
+home = "https://examples.org/windows-only"
+install = "https://github.com/example/windows-only"
+runtimes = ["Python", "python >=3"]
+platform = "windows"
+"#,
+        )?;
+        assert_eq!(
+            plugin.runtimes,
+            vec![
+                (PluginRuntime::Python, VersionReq::parse("*")?),
+                (PluginRuntime::Python, VersionReq::parse(">=3")?)
+            ]
+        );
+        assert_eq!(plugin.platforms, vec![PluginPlatform::Windows]);
+
+        Ok(())
+    }
+}

--- a/rust/plugins/src/lib.rs
+++ b/rust/plugins/src/lib.rs
@@ -379,12 +379,19 @@ impl Plugin {
 
     /// Read the plugin from the manifest in ints directory
     pub fn read_manifest(name: &str) -> Result<Self> {
-        let path = Plugin::plugin_dir(name, false)?.join(MANIFEST_FILENAME);
-        if !path.exists() {
-            bail!("Plugin `{name}` does not have a `{MANIFEST_FILENAME}` file")
+        let dir = Plugin::plugin_dir(name, false)?;
+
+        let manifest = dir.join(MANIFEST_FILENAME);
+        if !manifest.exists() {
+            bail!("Plugin `{name}` does not have a `{MANIFEST_FILENAME}` file. Is it installed?")
         }
 
-        Self::read_manifest_from(&path)
+        let mut plugin = Self::read_manifest_from(&manifest)?;
+        if dir.is_symlink() {
+            plugin.linked = true;
+        }
+
+        Ok(plugin)
     }
 
     /// Read whether the plugin is enabled or not

--- a/rust/plugins/src/lib.rs
+++ b/rust/plugins/src/lib.rs
@@ -359,7 +359,7 @@ impl Plugin {
 
     /// Read the plugin from a manifest file
     pub fn read_manifest_from(path: &Path) -> Result<Self> {
-        let manifest = std::fs::read_to_string(&path)
+        let manifest = std::fs::read_to_string(path)
             .wrap_err_with(|| eyre!("While reading plugin from `{}`", path.display()))?;
 
         let plugin = toml::from_str(&manifest)
@@ -625,7 +625,7 @@ async fn plugins() -> Vec<Plugin> {
         Ok(plugins) => plugins,
         Err(error) => {
             tracing::warn!("While getting list of plugins: {error}");
-            return vec![];
+            vec![]
         }
     }
 }

--- a/rust/plugins/src/lib.rs
+++ b/rust/plugins/src/lib.rs
@@ -24,7 +24,7 @@ use common::{
     strum::{Display, EnumString},
     tokio::{
         self,
-        io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter},
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
         process::{Child, ChildStdin, ChildStdout, Command},
     },
     toml,
@@ -734,6 +734,8 @@ home = "https://examples.org/stencila-super-plugin"
 install = "https://pypi.org/project/stencila-super-plugin"
 runtime = "python >=3,<4"
 platforms = ["Linux", "MacOS"]
+transports = ["stdio", "http"]
+command = "python ..."
 "#,
         )?;
         assert_eq!(plugin.name, "super-plugin");
@@ -756,6 +758,8 @@ home = "https://examples.org/windows-only"
 install = "https://github.com/example/windows-only"
 runtimes = ["Python", "python >=3"]
 platform = "windows"
+transports = ["http"]
+command = "python ..."
 "#,
         )?;
         assert_eq!(

--- a/rust/plugins/src/lib.rs
+++ b/rust/plugins/src/lib.rs
@@ -61,7 +61,7 @@ pub struct Plugin {
     /// The name of the operating system platforms that the plugin supports
     ///
     /// If empty, assumed to work on all platforms.
-    #[serde(alias = "platform", deserialize_with = "Plugin::deserialize_platforms")]
+    #[serde(alias = "platform", default, deserialize_with = "Plugin::deserialize_platforms")]
     platforms: Vec<PluginPlatform>,
 }
 

--- a/rust/plugins/src/link.rs
+++ b/rust/plugins/src/link.rs
@@ -1,0 +1,74 @@
+use std::path::{Path, PathBuf};
+
+use cli_utils::{message, Message};
+use common::{
+    clap::{self, Args},
+    eyre::{bail, Result},
+    tokio::fs::{remove_dir_all, remove_file},
+    tracing,
+};
+
+use crate::{Plugin, MANIFEST_FILENAME};
+
+/// Link a local directory as a plugin
+#[tracing::instrument]
+pub async fn link(target: &Path) -> Result<Message> {
+    tracing::debug!("Linking plugin directory `{}`", target.display());
+
+    if !target.exists() {
+        bail!("Directory `{}` does not exist", target.display())
+    }
+    let target = target.canonicalize()?;
+
+    // Check that there is a manifest in the directory and that it
+    // is valid, erroring if it is not
+    let manifest = target.join(MANIFEST_FILENAME);
+    if !manifest.exists() {
+        bail!(
+            "Directory `{}` does not have a `{MANIFEST_FILENAME}` file",
+            target.display()
+        )
+    }
+    let plugin = Plugin::read_manifest_from(&manifest)?;
+
+    // If the plugin link or directory already exists then remove it
+    let link = Plugin::plugin_dir(&plugin.name, false)?;
+    if link.exists() {
+        if link.is_file() || link.is_symlink() {
+            remove_file(&link).await?
+        } else {
+            remove_dir_all(&link).await?;
+        }
+    }
+
+    // Symlink to the directory
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        symlink(&target, link)?;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::symlink_dir;
+        symlink_dir(&target, link)?;
+    }
+
+    Ok(message!(
+        "🔗 Successfully linked directory `{}` as plugin `{}`",
+        target.display(),
+        plugin.name
+    ))
+}
+
+/// Link to a local plugin
+#[derive(Debug, Default, Args)]
+pub struct LinkArgs {
+    /// The directory to link to
+    pub directory: PathBuf,
+}
+
+impl LinkArgs {
+    pub async fn run(self) -> Result<Message> {
+        link(&self.directory).await
+    }
+}

--- a/rust/plugins/src/list.rs
+++ b/rust/plugins/src/list.rs
@@ -1,0 +1,128 @@
+use std::collections::HashMap;
+
+use app::{get_app_dir, DirType};
+use cli_utils::{
+    table::{self, Attribute, Cell},
+    ToStdout,
+};
+use common::{
+    clap::{self, Args},
+    derive_more::Deref,
+    eyre::{bail, eyre, Report, Result},
+    futures::future,
+    itertools::Itertools,
+    reqwest::get,
+    serde::{Deserialize, Serialize},
+    serde_json,
+    tokio::fs::{read_to_string, write},
+    toml, tracing,
+};
+
+use crate::Plugin;
+
+// TODO: change URL to point to `main` before PR is merged
+const PLUGINS_TOML_URL: &str =
+    "https://raw.githubusercontent.com/stencila/stencila/feature/plugins/plugins.toml";
+
+/// Get a list of plugins
+///
+/// Fetches the `plugins.toml` file at the root of the Stencila repository
+/// and expands it into a list of plugin manifests by fetching each individual
+/// manifest.
+///
+/// Caches the generated list of manifests. Use of cache can be overridden using
+/// the `options.refresh`.
+///
+/// Filtering the list is possible, currently only using `options.installed`
+/// (but in the future may allow for text matching "search" filtering)
+pub async fn list(options: ListOptions) -> Result<PluginList> {
+    tracing::info!("Refreshing list of plugins and their manifests");
+
+    let cache = get_app_dir(DirType::Plugins, true)?.join("manifests.json");
+
+    if !options.refresh && cache.exists() {
+        let json = read_to_string(cache).await?;
+        let list = serde_json::from_str(&json)?;
+        return Ok(list);
+    }
+
+    // Fetch the plugins list from the Stencila repo
+    let response = get(PLUGINS_TOML_URL).await?;
+    if let Err(error) = response.error_for_status_ref() {
+        let message = response.text().await?;
+        bail!("{error}: {message}");
+    }
+    let toml = response.text().await?;
+    let plugins: HashMap<String, String> = toml::from_str(&toml)?;
+
+    // Fetch each of the plugin manifests in parallel, logging debug messages
+    // on any errors (this avoids any one plugin with an invalid manifest from
+    // breaking the entire fetch or alarming the user with a blaring warning message, while still
+    // providing some visibility)
+    let futures = plugins.iter().map(|(name, url)| async move {
+        {
+            let response = get(url).await?;
+            if let Err(error) = response.error_for_status_ref() {
+                let message = response.text().await?;
+                bail!("While fetching plugin `{name}` from `{url}`: {error}: {message}");
+            }
+
+            let toml = response.text().await?;
+            let plugin: Plugin = toml::from_str(&toml)
+                .map_err(|error| eyre!("While deserializing plugin `{name}`: {error}"))?;
+
+            if &plugin.name != name {
+                bail!(
+                    "Plugin name is not the same as in plugin list: `{}` != `{}`",
+                    plugin.name,
+                    name
+                )
+            }
+
+            Ok::<Plugin, Report>(plugin)
+        }
+        .map_err(|error| eyre!("Error with plugin `{name}`: {error}"))
+    });
+    let plugins = future::join_all(futures)
+        .await
+        .into_iter()
+        .filter_map(|result| match result {
+            Ok(plugin) => Some(plugin),
+            Err(error) => {
+                tracing::debug!("{error}");
+                None
+            }
+        })
+        .collect_vec();
+
+    // Write the list to cache
+    write(cache, serde_json::to_string(&plugins)?).await?;
+
+    Ok(PluginList(plugins))
+}
+
+#[derive(Debug, Default, Args)]
+pub struct ListOptions {
+    /// Whether to force refresh the plugin manifests
+    #[arg(long, short)]
+    refresh: bool,
+
+    /// Whether to only show installed plugins
+    #[arg(long, short)]
+    installed: bool,
+}
+
+#[derive(Default, Deref, Serialize, Deserialize)]
+#[serde(crate = "common::serde")]
+pub struct PluginList(Vec<Plugin>);
+
+impl ToStdout for PluginList {
+    fn to_terminal(&self) -> impl std::fmt::Display {
+        let mut table = table::new();
+        table.set_header(["Name"]);
+        for plugin in self.iter() {
+            table.add_row([Cell::new(&plugin.name).add_attribute(Attribute::Bold)]);
+        }
+        table
+    }
+}

--- a/rust/plugins/src/list.rs
+++ b/rust/plugins/src/list.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use app::{get_app_dir, DirType};
 use cli_utils::{
     table::{self, Attribute, Cell, Color},
@@ -8,21 +6,16 @@ use cli_utils::{
 use common::{
     clap::{self, Args},
     derive_more::Deref,
-    eyre::{bail, eyre, Report, Result},
+    eyre::Result,
     futures::future,
     itertools::Itertools,
-    reqwest::get,
     serde::{Deserialize, Serialize},
     serde_json,
     tokio::fs::{read_to_string, write},
-    toml, tracing,
+    tracing,
 };
 
-use crate::Plugin;
-
-// TODO: change URL to point to `main` before PR is merged
-const PLUGINS_TOML_URL: &str =
-    "https://raw.githubusercontent.com/stencila/stencila/feature/plugins/plugins.toml";
+use crate::{Plugin, PluginStatus};
 
 /// Get a list of plugins
 ///
@@ -35,7 +28,7 @@ const PLUGINS_TOML_URL: &str =
 ///
 /// Filtering the list is possible, currently only using `options.installed`
 /// (but in the future may allow for text matching "search" filtering)
-pub async fn list(options: ListOptions) -> Result<PluginList> {
+pub async fn list(options: ListArgs) -> Result<PluginList> {
     let cache = get_app_dir(DirType::Plugins, true)?.join("manifests.json");
 
     if !options.refresh && cache.exists() {
@@ -47,42 +40,15 @@ pub async fn list(options: ListOptions) -> Result<PluginList> {
     tracing::info!("Refreshing list of plugins and their manifests");
 
     // Fetch the plugins list from the Stencila repo
-    let response = get(PLUGINS_TOML_URL).await?;
-    if let Err(error) = response.error_for_status_ref() {
-        let message = response.text().await?;
-        bail!("{error}: {message}");
-    }
-    let toml = response.text().await?;
-    let plugins: HashMap<String, String> = toml::from_str(&toml)?;
+    let plugins = Plugin::fetch_registry().await?;
 
     // Fetch each of the plugin manifests in parallel, logging debug messages
     // on any errors (this avoids any one plugin with an invalid manifest from
     // breaking the entire fetch or alarming the user with a blaring warning message, while still
     // providing some visibility)
-    let futures = plugins.iter().map(|(name, url)| async move {
-        {
-            let response = get(url).await?;
-            if let Err(error) = response.error_for_status_ref() {
-                let message = response.text().await?;
-                bail!("While fetching plugin `{name}` from `{url}`: {error}: {message}");
-            }
-
-            let toml = response.text().await?;
-            let plugin: Plugin = toml::from_str(&toml)
-                .map_err(|error| eyre!("While deserializing plugin `{name}`: {error}"))?;
-
-            if &plugin.name != name {
-                bail!(
-                    "Plugin name is not the same as in plugin list: `{}` != `{}`",
-                    plugin.name,
-                    name
-                )
-            }
-
-            Ok::<Plugin, Report>(plugin)
-        }
-        .map_err(|error| eyre!("Error with plugin `{name}`: {error}"))
-    });
+    let futures = plugins
+        .iter()
+        .map(|(name, url)| async move { Plugin::fetch_manifest(name, url).await });
     let plugins = future::join_all(futures)
         .await
         .into_iter()
@@ -103,7 +69,7 @@ pub async fn list(options: ListOptions) -> Result<PluginList> {
 }
 
 #[derive(Debug, Default, Args)]
-pub struct ListOptions {
+pub struct ListArgs {
     /// Whether to force refresh the plugin manifests
     #[arg(long, short)]
     refresh: bool,
@@ -120,12 +86,23 @@ pub struct PluginList(Vec<Plugin>);
 impl ToStdout for PluginList {
     fn to_terminal(&self) -> impl std::fmt::Display {
         let mut table = table::new();
-        table.set_header(["Name", "Description", "Home"]);
+        table.set_header(["Name", "Description", "Home", "Version"]);
+
         for plugin in self.iter() {
+            let availability = plugin.availability();
             table.add_row([
                 Cell::new(&plugin.name).add_attribute(Attribute::Bold),
                 Cell::new(&plugin.description),
                 Cell::new(&plugin.home).fg(Color::Blue),
+                match availability {
+                    PluginStatus::InstalledLatest(version) => Cell::new(version).fg(Color::Green),
+                    PluginStatus::InstalledOutdated(installed, latest) => {
+                        Cell::new(format!("{installed} → {latest}")).fg(Color::DarkYellow)
+                    }
+                    PluginStatus::Installable => Cell::new(availability).fg(Color::Cyan),
+                    PluginStatus::UnavailableRuntime => Cell::new(availability).fg(Color::Grey),
+                    PluginStatus::UnavailablePlatform => Cell::new(availability).fg(Color::Red),
+                },
             ]);
         }
         table

--- a/rust/plugins/src/main.rs
+++ b/rust/plugins/src/main.rs
@@ -1,0 +1,23 @@
+use common::{clap::Parser, eyre::Result, tokio};
+
+use plugins::cli::Cli;
+
+/// A mini command line interface just for plugins
+///
+/// Intended for use during development only. Example usage:
+///
+/// ```sh
+/// cargo run -p plugins list
+/// ```
+///
+/// The `Cli` struct is integrated into the main `stencila` CLI
+/// as the `plugins` subcommand e.g.
+///
+/// ```sh
+/// stencila plugins list
+/// ```
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    cli.run().await
+}

--- a/rust/plugins/src/show.rs
+++ b/rust/plugins/src/show.rs
@@ -1,0 +1,28 @@
+use common::{
+    clap::{self, Args},
+    eyre::Result,
+    tracing,
+};
+
+use crate::Plugin;
+
+/// Show details of a plugin
+#[tracing::instrument]
+pub async fn show(name: &str) -> Result<Plugin> {
+    tracing::debug!("Showing plugin `{name}`");
+
+    Plugin::read_manifest(name)
+}
+
+/// Show details of a plugin
+#[derive(Debug, Default, Args)]
+pub struct ShowArgs {
+    /// The name of the plugin to install
+    pub name: String,
+}
+
+impl ShowArgs {
+    pub async fn run(self) -> Result<Plugin> {
+        show(&self.name).await
+    }
+}

--- a/rust/plugins/src/uninstall.rs
+++ b/rust/plugins/src/uninstall.rs
@@ -15,7 +15,7 @@ pub async fn uninstall(name: &str) -> Result<()> {
     let dir = Plugin::plugin_dir(name, false)?;
     if dir.exists() {
         remove_dir_all(dir).await?;
-        tracing::info!("Successfully uninstalled plugin {}", name);
+        tracing::info!("🗑️ Successfully uninstalled plugin {}", name);
     } else {
         tracing::warn!("Plugin {} does not appear to be installed", name);
     }

--- a/rust/plugins/src/uninstall.rs
+++ b/rust/plugins/src/uninstall.rs
@@ -1,0 +1,30 @@
+use common::{
+    clap::{self, Args},
+    eyre::Result,
+    tokio::fs::remove_dir_all,
+    tracing,
+};
+
+use crate::Plugin;
+
+/// Uninstall a plugin
+#[tracing::instrument]
+pub async fn uninstall(name: &str) -> Result<()> {
+    tracing::debug!("Uninstalling plugin `{}`", name);
+
+    let dir = Plugin::plugin_dir(name, false)?;
+    if dir.exists() {
+        remove_dir_all(dir).await?;
+        tracing::info!("Successfully uninstalled plugin {}", name);
+    } else {
+        tracing::warn!("Plugin {} does not appear to be installed", name);
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Default, Args)]
+pub struct UninstallArgs {
+    /// The name of the plugin to uninstall
+    pub name: String,
+}

--- a/rust/plugins/src/uninstall.rs
+++ b/rust/plugins/src/uninstall.rs
@@ -1,3 +1,4 @@
+use cli_utils::{message, Message};
 use common::{
     clap::{self, Args},
     eyre::Result,
@@ -9,22 +10,29 @@ use crate::Plugin;
 
 /// Uninstall a plugin
 #[tracing::instrument]
-pub async fn uninstall(name: &str) -> Result<()> {
+pub async fn uninstall(name: &str) -> Result<Message> {
     tracing::debug!("Uninstalling plugin `{}`", name);
 
     let dir = Plugin::plugin_dir(name, false)?;
-    if dir.exists() {
+    let message = if dir.exists() {
         remove_dir_all(dir).await?;
-        tracing::info!("🗑️ Successfully uninstalled plugin {}", name);
+        message!("🗑️ Successfully uninstalled plugin `{}`", name)
     } else {
-        tracing::warn!("Plugin {} does not appear to be installed", name);
-    }
+        message!("Plugin `{}` does not appear to be installed", name)
+    };
 
-    Ok(())
+    Ok(message)
 }
 
+/// Uninstall a plugin
 #[derive(Debug, Default, Args)]
 pub struct UninstallArgs {
     /// The name of the plugin to uninstall
     pub name: String,
+}
+
+impl UninstallArgs {
+    pub async fn run(self) -> Result<Message> {
+        uninstall(&self.name).await
+    }
 }

--- a/rust/schema-gen/src/docs_codecs.rs
+++ b/rust/schema-gen/src/docs_codecs.rs
@@ -40,9 +40,9 @@ impl Schemas {
 
         for file in glob(dest.join("*.md").as_os_str().to_str().unwrap())?.flatten() {
             let name = file.file_stem().unwrap().to_string_lossy().to_string();
-            let format = Format::from_name(&name)?;
+            let format = Format::from_name(&name);
 
-            let Ok(codec) = codecs::get(None, Some(format), None) else {
+            let Ok(codec) = codecs::get(None, Some(&format), None) else {
                 continue;
             };
 
@@ -114,7 +114,7 @@ impl Schemas {
 
                     let encoding = codec_support(codec.supports_to_type(node_type));
                     let decoding = codec_support(codec.supports_from_type(node_type));
-                    let notes = td(Schemas::docs_format_notes(schema, format));
+                    let notes = td(Schemas::docs_format_notes(schema, format.clone()));
 
                     rows.push(tr([title, encoding, decoding, notes]));
                 }
@@ -159,7 +159,7 @@ impl Schemas {
 
     /// Generates notes for a schema and format
     pub fn docs_format_notes(schema: &Schema, template: Format) -> Vec<Inline> {
-        if let (Format::Html, Some(HtmlOptions { special, elem, .. })) = (template, &schema.html) {
+        if let (Format::Html, Some(HtmlOptions { special, elem, .. })) = (&template, &schema.html) {
             if *special {
                 if let Some(elem) = elem {
                     vec![
@@ -187,7 +187,7 @@ impl Schemas {
                 vec![t("Encoded using derived function")]
             }
         } else if let (Format::Jats, Some(JatsOptions { elem, special, .. })) =
-            (template, &schema.jats)
+            (&template, &schema.jats)
         {
             if *special {
                 if let Some(elem) = elem {
@@ -218,7 +218,7 @@ impl Schemas {
             Some(MarkdownOptions {
                 derive, template, ..
             }),
-        ) = (template, &schema.markdown)
+        ) = (&template, &schema.markdown)
         {
             if !derive {
                 vec![t("Encoded using implemented function")]

--- a/rust/schema-gen/src/docs_types.rs
+++ b/rust/schema-gen/src/docs_types.rs
@@ -378,7 +378,7 @@ fn formats(title: &str, schema: &Schema) -> Vec<Block> {
 
     let node_type = NodeType::try_from(title).ok();
     for format in Format::iter() {
-        let Ok(codec) = codecs::get(None, Some(format), None) else {
+        let Ok(codec) = codecs::get(None, Some(&format), None) else {
             continue;
         };
 

--- a/rust/schema/src/deserialize.rs
+++ b/rust/schema/src/deserialize.rs
@@ -105,7 +105,7 @@ where
     })
 }
 
-/// Deserialize a vector from one or many of the items
+/// Deserialize an optional vector from one or many of the items
 pub fn option_one_or_many<'de, T, D>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
 where
     T: DeserializeOwned,
@@ -118,7 +118,7 @@ where
     })
 }
 
-/// Deserialize struct from a string or object
+/// Deserialize a struct from a string or object
 #[allow(unused)]
 pub fn string_or_object<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
@@ -131,7 +131,7 @@ where
     })
 }
 
-/// Deserialize struct from a string or object
+/// Deserialize an optional struct from a string or object
 pub fn option_string_or_object<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
 where
     T: DeserializeOwned + FromStr,

--- a/rust/server/src/server.rs
+++ b/rust/server/src/server.rs
@@ -645,9 +645,7 @@ async fn export_document(
 
     let doc = docs.by_id(&id).await.map_err(InternalError::new)?;
 
-    let format = query
-        .get("format")
-        .and_then(|format| Format::from_name(format).ok());
+    let format = query.get("format").map(|format| Format::from_name(format));
 
     let dom = query.get("dom").and_then(|dom| dom.parse().ok());
 
@@ -825,7 +823,7 @@ async fn handle_ws_format(ws: WebSocket, doc: Arc<Document>, capability: &str, f
     let format = format.parse().ok();
 
     let decode_options = DecodeOptions {
-        format,
+        format: format.clone(),
         ..Default::default()
     };
 


### PR DESCRIPTION
This PR aims to implement an initial iteration of a plugin registry and API. Still a very much a work in progress but aiming to include this early version in this week's alpha release of the CLI.

At this stage there is a `plugins.toml` file in the root of this repository which acts as a registry and points to URLs containing the `manifest.toml` file of each plugin. I have created two example plugins, each with their own repo:

![image](https://github.com/stencila/stencila/assets/1152336/60d7789a-bcf7-46c4-b158-ed34b57de9e9)

Moving on next to plugin installation and fleshing out the manifest more:

- [x] Determine if a plugin is installable on machine (runtime available and platform supported) or if already installed
- [x] Do a fake install of a plugin by creating a dir for it and copying manifest there
- [x] Determine if the installed version of the plugin is out of date (compared version in 'manifests.json' with version in 'manifest.toml'

