### PR TITLE
Inline/block on demand & in flow

### DIFF
--- a/web/src/nodes/array.ts
+++ b/web/src/nodes/array.ts
@@ -8,6 +8,7 @@ import { withTwind } from '../twind'
 import { Entity } from './entity'
 
 import './array-item'
+import '../ui/nodes/in-flow/block'
 
 /**
  * Web component representing a Stencila Schema `Array` node
@@ -32,11 +33,11 @@ export class Array extends Entity {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="Array" view="dynamic">
+      <stencila-ui-block-in-flow type="Array" view="dynamic">
         <div slot="body" class="p-2">
           <slot></slot>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 
@@ -47,11 +48,11 @@ export class Array extends Entity {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="Array" view="source">
+      <stencila-ui-block-in-flow type="Array" view="source">
         <div slot="body" class="p-2">
           <slot></slot>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/boolean.ts
+++ b/web/src/nodes/boolean.ts
@@ -6,7 +6,7 @@ import { withTwind } from '../twind'
 
 import { Entity } from './entity'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 
 /**
  * Web component representing a Stencila Schema `Boolean` node
@@ -38,9 +38,9 @@ export class Boolean extends Entity {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="Boolean" view="dynamic">
+      <stencila-ui-block-in-flow type="Boolean" view="dynamic">
         <div slot="body" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 
@@ -51,9 +51,9 @@ export class Boolean extends Entity {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="Boolean" view="source">
+      <stencila-ui-block-in-flow type="Boolean" view="source">
         <div slot="body" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/code-block.ts
+++ b/web/src/nodes/code-block.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit'
 import { customElement } from 'lit/decorators'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -24,7 +24,7 @@ export class CodeBlock extends CodeStatic {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="CodeBlock" view="dynamic">
+      <stencila-ui-block-in-flow type="CodeBlock" view="dynamic">
         <div slot="body">
           <stencila-ui-node-authors>
             <slot name="authors"></slot>
@@ -38,7 +38,7 @@ export class CodeBlock extends CodeStatic {
           >
           </stencila-ui-node-code>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 
@@ -48,13 +48,21 @@ export class CodeBlock extends CodeStatic {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="CodeBlock" view="source">
+      <stencila-ui-block-in-flow type="CodeBlock" view="source">
         <div slot="body">
           <stencila-ui-node-authors>
             <slot name="authors"></slot>
           </stencila-ui-node-authors>
+
+          <stencila-ui-node-code
+            type="CodeBlock"
+            code=${this.code}
+            language=${this.programmingLanguage}
+            read-only
+          >
+          </stencila-ui-node-code>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/code-chunk.ts
+++ b/web/src/nodes/code-chunk.ts
@@ -4,7 +4,7 @@ import { customElement, property } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/commands/execution-commands'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
@@ -54,7 +54,7 @@ export class CodeChunk extends CodeExecutable {
    * with execution actions and details and code read-only and collapsed.
    */
   override renderDynamicView() {
-    return html`<stencila-ui-node-card type="CodeChunk" view="dynamic">
+    return html`<stencila-ui-block-in-flow type="CodeChunk" view="dynamic">
       <span slot="header-right">
         <stencila-ui-node-execution-commands node-id=${this.id}>
         </stencila-ui-node-execution-commands>
@@ -108,7 +108,7 @@ export class CodeChunk extends CodeExecutable {
           <slot name="caption" slot="caption"></slot>
         </stencila-ui-node-label-and-caption>
       </div>
-    </stencila-ui-node-card>`
+    </stencila-ui-block-in-flow>`
   }
 
   /**
@@ -116,7 +116,7 @@ export class CodeChunk extends CodeExecutable {
    * code, label, caption (because they are displayed in the source code).
    */
   override renderSourceView() {
-    return html`<stencila-ui-node-card type="CodeChunk" view="source">
+    return html`<stencila-ui-block-in-flow type="CodeChunk" view="source">
       <span slot="header-right">
         <stencila-ui-node-execution-commands node-id=${this.id}>
         </stencila-ui-node-execution-commands>
@@ -153,6 +153,6 @@ export class CodeChunk extends CodeExecutable {
           <slot name="outputs"></slot>
         </stencila-ui-node-outputs>
       </div>
-    </stencila-ui-node-card>`
+    </stencila-ui-block-in-flow>`
   }
 }

--- a/web/src/nodes/code-expression.ts
+++ b/web/src/nodes/code-expression.ts
@@ -3,7 +3,7 @@ import { customElement } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/commands/execution-commands'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
@@ -34,11 +34,7 @@ export class CodeExpression extends CodeExecutable {
    * on demand with execution actions and details and code read-only.
    */
   override renderDynamicView() {
-    return html`<stencila-ui-node-card
-      type="CodeExpression"
-      view="dynamic"
-      display="on-demand"
-    >
+    return html`<stencila-ui-block-in-flow type="CodeExpression" view="dynamic">
       <span slot="header-right">
         <stencila-ui-node-execution-commands node-id=${this.id}>
         </stencila-ui-node-execution-commands>
@@ -86,7 +82,7 @@ export class CodeExpression extends CodeExecutable {
           <slot name="output"></slot>
         </stencila-ui-node-output>
       </span>
-    </stencila-ui-node-card>`
+    </stencila-ui-block-in-flow>`
   }
 
   /**
@@ -94,7 +90,7 @@ export class CodeExpression extends CodeExecutable {
    * code (because it is displayed in the source code).
    */
   override renderSourceView() {
-    return html`<stencila-ui-node-card type="CodeExpression" view="source">
+    return html`<stencila-ui-block-in-flow type="CodeExpression" view="source">
       <span slot="header-right">
         <stencila-ui-node-execution-commands node-id=${this.id}>
         </stencila-ui-node-execution-commands>
@@ -131,6 +127,6 @@ export class CodeExpression extends CodeExecutable {
           <slot name="output"></slot>
         </stencila-ui-node-output>
       </div>
-    </stencila-ui-node-card>`
+    </stencila-ui-block-in-flow>`
   }
 }

--- a/web/src/nodes/code-inline.ts
+++ b/web/src/nodes/code-inline.ts
@@ -2,8 +2,10 @@ import { html } from 'lit'
 import { customElement } from 'lit/decorators'
 
 import '../ui/nodes/on-demand/in-line'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
+import '../ui/nodes/properties/outputs'
 
 import { CodeStatic } from './code-static'
 
@@ -37,6 +39,9 @@ export class CodeInline extends CodeStatic {
             read-only
           >
           </stencila-ui-node-code>
+          <stencila-ui-node-outputs type="CodeInline">
+            <slot name="outputs">${this.code}</slot>
+          </stencila-ui-node-outputs>
         </div>
         <span slot="content"> ${this.code} </span>
       </stencila-ui-inline-on-demand>
@@ -49,13 +54,24 @@ export class CodeInline extends CodeStatic {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="CodeInline" view="source">
+      <stencila-ui-block-in-flow type="CodeInline" view="source">
         <div slot="body">
           <stencila-ui-node-authors>
             <slot name="authors"></slot>
           </stencila-ui-node-authors>
+
+          <stencila-ui-node-code
+            type="CodeInline"
+            code=${this.code}
+            language=${this.programmingLanguage}
+            read-only
+          >
+          </stencila-ui-node-code>
+          <stencila-ui-node-outputs type="CodeInline">
+            <slot name="outputs">${this.code}</slot>
+          </stencila-ui-node-outputs>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/code-inline.ts
+++ b/web/src/nodes/code-inline.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit'
 import { customElement } from 'lit/decorators'
 
-import '../ui/nodes/card'
+import '../ui/nodes/on-demand/in-line'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -24,7 +24,7 @@ export class CodeInline extends CodeStatic {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="CodeInline" view="dynamic">
+      <stencila-ui-inline-on-demand type="CodeInline" view="dynamic">
         <div slot="body">
           <stencila-ui-node-authors type="CodeInline">
             <slot name="authors"></slot>
@@ -38,7 +38,8 @@ export class CodeInline extends CodeStatic {
           >
           </stencila-ui-node-code>
         </div>
-      </stencila-ui-node-card>
+        <span slot="content"> ${this.code} </span>
+      </stencila-ui-inline-on-demand>
     `
   }
 

--- a/web/src/nodes/integer.ts
+++ b/web/src/nodes/integer.ts
@@ -6,7 +6,7 @@ import { withTwind } from '../twind'
 
 import { Entity } from './entity'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 
 /**
  * Web component representing a Stencila Schema `Integer` node
@@ -38,9 +38,9 @@ export class Integer extends Entity {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="Integer" view="dynamic">
+      <stencila-ui-block-in-flow type="Integer" view="dynamic">
         <div slot="body" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 
@@ -51,9 +51,9 @@ export class Integer extends Entity {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="Integer" view="source">
+      <stencila-ui-block-in-flow type="Integer" view="source">
         <div slot="body" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/math-block.ts
+++ b/web/src/nodes/math-block.ts
@@ -4,6 +4,7 @@ import { customElement } from 'lit/decorators'
 import { withTwind } from '../twind'
 
 import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -25,7 +26,7 @@ export class MathBlock extends Math {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="MathBlock" view="source">
+      <stencila-ui-block-in-flow type="MathBlock" view="source">
         <div slot="body">
           <stencila-ui-node-authors type="MathBlock">
             <slot name="authors"></slot>
@@ -40,11 +41,11 @@ export class MathBlock extends Math {
           >
           </stencila-ui-node-code>
 
-          <div class="p-6">
+          <div class="px-4 py-3">
             <slot name="mathml"></slot>
           </div>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 

--- a/web/src/nodes/math-block.ts
+++ b/web/src/nodes/math-block.ts
@@ -3,7 +3,6 @@ import { customElement } from 'lit/decorators'
 
 import { withTwind } from '../twind'
 
-import '../ui/nodes/card'
 import '../ui/nodes/in-flow/block'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
@@ -56,7 +55,7 @@ export class MathBlock extends Math {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="MathBlock" view="source">
+      <stencila-ui-block-in-flow type="MathBlock" view="source">
         <div slot="body">
           <stencila-ui-node-authors type="MathBlock">
             <slot name="authors"></slot>
@@ -66,7 +65,7 @@ export class MathBlock extends Math {
             <slot name="mathml"></slot>
           </div>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/math-inline.ts
+++ b/web/src/nodes/math-inline.ts
@@ -4,6 +4,7 @@ import { customElement } from 'lit/decorators'
 import { withTwind } from '../twind'
 
 import '../ui/nodes/on-demand/in-line'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -53,7 +54,7 @@ export class MathInline extends Math {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="MathInline" view="source">
+      <stencila-ui-block-in-flow type="MathInline" view="source">
         <div slot="body">
           <stencila-ui-node-authors type="MathInline">
             <slot name="authors"></slot>
@@ -63,7 +64,7 @@ export class MathInline extends Math {
             <slot name="mathml"></slot>
           </div>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/math-inline.ts
+++ b/web/src/nodes/math-inline.ts
@@ -3,7 +3,6 @@ import { customElement } from 'lit/decorators'
 
 import { withTwind } from '../twind'
 
-import '../ui/nodes/card'
 import '../ui/nodes/on-demand/in-line'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'

--- a/web/src/nodes/math-inline.ts
+++ b/web/src/nodes/math-inline.ts
@@ -4,6 +4,7 @@ import { customElement } from 'lit/decorators'
 import { withTwind } from '../twind'
 
 import '../ui/nodes/card'
+import '../ui/nodes/on-demand/in-line'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -25,11 +26,7 @@ export class MathInline extends Math {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card
-        type="MathInline"
-        view="source"
-        display="on-demand"
-      >
+      <stencila-ui-inline-on-demand type="MathInline" view="source">
         <div slot="body">
           <stencila-ui-node-authors type="MathInline">
             <slot name="authors"></slot>
@@ -47,7 +44,7 @@ export class MathInline extends Math {
         <span slot="content">
           <slot name="mathml"></slot>
         </span>
-      </stencila-ui-node-card>
+      </stencila-ui-inline-on-demand>
     `
   }
 

--- a/web/src/nodes/number.ts
+++ b/web/src/nodes/number.ts
@@ -2,7 +2,7 @@ import { apply } from '@twind/core'
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 
 import { withTwind } from '../twind'
 
@@ -38,9 +38,9 @@ export class Number extends Entity {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="Number" view="dynamic">
+      <stencila-ui-block-in-flow type="Number" view="dynamic">
         <div slot="body" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 
@@ -51,9 +51,9 @@ export class Number extends Entity {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="Number" view="source">
+      <stencila-ui-block-in-flow type="Number" view="source">
         <div slot="body" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/object.ts
+++ b/web/src/nodes/object.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 
 import { withTwind } from '../twind'
 
@@ -31,11 +31,11 @@ export class Object extends Entity {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="Object" view="dynamic">
+      <stencila-ui-block-in-flow type="Object" view="dynamic">
         <div slot="body" class="p-2">
           <slot></slot>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 
@@ -46,11 +46,11 @@ export class Object extends Entity {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="Object" view="source">
+      <stencila-ui-block-in-flow type="Object" view="source">
         <div slot="body" class="p-2">
           <slot></slot>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/paragraph.ts
+++ b/web/src/nodes/paragraph.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit'
+import { css, html } from 'lit'
 import { customElement } from 'lit/decorators'
 
 import { withTwind } from '../twind'
@@ -16,6 +16,12 @@ import { Entity } from './entity'
 @customElement('stencila-paragraph')
 @withTwind()
 export class Paragraph extends Entity {
+  static override styles = css`
+    ::slotted(p) {
+      display: flex;
+    }
+  `
+
   /**
    * In static view just render the `content`.
    */
@@ -41,7 +47,9 @@ export class Paragraph extends Entity {
             <slot name="authors"></slot>
           </stencila-ui-node-authors>
         </div>
-        <slot name="content" slot="content"></slot>
+        <div slot="content" class="content">
+          <slot name="content"></slot>
+        </div>
       </stencila-ui-node-card>
     `
   }

--- a/web/src/nodes/paragraph.ts
+++ b/web/src/nodes/paragraph.ts
@@ -37,7 +37,7 @@ export class Paragraph extends Entity {
             <slot name="authors"></slot>
           </stencila-ui-node-authors>
         </div>
-        <div slot="content" class="inline-elements">
+        <div slot="content">
           <slot name="content"></slot>
         </div>
       </stencila-ui-block-on-demand>

--- a/web/src/nodes/paragraph.ts
+++ b/web/src/nodes/paragraph.ts
@@ -1,9 +1,9 @@
-import { css, html } from 'lit'
+import { html } from 'lit'
 import { customElement } from 'lit/decorators'
 
 import { withTwind } from '../twind'
 
-import '../ui/nodes/card'
+import '../ui/nodes/on-demand/block'
 import '../ui/nodes/properties/authors'
 
 import { Entity } from './entity'
@@ -16,12 +16,6 @@ import { Entity } from './entity'
 @customElement('stencila-paragraph')
 @withTwind()
 export class Paragraph extends Entity {
-  static override styles = css`
-    ::slotted(p) {
-      display: flex;
-    }
-  `
-
   /**
    * In static view just render the `content`.
    */
@@ -37,20 +31,16 @@ export class Paragraph extends Entity {
     // TODO: Add summary stats to card
 
     return html`
-      <stencila-ui-node-card
-        type="Paragraph"
-        view="dynamic"
-        display="on-demand"
-      >
+      <stencila-ui-block-on-demand type="Paragraph" view="dynamic">
         <div slot="body">
           <stencila-ui-node-authors type="Paragraph">
             <slot name="authors"></slot>
           </stencila-ui-node-authors>
         </div>
-        <div slot="content" class="content">
+        <div slot="content" class="inline-elements">
           <slot name="content"></slot>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-on-demand>
     `
   }
 
@@ -62,13 +52,13 @@ export class Paragraph extends Entity {
     // TODO: Add summary stats to card
 
     return html`
-      <stencila-ui-node-card type="Paragraph" view="source">
+      <stencila-ui-block-on-demand type="Paragraph" view="source">
         <div slot="body">
           <stencila-ui-node-authors type="Paragraph">
             <slot name="authors"></slot>
           </stencila-ui-node-authors>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-on-demand>
     `
   }
 }

--- a/web/src/nodes/string.ts
+++ b/web/src/nodes/string.ts
@@ -2,7 +2,7 @@ import { apply } from '@twind/core'
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
-import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 
 import { withTwind } from '../twind'
 
@@ -33,11 +33,11 @@ export class String extends Entity {
    */
   override renderDynamicView() {
     return html`
-      <stencila-ui-node-card type="String" view="dynamic">
+      <stencila-ui-block-in-flow type="String" view="dynamic">
         <div slot="body" class=${this.bodyStyles}>
           <q><slot></slot></q>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 
@@ -48,11 +48,11 @@ export class String extends Entity {
    */
   override renderSourceView() {
     return html`
-      <stencila-ui-node-card type="String" view="source">
+      <stencila-ui-block-in-flow type="String" view="source">
         <div slot="body" class=${this.bodyStyles}>
           <q><slot></slot></q>
         </div>
-      </stencila-ui-node-card>
+      </stencila-ui-block-in-flow>
     `
   }
 }

--- a/web/src/nodes/styled-block.ts
+++ b/web/src/nodes/styled-block.ts
@@ -2,6 +2,7 @@ import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
 import '../ui/nodes/card'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -34,7 +35,7 @@ export class StyledBlock extends Styled {
   override renderDynamicView() {
     this.adoptCss()
 
-    return html` <stencila-ui-node-card type="StyledBlock" view="dynamic">
+    return html` <stencila-ui-block-in-flow type="StyledBlock" view="dynamic">
       <div slot="body">
         <stencila-ui-node-authors type="StyledBlock">
           <slot name="authors"></slot>
@@ -55,7 +56,7 @@ export class StyledBlock extends Styled {
           <slot name="content"></slot>
         </div>
       </div>
-    </stencila-ui-node-card>`
+    </stencila-ui-block-in-flow>`
   }
 
   /**
@@ -64,12 +65,12 @@ export class StyledBlock extends Styled {
    * TODO: Also render compiled CSS and styled content to help with debugging?
    */
   override renderSourceView() {
-    return html` <stencila-ui-node-card type="StyledBlock" view="source">
+    return html` <stencila-ui-block-in-flow type="StyledBlock" view="source">
       <div slot="body">
         <stencila-ui-node-authors type="StyledBlock">
           <slot name="authors"></slot>
         </stencila-ui-node-authors>
       </div>
-    </stencila-ui-node-card>`
+    </stencila-ui-block-in-flow>`
   }
 }

--- a/web/src/nodes/styled-block.ts
+++ b/web/src/nodes/styled-block.ts
@@ -1,3 +1,4 @@
+import { apply } from '@twind/core'
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
@@ -15,6 +16,7 @@ import { Styled } from './styled'
  */
 @customElement('stencila-styled-block')
 export class StyledBlock extends Styled {
+  private contentCSS = apply(['w-full', '-mx-4'])
   /**
    * In static view just render the `content` with styles applied
    */
@@ -51,7 +53,7 @@ export class StyledBlock extends Styled {
         </stencila-ui-node-code>
       </div>
 
-      <div slot="content" class="styled">
+      <div slot="content" class=${`styled`}>
         <div class="${this.classes}">
           <slot name="content"></slot>
         </div>
@@ -65,11 +67,27 @@ export class StyledBlock extends Styled {
    * TODO: Also render compiled CSS and styled content to help with debugging?
    */
   override renderSourceView() {
+    this.adoptCss()
+
     return html` <stencila-ui-block-in-flow type="StyledBlock" view="source">
       <div slot="body">
         <stencila-ui-node-authors type="StyledBlock">
           <slot name="authors"></slot>
         </stencila-ui-node-authors>
+
+        <stencila-ui-node-code
+          type="StyledBlock"
+          code=${this.code}
+          language=${this.styleLanguage}
+          read-only
+          collapsed
+        >
+        </stencila-ui-node-code>
+      </div>
+      <div slot="content" class=${`styled ${this.contentCSS}`}>
+        <div class="${this.classes}">
+          <slot name="content"></slot>
+        </div>
       </div>
     </stencila-ui-block-in-flow>`
   }

--- a/web/src/nodes/styled-inline.ts
+++ b/web/src/nodes/styled-inline.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
-import '../ui/nodes/card'
+import '../ui/nodes/on-demand/in-line'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -34,10 +34,9 @@ export class StyledInline extends Styled {
   override renderDynamicView() {
     this.adoptCss()
 
-    return html` <stencila-ui-node-card
+    return html` <stencila-ui-inline-on-demand
       type="StyledInline"
       view="dynamic"
-      display="on-demand"
     >
       <div slot="body">
         <stencila-ui-node-authors type="StyledInline">
@@ -59,7 +58,7 @@ export class StyledInline extends Styled {
           <slot name="content"></slot>
         </span>
       </span>
-    </stencila-ui-node-card>`
+    </stencila-ui-inline-on-demand>`
   }
 
   /**

--- a/web/src/nodes/styled-inline.ts
+++ b/web/src/nodes/styled-inline.ts
@@ -2,6 +2,7 @@ import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
 import '../ui/nodes/on-demand/in-line'
+import '../ui/nodes/in-flow/block'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code'
 
@@ -67,12 +68,12 @@ export class StyledInline extends Styled {
    * TODO: Also render compiled CSS and styled content to help with debugging?
    */
   override renderSourceView() {
-    return html` <stencila-ui-node-card type="StyledBlock" view="source">
+    return html` <stencila-ui-block-in-flow type="StyledBlock" view="source">
       <div slot="body">
         <stencila-ui-node-authors type="StyledBlock">
           <slot name="authors"></slot>
         </stencila-ui-node-authors>
       </div>
-    </stencila-ui-node-card>`
+    </stencila-ui-block-in-flow>`
   }
 }

--- a/web/src/nodes/styled.ts
+++ b/web/src/nodes/styled.ts
@@ -22,7 +22,7 @@ export abstract class Styled extends Entity {
   classes?: string
 
   /**
-   * Derived classes should class this in the render function
+   * Derived classes should call this in the render function
    */
   protected adoptCss() {
     if (this.css) {

--- a/web/src/ui/nodes/in-flow/block.ts
+++ b/web/src/ui/nodes/in-flow/block.ts
@@ -29,7 +29,7 @@ export class UIBlockInFlow extends UIBaseClass {
       'border border-[transparent]',
       'rounded',
       this.view === 'source' ? 'flex flex-col h-full' : 'my-2',
-      `border-[${this.ui.borderColour}]`,
+      this.ui.borderColour && `border-[${this.ui.borderColour}]`,
     ])
 
     return html`<div class=${`${cardStyles}`}>
@@ -48,7 +48,7 @@ export class UIBlockInFlow extends UIBaseClass {
     const headerStyles = apply([
       'flex items-center',
       'w-full',
-      'px-6 py-3',
+      'px-4 py-2',
       'gap-x-2',
       `bg-[${borderColour}]`,
       `border border-[${borderColour}]`,

--- a/web/src/ui/nodes/in-flow/block.ts
+++ b/web/src/ui/nodes/in-flow/block.ts
@@ -1,0 +1,122 @@
+import '@shoelace-style/shoelace/dist/components/icon/icon'
+import { apply } from '@twind/core'
+import { PropertyValueMap, html } from 'lit'
+import { customElement, state } from 'lit/decorators'
+
+import { withTwind } from '../../../twind'
+import '../../animation/collapsible'
+import { UIBaseClass } from '../mixins/uiBaseClass'
+
+/**
+ * UI in-flow-block
+ *
+ * A component to render a node-card "in flow" - i.e. renders a block as is
+ * without requiring user interaction
+ */
+@customElement('stencila-ui-block-in-flow')
+@withTwind()
+export class UIBlockInFlow extends UIBaseClass {
+  /**
+   * Disables showing content if slot has no content.
+   */
+  @state()
+  displayContent: boolean = false
+
+  override render() {
+    const cardStyles = apply([
+      'group',
+      'transition duration-400',
+      'border border-[transparent]',
+      'rounded',
+      this.view === 'source' ? 'flex flex-col h-full' : 'my-2',
+      `border-[${this.ui.borderColour}]`,
+    ])
+
+    return html`<div class=${`${cardStyles}`}>
+      <div class="relative">
+        <stencila-ui-collapsible-animation class=${'opened'}>
+          ${this.renderHeader()} ${this.renderBody()}
+        </stencila-ui-collapsible-animation>
+        ${this.renderContent()}
+      </div>
+    </div>`
+  }
+
+  private renderHeader() {
+    const { iconLibrary, icon, title, borderColour } = this.ui
+
+    const headerStyles = apply([
+      'flex items-center',
+      'w-full',
+      'px-6 py-3',
+      'gap-x-2',
+      `bg-[${borderColour}]`,
+      `border border-[${borderColour}]`,
+      this.view === 'source' ? '' : 'rounded-t',
+      'font-medium',
+    ])
+
+    return html`<div class=${headerStyles}>
+      <div class="flex items-center gap-x-2 grow">
+        <span class="items-center flex grow-0 shrink-0">
+          <sl-icon
+            library=${iconLibrary}
+            name=${icon}
+            class="text-2xl"
+          ></sl-icon>
+        </span>
+        <div class="flex justify-between items-center gap-x-2 grow">
+          <span class="font-bold grow">${title}</span>
+          <div class="">
+            <slot name="header-right"></slot>
+          </div>
+        </div>
+      </div>
+    </div>`
+  }
+
+  private renderBody() {
+    const { colour, borderColour } = this.ui
+    const bodyStyles = apply([
+      'relative',
+      'w-full h-full',
+      `bg-[${colour}]`,
+      `border border-[${borderColour}] rounded-b`,
+    ])
+
+    return html`<div class=${bodyStyles}>
+      <slot name="body"></slot>
+    </div>`
+  }
+
+  private renderContent() {
+    const contentStyles = apply([
+      'flex',
+      'relative',
+      'transition-[padding] ease-in-out duration-[250ms]',
+      'px-3',
+    ])
+
+    return html`<div class=${contentStyles}>
+      <slot name="content"></slot>
+    </div>`
+  }
+
+  protected override update(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>
+  ) {
+    super.update(changedProperties)
+    const slot: HTMLSlotElement = this.shadowRoot.querySelector(
+      'slot[name="content"]'
+    )
+
+    if (slot) {
+      const hasItems = slot.assignedElements({ flatten: true }).length !== 0
+
+      if (hasItems !== this.displayContent) {
+        this.displayContent = hasItems
+      }
+    }
+  }
+}

--- a/web/src/ui/nodes/mixins/uiBaseClass.ts
+++ b/web/src/ui/nodes/mixins/uiBaseClass.ts
@@ -29,9 +29,9 @@ export class UIBaseClass extends LitElement {
   @property()
   view: DocumentView
 
-  // /**
-  //  * Internal copy of the ui attributes.
-  //  */
+  /**
+   * Internal copy of the ui attributes.
+   */
   protected ui: ReturnType<typeof nodeUi> | undefined = undefined
 
   /**

--- a/web/src/ui/nodes/mixins/uiBaseClass.ts
+++ b/web/src/ui/nodes/mixins/uiBaseClass.ts
@@ -1,0 +1,45 @@
+import { NodeType } from '@stencila/types'
+import { LitElement } from 'lit'
+import { property } from 'lit/decorators'
+
+import { DocumentView } from '../../../types'
+import { nodeUi } from '../icons-and-colours'
+
+/**
+ * A Base class for UI elements. Provides access to ui theming.
+ *
+ * @export
+ * @class UIBaseClass
+ * @extends {LitElement}
+ */
+export class UIBaseClass extends LitElement {
+  /**
+   * The type of node that this card is for
+   *
+   * Used to determine the title, icon and colors of the card.
+   */
+  @property()
+  type: NodeType
+
+  /**
+   * The view that this card is within
+   *
+   * Used for adapting styling for the view.
+   */
+  @property()
+  view: DocumentView
+
+  // /**
+  //  * Internal copy of the ui attributes.
+  //  */
+  protected ui: ReturnType<typeof nodeUi> | undefined = undefined
+
+  /**
+   * Provide ui options based on the node type.
+   */
+  override connectedCallback() {
+    super.connectedCallback()
+
+    this.ui = nodeUi(this.type)
+  }
+}

--- a/web/src/ui/nodes/on-demand/block.ts
+++ b/web/src/ui/nodes/on-demand/block.ts
@@ -54,7 +54,7 @@ export class UIBlockOnDemand extends UIBaseClass {
     const headerStyles = apply([
       'flex items-center',
       'w-full',
-      'px-6 py-3',
+      'px-4 py-2',
       'gap-x-2',
       `bg-[${borderColour}]`,
       `border border-[${borderColour}]`,

--- a/web/src/ui/nodes/on-demand/in-line.ts
+++ b/web/src/ui/nodes/on-demand/in-line.ts
@@ -1,6 +1,6 @@
 import '@shoelace-style/shoelace/dist/components/icon/icon'
 import { apply, css as twCss, Twind } from '@twind/core'
-import { PropertyValueMap, html } from 'lit'
+import { PropertyValueMap, css, html } from 'lit'
 import { customElement, state } from 'lit/decorators'
 
 import { withTwind } from '../../../twind'
@@ -33,12 +33,18 @@ export class UIInlineOnDemand extends UIBaseClass {
 
   private tw: Twind
 
+  static override styles = css`
+    :host {
+      display: inline-block;
+    }
+  `
+
   override render() {
     const cardStyles = apply([
       'group',
       'transition duration-400',
       'rounded',
-      this.view === 'source' ? 'flex flex-col h-full' : 'my-2',
+      this.view === 'source' ? 'flex flex-col h-full' : '',
     ])
 
     return html`<div class=${`${cardStyles}`}>
@@ -52,7 +58,7 @@ export class UIInlineOnDemand extends UIBaseClass {
     const headerStyles = apply([
       'flex items-center',
       'w-full',
-      'px-4 py-1',
+      'px-4 py-2',
       'gap-x-2',
       `bg-[${borderColour}]`,
       'border-b border-black/20',
@@ -156,6 +162,19 @@ export class UIInlineOnDemand extends UIBaseClass {
         --sl-tooltip-color: ${(colors['black'] ?? 'black') as string};
 
         pointer-events: all;
+      }
+
+      &::part(body)::after {
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.15);
+        mix-blend-mode: multiply;
+        content: '';
+
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        bottom: 0;
+        z-index: -1;
       }
     `
 

--- a/web/src/ui/nodes/on-demand/in-line.ts
+++ b/web/src/ui/nodes/on-demand/in-line.ts
@@ -1,46 +1,21 @@
 import '@shoelace-style/shoelace/dist/components/icon/icon'
-import type { NodeType } from '@stencila/types'
 import { apply } from '@twind/core'
-import { html, LitElement } from 'lit'
-import { customElement, property, state } from 'lit/decorators'
+import { PropertyValueMap, css, html } from 'lit'
+import { customElement, state } from 'lit/decorators'
 
-import { withTwind } from '../../twind'
-import { DocumentView } from '../../types'
-
-import { nodeUi } from './icons-and-colours'
-
-import '../animation/collapsible'
+import { withTwind } from '../../../twind'
+import '../../animation/collapsible'
+import { UIBaseClass } from '../mixins/uiBaseClass'
 
 /**
- * A component for displaying information about a node type (e.g. a `Heading` or `Table`)
+ * UI inline-on-demand
+ *
+ * A component to render a node-card on demand - i.e. a user requests to see
+ * the info rather than just the content of a card.
  */
-@customElement('stencila-ui-node-card')
+@customElement('stencila-ui-inline-on-demand')
 @withTwind()
-export class UINodeCard extends LitElement {
-  /**
-   * The type of node that this card is for
-   *
-   * Used to determine the title, icon and colors of the card.
-   */
-  @property()
-  type: NodeType
-
-  /**
-   * The view that this card is within
-   *
-   * Used for adapting styling for the view.
-   */
-  @property()
-  view: DocumentView
-
-  /**
-   * Determine how to display the node-card. By default, we simply display the
-   * card as is (`auto`). However, if we show the card in the dynamic view, we
-   * need the ability to only show the card only when needed.
-   */
-  @property()
-  display: 'on-demand' | 'auto' = 'auto'
-
+export class UIInlineOnDemand extends UIBaseClass {
   /**
    * Manages showing/hiding the card info (when rendering display = 'on-demand')
    */
@@ -48,53 +23,35 @@ export class UINodeCard extends LitElement {
   toggle: boolean = false
 
   /**
-   * Internal copy of the ui attributes.
+   * Disables showing content if slot has no content.
    */
-  private ui: ReturnType<typeof nodeUi> | undefined = undefined
+  @state()
+  displayContent: boolean = false
 
-  /**
-   * Provide ui options based on the node type.
-   */
-  override connectedCallback() {
-    super.connectedCallback()
-
-    this.ui = nodeUi(this.type)
-  }
+  static override styles = css`
+    :host {
+      flex-grow: 0;
+      background-color: red;
+      width: 100%;
+    }
+  `
 
   override render() {
     const cardStyles = apply([
       'group',
       'transition duration-400',
       'border border-[transparent]',
-      this.display && 'rounded',
+      'rounded',
       this.view === 'source' ? 'flex flex-col h-full' : 'my-2',
-      this.display === 'on-demand' &&
-        this.toggle &&
-        `border-[${this.ui.borderColour}]`,
+      this.toggle && `border-[${this.ui.borderColour}]`,
     ])
 
-    const contentStyles = apply([
-      'flex',
-      'relative',
-      'transition-[padding] ease-in-out duration-[250ms]',
-      'px-0',
-      'w-full',
-      this.display === 'on-demand' && this.toggle && 'px-3',
-    ])
-
-    return html` <div class=${`${cardStyles}`}>
+    return html`<div class=${`${cardStyles}`}>
       <div class="relative">
-        <stencila-ui-collapsible-animation
-          class=${this.toggle || this.display === 'auto' ? 'opened' : ''}
-        >
+        <stencila-ui-collapsible-animation class=${this.toggle ? 'opened' : ''}>
           ${this.renderHeader()} ${this.renderBody()}
         </stencila-ui-collapsible-animation>
-        <div class=${contentStyles}>
-          ${this.renderChip()}
-          <div class="inline grow">
-            <slot name="content"></slot>
-          </div>
-        </div>
+        ${this.renderContent()}
       </div>
     </div>`
   }
@@ -139,7 +96,7 @@ export class UINodeCard extends LitElement {
       'relative',
       'w-full h-full',
       `bg-[${colour}]`,
-      this.display === 'auto' && `border border-[${borderColour}] rounded-b`,
+      `border border-[${borderColour}] rounded-b`,
     ])
 
     return html`<div class=${bodyStyles}>
@@ -148,12 +105,7 @@ export class UINodeCard extends LitElement {
   }
 
   private renderClose() {
-    const styles = apply([
-      'text-base',
-      'cursor-pointer',
-      'grow-0 shrink-0',
-      this.display === 'auto' && 'hidden pointer-events-none',
-    ])
+    const styles = apply(['text-base', 'cursor-pointer', 'grow-0 shrink-0'])
 
     return html`<sl-icon
       class=${styles}
@@ -167,9 +119,8 @@ export class UINodeCard extends LitElement {
     const { iconLibrary, icon, colour, borderColour } = this.ui
 
     const styles = apply([
-      this.display === 'auto' && `hidden pointer-events-none`,
-      this.display === 'on-demand' && this.toggle && 'pointer-events-none',
-      this.display === 'on-demand' && !this.toggle && 'group-hover:opacity-100',
+      this.toggle && 'pointer-events-none',
+      !this.toggle && 'group-hover:opacity-100',
       'h-8',
       'flex items-center',
       'opacity-0',
@@ -196,7 +147,40 @@ export class UINodeCard extends LitElement {
     `
   }
 
+  private renderContent() {
+    const contentStyles = apply([
+      !this.displayContent && this.toggle ? 'hidden' : 'flex',
+      'relative',
+      'transition-[padding] ease-in-out duration-[250ms]',
+      'px-0',
+      this.toggle && 'px-3',
+    ])
+
+    return html` <div class=${contentStyles}>
+      ${this.renderChip()}
+      <slot name="content"></slot>
+    </div>`
+  }
+
   private toggleCardDisplay() {
     this.toggle = !this.toggle
+  }
+
+  protected override update(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>
+  ) {
+    super.update(changedProperties)
+    const slot: HTMLSlotElement = this.shadowRoot.querySelector(
+      'slot[name="content"]'
+    )
+
+    if (slot) {
+      const hasItems = slot.assignedElements({ flatten: true }).length !== 0
+
+      if (hasItems !== this.displayContent) {
+        this.displayContent = hasItems
+      }
+    }
   }
 }

--- a/web/src/ui/split-drag/index.ts
+++ b/web/src/ui/split-drag/index.ts
@@ -67,16 +67,17 @@ export class DragSplit extends TWLitElement {
   override render() {
     const panel = apply([
       'w-full min-w-full',
-      'h-[calc(50vh-32px)]',
-      'lg:(max-h-screen min-h-screen min-w-0)',
+      'h-[calc(100%-1px)]',
+      'lg:(max-h-[calc(100vh-5rem-1px)] min-w-0)',
+      'border-r',
     ])
 
-    return html`<div class="flex h-screen flex-col lg:flex-row">
-      <div class="${panel} overflow-scroll" ${ref(this.leftRef)}>
+    return html`<div class="flex h-[calc(100vh-5rem-1px)] flex-col lg:flex-row">
+      <div class="${panel} overflow-hidden" ${ref(this.leftRef)}>
         <slot name="left"></slot>
       </div>
       ${this.renderDrag()}
-      <div class="${panel} overflow-y-scroll" ${ref(this.rightRef)}>
+      <div class="overflow-y-scroll" ${ref(this.rightRef)}>
         <slot name="right"></slot>
       </div>
     </div>`

--- a/web/src/views/source.ts
+++ b/web/src/views/source.ts
@@ -460,7 +460,7 @@ export class SourceView extends TWLitElement {
       Height offset for the source view container,
       includes header height and tab container border
     */
-    const heightOffset = '5rem-1px'
+    const heightOffset = '5rem-3px'
 
     const styles = apply([
       'relative flex',

--- a/web/src/views/split.ts
+++ b/web/src/views/split.ts
@@ -62,6 +62,7 @@ export class SplitView extends LitElement {
             format=${this.format}
             displayMode="split"
             slot="left"
+            ?gutter-markers=${true}
           >
           </stencila-source-view>
           <div slot="right" class="${dynamicStyles}">


### PR DESCRIPTION
**Description**

Previously we had a `node-card` component which allowed us to render a node in either `on-demand` or `auto` modes. `on-demand` was for allowing blocks to be rendered as users interacted with them, `auto` - the element rendered on the screen as is.

This did not take `inline` vs `block` elements into account.

This PR provides some new components:

- `stencila-ui-block-in-flow`: `ui/in-flow/block.ts`
- `stencila-ui-block-on-demand`: `ui/on-demand/block.ts`
- `stencila-ui-inline-on-demand`: `ui/on-demand/in-line.ts`

These have been applied to the following (plus some other minor node types):

- `CodeChunk`
- `CodeExpression`
- `CodeBlock`
- `CodeInline`
- `MathBlock`
- `MathInline`
- `StyledBlock`
- `StyledInline`

_Note:_ Some rendering issues have fallen out of this issue. See #2187 for details on next steps.

---

closes #2174 