### PR TITLE
fix(views): set views to respond to doc property update

### DIFF
--- a/web/src/views/dynamic.ts
+++ b/web/src/views/dynamic.ts
@@ -52,19 +52,21 @@ export class DynamicView extends ThemedView {
    * Override so that clients are instantiated _after_ this
    * element has a document `[data-root]` element in its `renderRoot`.
    */
-  override firstUpdated(changedProperties: Map<string, string | boolean>) {
-    super.firstUpdated(changedProperties)
+  override update(changedProperties: Map<string, string | boolean>): void {
+    super.update(changedProperties)
 
-    this.domClient = new DomClient(
-      this.doc,
-      this.renderRoot.firstElementChild as HTMLElement
-    )
+    if (changedProperties.has('doc')) {
+      this.domClient = new DomClient(
+        this.doc,
+        this.renderRoot.firstElementChild as HTMLElement
+      )
 
-    this.nodesClient = new NodesClient(
-      this.doc,
-      this.access,
-      this.renderRoot as HTMLElement
-    )
+      this.nodesClient = new NodesClient(
+        this.doc,
+        this.access,
+        this.renderRoot as HTMLElement
+      )
+    }
   }
 
   override render() {

--- a/web/src/views/source.ts
+++ b/web/src/views/source.ts
@@ -325,7 +325,7 @@ export class SourceView extends TWLitElement {
   override async update(changedProperties: Map<string, string | boolean>) {
     super.update(changedProperties)
 
-    if (changedProperties.has('format')) {
+    if (changedProperties.has('format') || changedProperties.has('doc')) {
       // Destroy the existing editor if there is one
       this.codeMirrorView?.destroy()
 
@@ -422,7 +422,6 @@ export class SourceView extends TWLitElement {
       'relative',
       `h-full max-h-[calc(100vh-${heightOffset})]`,
     ])
-
     return html`
       <div class="${styles}">
         <div id="codemirror" class="h-full ${this.codeMirrorCSS}"></div>

--- a/web/src/views/static.ts
+++ b/web/src/views/static.ts
@@ -31,15 +31,32 @@ export class StaticView extends ThemedView {
   fetch: boolean
 
   /**
+   * Fetch and set the current doc's html
+   */
+  private fetchHTML = () => {
+    new ExportClient(this.doc, 'dom').fetch().then((html) => {
+      this.shadowRoot.innerHTML = html
+    })
+  }
+
+  /**
    * Override to fetch document's HTML if necessary
    */
   override connectedCallback() {
     super.connectedCallback()
 
     if (this.fetch) {
-      new ExportClient(this.doc, 'dom').fetch().then((html) => {
-        this.shadowRoot.innerHTML = html
-      })
+      this.fetchHTML()
+    }
+  }
+
+  /**
+   * Override to re fetch the html if the `doc` property has updated
+   */
+  override update(changedProperties: Map<string, string | boolean>): void {
+    super.update(changedProperties)
+    if (changedProperties.has('doc') && this.fetch) {
+      this.fetchHTML()
     }
   }
 

--- a/web/src/views/visual.ts
+++ b/web/src/views/visual.ts
@@ -60,7 +60,6 @@ export class VisualView extends ThemedView {
   /**
    * A ProseMirror editor view which the client interacts with
    */
-  // @ts-expect-error "prose mirror view is set, not read"
   private proseMirrorView: ProseMirrorView
 
   /**

--- a/web/src/views/visual.ts
+++ b/web/src/views/visual.ts
@@ -66,47 +66,55 @@ export class VisualView extends ThemedView {
   /**
    * Override so that clients are instantiated _after_ this
    * element has a document `[root]` element in its `renderRoot`.
+   *
+   * If the `doc` property has changed, destroy and create the view again
    */
-  override firstUpdated(changedProperties: Map<string, string | boolean>) {
-    super.firstUpdated(changedProperties)
+  override update(changedProperties: Map<string, string | boolean>) {
+    super.update(changedProperties)
+    if (changedProperties.has('doc')) {
+      // destroy prosemirror view if it exists
+      if (this.proseMirrorView) {
+        this.proseMirrorView.destroy()
+      }
 
-    // Get the ProseMirror schema corresponding to the node type
-    // of the document
-    const tagName =
-      this.renderRoot.querySelector('[root]')?.tagName.toLowerCase() ??
-      'stencila-article'
-    let schema: Schema
-    let views: Record<string, NodeViewConstructor>
-    if (tagName === 'stencila-article') {
-      // eslint-disable-next-line no-extra-semi
-      ;({ schema, views } = schemas.article)
-    } else {
-      throw new Error(`No schema for element '${tagName}'`)
+      // Get the ProseMirror schema corresponding to the node type
+      // of the document
+      const tagName =
+        this.renderRoot.querySelector('[root]')?.tagName.toLowerCase() ??
+        'stencila-article'
+      let schema: Schema
+      let views: Record<string, NodeViewConstructor>
+      if (tagName === 'stencila-article') {
+        // eslint-disable-next-line no-extra-semi
+        ;({ schema, views } = schemas.article)
+      } else {
+        throw new Error(`No schema for element '${tagName}'`)
+      }
+
+      // Parse the document's DOM into a ProseMirror document
+      // and then remove it (because it will be redundant)
+      const doc = DOMParser.fromSchema(schema).parse(this.renderRoot)
+      this.renderRoot.firstElementChild.remove()
+
+      this.proseMirrorClient = new ProseMirrorClient(
+        this.doc,
+        this.access,
+        this.renderRoot as HTMLElement
+      )
+
+      this.proseMirrorView = new ProseMirrorView(this.renderRoot, {
+        state: EditorState.create({
+          doc,
+        }),
+        dispatchTransaction: this.proseMirrorClient.sendPatches(),
+        nodeViews: views,
+      })
+
+      // Attach the `DomClient` to the ProseMirror element
+      const proseMirrorElem = this.renderRoot.querySelector('.ProseMirror')
+        .firstElementChild as HTMLElement
+      this.domClient = new DomClient(this.doc, proseMirrorElem)
     }
-
-    // Parse the document's DOM into a ProseMirror document
-    // and then remove it (because it will be redundant)
-    const doc = DOMParser.fromSchema(schema).parse(this.renderRoot)
-    this.renderRoot.firstElementChild.remove()
-
-    this.proseMirrorClient = new ProseMirrorClient(
-      this.doc,
-      this.access,
-      this.renderRoot as HTMLElement
-    )
-
-    this.proseMirrorView = new ProseMirrorView(this.renderRoot, {
-      state: EditorState.create({
-        doc,
-      }),
-      dispatchTransaction: this.proseMirrorClient.sendPatches(),
-      nodeViews: views,
-    })
-
-    // Attach the `DomClient` to the ProseMirror element
-    const proseMirrorElem = this.renderRoot.querySelector('.ProseMirror')
-      .firstElementChild as HTMLElement
-    this.domClient = new DomClient(this.doc, proseMirrorElem)
   }
 
   override render() {


### PR DESCRIPTION
**details**

This fixes an issue related to the document tabs in all views,

 - when closing tabs sometimes the tabs are not associated with the panels properly
 
The issue was not with the logic, the view in the panels were not updating itself
 
TL:DR; 
Here's what was happening: 
If i had two tabs open with ids: doc_1 and doc_2.
and I closed doc_1 and the main LitELement updates,  doc_2 is now the only tab, however it has moved into the panel where doc_1 was before. The property `doc` was updated correctly and passed down to child elements, however the view (eg, source, visual) element inside that panel had no way of responding an update in the `doc` property. I have set it now so It reset each view in this case.

**related issue**: #2065 