### PR TITLE
feat(quickjs kernel): add a QuickJS kernel and make default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -96,6 +96,7 @@
         "Pydantic",
         "pyfunction",
         "pyproject",
+        "quickjs",
         "rdfs",
         "regexes",
         "requireds",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,6 +3345,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel-quickjs"
+version = "0.0.0"
+dependencies = [
+ "common-dev",
+ "kernel",
+ "rquickjs",
+ "test-log",
+]
+
+[[package]]
 name = "kernel-r"
 version = "0.0.0"
 dependencies = [
@@ -3396,6 +3406,7 @@ dependencies = [
  "kernel-jinja",
  "kernel-node",
  "kernel-python",
+ "kernel-quickjs",
  "kernel-r",
  "kernel-rhai",
  "kernel-style",
@@ -5201,6 +5212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,6 +5467,54 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rquickjs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7f63201fa6f2ff8173e4758ea552549d687d8f63003361a8b5c50f7c446ded"
+dependencies = [
+ "rquickjs-core",
+ "rquickjs-macro",
+]
+
+[[package]]
+name = "rquickjs-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad00eeddc0f88af54ee202c8385fb214fe0423897c056a7df8369fb482e3695"
+dependencies = [
+ "async-lock 2.8.0",
+ "relative-path",
+ "rquickjs-sys",
+]
+
+[[package]]
+name = "rquickjs-macro"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27b39e889cc951e3e5f6b74012f943e642fa0fac51a8552948751f19a9b62f8"
+dependencies = [
+ "convert_case 0.6.0",
+ "fnv",
+ "ident_case",
+ "indexmap 2.2.6",
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "rquickjs-core",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "rquickjs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120dbbc3296de9b96de8890091635d46f3506cd38b4e8f21800c386c035d64fa"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/examples/kernels/code-chunk/hello-world-quickjs.json
+++ b/examples/kernels/code-chunk/hello-world-quickjs.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "CodeChunk",
+      "code": "console.log(\"Hello world!\")",
+      "programmingLanguage": "quickjs",
+      "outputs": [
+        "Hello world!"
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 846560560463224243
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 846560560463224243
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626675274,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 7,
+        "timeUnit": "Millisecond"
+      }
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626675274,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 7,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/code-chunk/hello-world-quickjs.md
+++ b/examples/kernels/code-chunk/hello-world-quickjs.md
@@ -1,0 +1,3 @@
+```quickjs exec
+console.log("Hello world!")
+```

--- a/examples/kernels/code-chunk/messages-quickjs.json
+++ b/examples/kernels/code-chunk/messages-quickjs.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "CodeChunk",
+      "code": "console.debug('a debug message')\nconsole.info('an info message')\nconsole.warn('a warning message')\nconsole.error('an error message')",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 12388780411211314469
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 12388780411211314469
+      },
+      "executionCount": 1,
+      "executionRequired": "ExecutionFailed",
+      "executionStatus": "Errors",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626190752,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 2,
+        "timeUnit": "Millisecond"
+      },
+      "executionMessages": [
+        {
+          "type": "ExecutionMessage",
+          "level": "Debug",
+          "message": "a debug message"
+        },
+        {
+          "type": "ExecutionMessage",
+          "level": "Info",
+          "message": "an info message"
+        },
+        {
+          "type": "ExecutionMessage",
+          "level": "Warning",
+          "message": "a warning message"
+        },
+        {
+          "type": "ExecutionMessage",
+          "level": "Error",
+          "message": "an error message"
+        }
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "code": "if // This is a syntax error",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 1187390132784655538
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 1187390132784655538
+      },
+      "executionCount": 1,
+      "executionRequired": "ExecutionFailed",
+      "executionStatus": "Exceptions",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626190752,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 0,
+        "timeUnit": "Millisecond"
+      },
+      "executionMessages": [
+        {
+          "type": "ExecutionMessage",
+          "level": "Exception",
+          "message": "expecting '('",
+          "stackTrace": "    at eval_script:1:28\n"
+        }
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "code": "foo // This is a runtime error",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 3445042760591135896
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 3445042760591135896
+      },
+      "executionCount": 1,
+      "executionRequired": "ExecutionFailed",
+      "executionStatus": "Exceptions",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626190752,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 0,
+        "timeUnit": "Millisecond"
+      },
+      "executionMessages": [
+        {
+          "type": "ExecutionMessage",
+          "level": "Exception",
+          "message": "'foo' is not defined",
+          "stackTrace": "    at <eval> (eval_script:1:1)\n"
+        }
+      ]
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626190752,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 2,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/code-chunk/messages-quickjs.md
+++ b/examples/kernels/code-chunk/messages-quickjs.md
@@ -1,0 +1,14 @@
+```quickjs exec
+console.debug('a debug message')
+console.info('an info message')
+console.warn('a warning message')
+console.error('an error message')
+```
+
+```quickjs exec
+if // This is a syntax error
+```
+
+```quickjs exec
+foo // This is a runtime error
+```

--- a/examples/kernels/code-chunk/output-types-quickjs.json
+++ b/examples/kernels/code-chunk/output-types-quickjs.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        {
+          "type": "Text",
+          "value": "The "
+        },
+        {
+          "type": "CodeInline",
+          "code": "quickjs"
+        },
+        {
+          "type": "Text",
+          "value": " kernel supports outputting most primitive JavaScript types:"
+        }
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "code": "console.log(true, 1, 2.34, \"string\", [1, 2, 3], { a: 1, b: 2 });",
+      "programmingLanguage": "quickjs",
+      "outputs": [
+        true,
+        1,
+        2.34,
+        "string",
+        [
+          1,
+          2,
+          3
+        ],
+        {
+          "a": 1,
+          "b": 2
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 12989105177539414841
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 12989105177539414841
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626191149,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 4,
+        "timeUnit": "Millisecond"
+      }
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626191149,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 4,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/code-chunk/output-types-quickjs.md
+++ b/examples/kernels/code-chunk/output-types-quickjs.md
@@ -1,0 +1,5 @@
+The `quickjs` kernel supports outputting most primitive JavaScript types:
+
+```quickjs exec
+console.log(true, 1, 2.34, "string", [1, 2, 3], { a: 1, b: 2 });
+```

--- a/examples/kernels/code-chunk/sleeps-quickjs.json
+++ b/examples/kernels/code-chunk/sleeps-quickjs.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "CodeChunk",
+      "code": "// A sleep function which can be called at top level\n// without using await (which is not supported in QuickJS)\nfunction sleep(seconds) {\n    const startTime = new Date().getTime();\n    let currentTime = null;\n    do {\n        currentTime = new Date().getTime();\n    } while (currentTime - startTime < seconds * 1000);\n}\n\nsleep(1)",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 860411442819514009
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 860411442819514009
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626308474,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 1005,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "CodeChunk",
+      "code": "sleep(2)",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17765237458248636103
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17765237458248636103
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626310474,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 2000,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "CodeChunk",
+      "code": "sleep(4)",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 13227037415934127697
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 13227037415934127697
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626314474,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 4000,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "CodeChunk",
+      "code": "sleep(8)",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 11962107935453406448
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 11962107935453406448
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626322474,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 8000,
+        "timeUnit": "Millisecond"
+      }
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626322474,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 15006,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/code-chunk/sleeps-quickjs.md
+++ b/examples/kernels/code-chunk/sleeps-quickjs.md
@@ -1,0 +1,25 @@
+```quickjs exec
+// A sleep function which can be called at top level
+// without using await (which is not supported in QuickJS)
+function sleep(seconds) {
+    const startTime = new Date().getTime();
+    let currentTime = null;
+    do {
+        currentTime = new Date().getTime();
+    } while (currentTime - startTime < seconds * 1000);
+}
+
+sleep(1)
+```
+
+```quickjs exec
+sleep(2)
+```
+
+```quickjs exec
+sleep(4)
+```
+
+```quickjs exec
+sleep(8)
+```

--- a/examples/kernels/code-expression/standalone-quickjs.json
+++ b/examples/kernels/code-expression/standalone-quickjs.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        {
+          "type": "CodeExpression",
+          "code": "1 + 2 + 3",
+          "programmingLanguage": "quickjs",
+          "output": 6,
+          "compilationDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 18405601415054431570
+          },
+          "executionDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 18405601415054431570
+          },
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626619339,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 6,
+            "timeUnit": "Millisecond"
+          }
+        }
+      ]
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626619339,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 6,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/code-expression/standalone-quickjs.md
+++ b/examples/kernels/code-expression/standalone-quickjs.md
@@ -1,0 +1,1 @@
+`1 + 2 + 3`{quickjs exec}

--- a/examples/kernels/for-block/assigned-quickjs.json
+++ b/examples/kernels/for-block/assigned-quickjs.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "CodeChunk",
+      "code": "const items = [1, 2, 3]",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17894060278345452492
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17894060278345452492
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626619740,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 3,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "ForBlock",
+      "code": "items",
+      "variable": "item",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "Text",
+              "value": "This is item "
+            },
+            {
+              "type": "CodeExpression",
+              "code": "item"
+            }
+          ]
+        }
+      ],
+      "iterations": [
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "This is item "
+                },
+                {
+                  "type": "CodeExpression",
+                  "code": "item",
+                  "output": 1,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626619748,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "This is item "
+                },
+                {
+                  "type": "CodeExpression",
+                  "code": "item",
+                  "output": 2,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626619748,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "This is item "
+                },
+                {
+                  "type": "CodeExpression",
+                  "code": "item",
+                  "output": 3,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626619749,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 1,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 3479311611422325985
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 3479311611422325985
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626619749,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 9,
+        "timeUnit": "Millisecond"
+      }
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626619749,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 12,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/for-block/assigned-quickjs.md
+++ b/examples/kernels/for-block/assigned-quickjs.md
@@ -1,0 +1,9 @@
+```quickjs exec
+const items = [1, 2, 3]
+```
+
+::: for item in items
+
+This is item {{item}}
+
+:::

--- a/examples/kernels/for-block/otherwise-quickjs.json
+++ b/examples/kernels/for-block/otherwise-quickjs.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "ForBlock",
+      "code": "[]",
+      "programmingLanguage": "quickjs",
+      "variable": "item",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "Text",
+              "value": "Content for each item."
+            }
+          ]
+        }
+      ],
+      "otherwise": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "Text",
+              "value": "There were no items and the date is "
+            },
+            {
+              "type": "CodeExpression",
+              "code": " new Date().toISOString() ",
+              "output": "2024-04-09T01:37:00.147Z",
+              "compilationDigest": {
+                "type": "CompilationDigest",
+                "stateDigest": 10858042282365217967
+              },
+              "executionDigest": {
+                "type": "CompilationDigest",
+                "stateDigest": 10858042282365217967
+              },
+              "executionCount": 1,
+              "executionRequired": "No",
+              "executionStatus": "Succeeded",
+              "executionEnded": {
+                "type": "Timestamp",
+                "value": 1712626620147,
+                "timeUnit": "Millisecond"
+              },
+              "executionDuration": {
+                "type": "Duration",
+                "value": 0,
+                "timeUnit": "Millisecond"
+              }
+            },
+            {
+              "type": "Text",
+              "value": "."
+            }
+          ]
+        }
+      ],
+      "iterations": [],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17499428202029287323
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17499428202029287323
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620147,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 3,
+        "timeUnit": "Millisecond"
+      }
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626620147,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 3,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/for-block/otherwise-quickjs.md
+++ b/examples/kernels/for-block/otherwise-quickjs.md
@@ -1,4 +1,4 @@
-::: for item in [] {js}
+::: for item in [] {quickjs}
 
 Content for each item.
 

--- a/examples/kernels/for-block/standalone-quickjs.json
+++ b/examples/kernels/for-block/standalone-quickjs.json
@@ -1,0 +1,676 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "ForBlock",
+      "code": "null",
+      "programmingLanguage": "quickjs",
+      "variable": "item",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "Text",
+              "value": "No iterations"
+            }
+          ]
+        }
+      ],
+      "iterations": [],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 16939695936675214352
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 16939695936675214352
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620542,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 6,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "ForBlock",
+      "code": "true",
+      "variable": "item",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "CodeExpression",
+              "code": " item "
+            }
+          ]
+        }
+      ],
+      "iterations": [
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " item ",
+                  "output": true,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620544,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 16914997631442930553
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 16914997631442930553
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620544,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 2,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "ForBlock",
+      "code": "3",
+      "variable": "int",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "CodeExpression",
+              "code": " int "
+            }
+          ]
+        }
+      ],
+      "iterations": [
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "output": 0,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620546,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "output": 1,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620547,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "output": 2,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620547,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 10489139260846039361
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 10489139260846039361
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620547,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 3,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "ForBlock",
+      "code": "3.0",
+      "variable": "int",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "CodeExpression",
+              "code": " int "
+            }
+          ]
+        }
+      ],
+      "iterations": [
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "output": 0,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620548,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "output": 1,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620548,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "output": 2,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620548,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 16106270102739274808
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 16106270102739274808
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620548,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 1,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "ForBlock",
+      "code": "\"123\"",
+      "variable": "char",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "CodeExpression",
+              "code": " char "
+            }
+          ]
+        }
+      ],
+      "iterations": [
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " char ",
+                  "output": "1",
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620549,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " char ",
+                  "output": "2",
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620549,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " char ",
+                  "output": "3",
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620549,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 1382367851828009517
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 1382367851828009517
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620549,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 1,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "ForBlock",
+      "code": "[1, 2, 3]",
+      "variable": "int",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "CodeExpression",
+              "code": " int "
+            }
+          ]
+        }
+      ],
+      "iterations": [
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "output": 1,
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620551,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 0,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int ",
+                  "executionStatus": "Running"
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": " int "
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 8682891849222145763
+      },
+      "executionStatus": "Running"
+    },
+    {
+      "type": "ForBlock",
+      "code": "{'a': 1, 'b': 2, 'c': 3}",
+      "variable": "pair",
+      "content": [
+        {
+          "type": "Paragraph",
+          "content": [
+            {
+              "type": "Text",
+              "value": "{{ `"
+            },
+            {
+              "type": "MathInline",
+              "code": "{pair[0]}: "
+            },
+            {
+              "type": "Text",
+              "value": "{pair[1]}` }}"
+            }
+          ]
+        }
+      ],
+      "iterations": [
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "{{ `"
+                },
+                {
+                  "type": "MathInline",
+                  "code": "{pair[0]}: "
+                },
+                {
+                  "type": "Text",
+                  "value": "{pair[1]}` }}"
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "{{ `"
+                },
+                {
+                  "type": "MathInline",
+                  "code": "{pair[0]}: "
+                },
+                {
+                  "type": "Text",
+                  "value": "{pair[1]}` }}"
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        },
+        {
+          "type": "Section",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "{{ `"
+                },
+                {
+                  "type": "MathInline",
+                  "code": "{pair[0]}: "
+                },
+                {
+                  "type": "Text",
+                  "value": "{pair[1]}` }}"
+                }
+              ]
+            }
+          ],
+          "sectionType": "Iteration"
+        }
+      ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 2518230968571619558
+      },
+      "executionStatus": "Pending"
+    }
+  ],
+  "executionStatus": "Running"
+}

--- a/examples/kernels/for-block/standalone-quickjs.md
+++ b/examples/kernels/for-block/standalone-quickjs.md
@@ -1,0 +1,41 @@
+::: for item in null {quickjs}
+
+No iterations
+
+:::
+
+::: for item in true
+
+{{ item }}
+
+:::
+
+::: for int in 3
+
+{{ int }}
+
+:::
+
+::: for int in 3.0
+
+{{ int }}
+
+:::
+
+::: for char in "123"
+
+{{ char }}
+
+:::
+
+::: for int in [1, 2, 3]
+
+{{ int }}
+
+:::
+
+::: for pair in `{'a': 1, 'b': 2, 'c': 3}`
+
+{{ `${pair[0]}: ${pair[1]}` }}
+
+:::

--- a/examples/kernels/if-block/assigned-quickjs.json
+++ b/examples/kernels/if-block/assigned-quickjs.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "CodeChunk",
+      "code": "const x = 3",
+      "programmingLanguage": "quickjs",
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17498981286972441881
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 17498981286972441881
+      },
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620979,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 7,
+        "timeUnit": "Millisecond"
+      }
+    },
+    {
+      "type": "IfBlock",
+      "clauses": [
+        {
+          "type": "IfBlockClause",
+          "code": "x === 1",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "x is "
+                },
+                {
+                  "type": "CodeExpression",
+                  "code": " x ",
+                  "compilationDigest": {
+                    "type": "CompilationDigest",
+                    "stateDigest": 11004962792487161716
+                  }
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626620980,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 1,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "x === 2",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "x is "
+                },
+                {
+                  "type": "CodeExpression",
+                  "code": " x ",
+                  "compilationDigest": {
+                    "type": "CompilationDigest",
+                    "stateDigest": 11004962792487161716
+                  }
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626620980,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "",
+          "isActive": true,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "x is "
+                },
+                {
+                  "type": "CodeExpression",
+                  "code": " x ",
+                  "output": 3,
+                  "compilationDigest": {
+                    "type": "CompilationDigest",
+                    "stateDigest": 11004962792487161716
+                  },
+                  "executionDigest": {
+                    "type": "CompilationDigest",
+                    "stateDigest": 11004962792487161716
+                  },
+                  "executionCount": 1,
+                  "executionRequired": "No",
+                  "executionStatus": "Succeeded",
+                  "executionEnded": {
+                    "type": "Timestamp",
+                    "value": 1712626620981,
+                    "timeUnit": "Millisecond"
+                  },
+                  "executionDuration": {
+                    "type": "Duration",
+                    "value": 1,
+                    "timeUnit": "Millisecond"
+                  }
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626620981,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 1,
+            "timeUnit": "Millisecond"
+          }
+        }
+      ],
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626620981,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 2,
+        "timeUnit": "Millisecond"
+      }
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626620981,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 9,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/if-block/assigned-quickjs.md
+++ b/examples/kernels/if-block/assigned-quickjs.md
@@ -1,0 +1,17 @@
+```quickjs exec
+const x = 3
+```
+
+::: if x === 1
+
+x is {{ x }}
+
+::: elif x === 2
+
+x is {{ x }}
+
+::: else
+
+x is {{ x }}
+
+:::

--- a/examples/kernels/if-block/standalone-quickjs.json
+++ b/examples/kernels/if-block/standalone-quickjs.json
@@ -1,0 +1,308 @@
+{
+  "$schema": "https://stencila.org/Article.schema.json",
+  "@context": "https://stencila.org/context.jsonld",
+  "type": "Article",
+  "content": [
+    {
+      "type": "IfBlock",
+      "clauses": [
+        {
+          "type": "IfBlockClause",
+          "code": "null",
+          "programmingLanguage": "quickjs",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeInline",
+                  "code": "null"
+                },
+                {
+                  "type": "Text",
+                  "value": " is falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621385,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 6,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "false",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeInline",
+                  "code": "false"
+                },
+                {
+                  "type": "Text",
+                  "value": " is falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621386,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "-1",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "Non-positive integers are falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621386,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "0",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "Non-positive unsigned integers are falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621386,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "-1.0",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "Non-positive numbers are falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621386,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "\"\"",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "Empty strings are falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621386,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "[]",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "Empty arrays are falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621386,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "{}",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "Empty objects are falsy"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621386,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 0,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": "",
+          "isActive": true,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": "Evaluated in QuickJS"
+                }
+              ]
+            }
+          ],
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1712626621387,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 1,
+            "timeUnit": "Millisecond"
+          }
+        }
+      ],
+      "executionCount": 1,
+      "executionRequired": "No",
+      "executionStatus": "Succeeded",
+      "executionEnded": {
+        "type": "Timestamp",
+        "value": 1712626621387,
+        "timeUnit": "Millisecond"
+      },
+      "executionDuration": {
+        "type": "Duration",
+        "value": 8,
+        "timeUnit": "Millisecond"
+      }
+    }
+  ],
+  "executionCount": 1,
+  "executionRequired": "No",
+  "executionStatus": "Succeeded",
+  "executionEnded": {
+    "type": "Timestamp",
+    "value": 1712626621387,
+    "timeUnit": "Millisecond"
+  },
+  "executionDuration": {
+    "type": "Duration",
+    "value": 8,
+    "timeUnit": "Millisecond"
+  }
+}

--- a/examples/kernels/if-block/standalone-quickjs.md
+++ b/examples/kernels/if-block/standalone-quickjs.md
@@ -1,0 +1,37 @@
+::: if null {quickjs}
+
+`null` is falsy
+
+::: elif false
+
+`false` is falsy
+
+::: elif -1
+
+Non-positive integers are falsy
+
+::: elif 0
+
+Non-positive unsigned integers are falsy
+
+::: elif -1.0
+
+Non-positive numbers are falsy
+
+::: elif ""
+
+Empty strings are falsy
+
+::: elif []
+
+Empty arrays are falsy
+
+::: elif `{}`
+
+Empty objects are falsy
+
+::: else
+
+Evaluated in QuickJS
+
+:::

--- a/rust/codec-mapping/src/lib.rs
+++ b/rust/codec-mapping/src/lib.rs
@@ -113,7 +113,8 @@ impl Mapping {
                     range: Range { start, .. },
                     node_type,
                     node_id,
-                    property,..
+                    property,
+                    ..
                 } = self.entries.remove(first_index);
 
                 // Add a new entry after the second with appropriate offsets
@@ -140,8 +141,8 @@ impl Display for Mapping {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(
             f,
-            "{:>6} {:>6} {:>10}   {:<24} {}",
-            "start", "end", "offsets", "node_id", "node_type+property"
+            "{:>6} {:>6} {:>10}   {:<24} node_type+property",
+            "start", "end", "offsets", "node_id"
         )?;
 
         for MappingEntry {

--- a/rust/kernel-quickjs/Cargo.toml
+++ b/rust/kernel-quickjs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kernel-quickjs"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+kernel = { path = "../kernel" }
+rquickjs = { version = "0.5.1", features = ["classes", "futures", "macro", "parallel"] }
+
+[dev-dependencies]
+common-dev = { path = "../common-dev" }
+test-log = { version = "0.2.15", default-features = false, features = ["trace"] }

--- a/rust/kernel-quickjs/src/lib.rs
+++ b/rust/kernel-quickjs/src/lib.rs
@@ -1,0 +1,1083 @@
+#![allow(non_snake_case)]
+
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{
+        atomic::{AtomicU64, AtomicU8, Ordering},
+        Arc,
+    },
+};
+
+use rquickjs::{
+    class::Trace, function::Rest, Array as JsArray, AsyncContext, AsyncRuntime, BigInt, Ctx, Error,
+    Object as JsObject, String as JsString, Value,
+};
+
+use kernel::{
+    common::{
+        async_trait::async_trait,
+        eyre::{bail, eyre, Result},
+        indexmap::IndexMap,
+        serde_json,
+        tokio::{
+            self,
+            sync::{mpsc, watch},
+        },
+        tracing,
+    },
+    format::Format,
+    schema::{
+        Array, ArrayHint, ExecutionMessage, Hint, MessageLevel, Node, NodeType, Null, Object,
+        ObjectHint, Primitive, SoftwareApplication, SoftwareApplicationOptions, SoftwareSourceCode,
+        StringHint, Variable,
+    },
+    Kernel, KernelForks, KernelInstance, KernelSignal, KernelStatus, KernelTerminate,
+};
+
+/// A kernel for executing JavaScript using the QuickJS engine.
+#[derive(Default)]
+pub struct QuickJsKernel {
+    /// A counter of instances of this kernel
+    instances: AtomicU64,
+}
+
+impl Kernel for QuickJsKernel {
+    fn name(&self) -> String {
+        "quickjs".to_string()
+    }
+
+    fn supports_languages(&self) -> Vec<Format> {
+        vec![Format::JavaScript]
+    }
+
+    fn supports_forks(&self) -> KernelForks {
+        KernelForks::Yes
+    }
+
+    fn supports_terminate(&self) -> KernelTerminate {
+        KernelTerminate::Yes
+    }
+
+    fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
+        // Assign an id for the instance using the index, if necessary, to ensure it is unique
+        let index = self.instances.fetch_add(1, Ordering::SeqCst);
+        let id = if index == 0 {
+            self.name()
+        } else {
+            format!("{}-{index}", self.name())
+        };
+
+        Ok(Box::new(QuickJsKernelInstance::new(id)))
+    }
+}
+
+pub struct QuickJsKernelInstance {
+    /// The id of this instance
+    id: String,
+
+    /// The QuickJs runtime context for this instance
+    context: Option<AsyncContext>,
+
+    /// The QuickJs runtime for this instance
+    runtime: Option<AsyncRuntime>,
+
+    /// The status of this instance
+    status: Arc<AtomicU8>,
+
+    /// A channel sender for the status of this instance
+    status_sender: watch::Sender<KernelStatus>,
+
+    /// A channel sender for sending signals to the instance
+    signal_sender: mpsc::Sender<KernelSignal>,
+
+    /// A counter of forks of this instance
+    forks: AtomicU64,
+}
+
+#[async_trait]
+impl KernelInstance for QuickJsKernelInstance {
+    fn name(&self) -> String {
+        self.id.clone()
+    }
+
+    async fn status(&self) -> Result<KernelStatus> {
+        Ok(self.get_status())
+    }
+
+    fn status_watcher(&self) -> Result<watch::Receiver<KernelStatus>> {
+        Ok(self.status_sender.subscribe())
+    }
+
+    fn signal_sender(&self) -> Result<mpsc::Sender<KernelSignal>> {
+        Ok(self.signal_sender.clone())
+    }
+
+    async fn start(&mut self, _directory: &Path) -> Result<()> {
+        tracing::trace!("Starting QuickJS kernel instance");
+
+        let runtime = AsyncRuntime::new()?;
+        let context = AsyncContext::full(&runtime).await?;
+
+        self.runtime = Some(runtime);
+        self.context = Some(context);
+
+        self.set_status(KernelStatus::Ready)
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        tracing::trace!("Stopping QuickJS kernel instance");
+
+        self.set_status(KernelStatus::Stopped)
+    }
+
+    async fn execute(&mut self, code: &str) -> Result<(Vec<Node>, Vec<ExecutionMessage>)> {
+        tracing::trace!("Executing QuickJS code");
+
+        let status = self.get_status();
+        if status != KernelStatus::Ready {
+            bail!(
+                "Kernel `{}` is not ready; status is `{status}`",
+                self.name()
+            )
+        }
+
+        self.run_code(code).await
+    }
+
+    async fn evaluate(&mut self, code: &str) -> Result<(Node, Vec<ExecutionMessage>)> {
+        tracing::trace!("Evaluating QuickJS code");
+
+        let status = self.get_status();
+        if status != KernelStatus::Ready {
+            bail!(
+                "Kernel `{}` is not ready; status is `{status}`",
+                self.name()
+            )
+        }
+
+        let (mut outputs, messages) = self.run_code(code).await?;
+        let output = if outputs.is_empty() {
+            Node::Null(Null)
+        } else {
+            outputs.swap_remove(0)
+        };
+
+        Ok((output, messages))
+    }
+
+    async fn info(&mut self) -> Result<SoftwareApplication> {
+        tracing::trace!("Getting QuickJS runtime info");
+
+        Ok(SoftwareApplication {
+            name: "QuickJS".to_string(),
+            options: Box::new(SoftwareApplicationOptions {
+                software_version: Some("1".to_string()),
+                operating_system: Some(std::env::consts::OS.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+    }
+
+    async fn packages(&mut self) -> Result<Vec<SoftwareSourceCode>> {
+        tracing::trace!("Getting QuickJS packages");
+
+        Ok(vec![])
+    }
+
+    async fn list(&mut self) -> Result<Vec<Variable>> {
+        tracing::trace!("Listing QuickJS variables");
+
+        self.set_status(KernelStatus::Busy)?;
+
+        let variables = self
+            .get_context()?
+            .with(|ctx| {
+                ctx.globals()
+                    .into_iter()
+                    .flatten()
+                    .flat_map(|(name, value)| {
+                        let Ok(name) = name.to_string() else {
+                            return None;
+                        };
+
+                        let programming_language = Some("JavaScript".to_string());
+                        let native_type = Some(
+                            match value.type_name() {
+                                "bool" => "boolean",
+                                "big_int" => "bigint",
+                                "float" => "number",
+                                name => name,
+                            }
+                            .to_string(),
+                        );
+                        let (node_type, hint) = value_to_type_hint(value);
+
+                        Some(Variable {
+                            name,
+                            programming_language,
+                            native_type,
+                            node_type,
+                            hint,
+                            ..Default::default()
+                        })
+                    })
+                    .collect()
+            })
+            .await;
+
+        self.set_status(KernelStatus::Ready)?;
+
+        Ok(variables)
+    }
+
+    async fn get(&mut self, name: &str) -> Result<Option<Node>> {
+        tracing::trace!("Getting QuickJS variable");
+
+        self.set_status(KernelStatus::Busy)?;
+
+        let node = self
+            .get_context()?
+            .with(|ctx| match ctx.globals().get::<_, Value>(name) {
+                Ok(value) => {
+                    if value.is_undefined() {
+                        Ok(None)
+                    } else {
+                        value_to_node(ctx, value).map(Some)
+                    }
+                }
+                Err(..) => Ok(None),
+            })
+            .await?;
+
+        self.set_status(KernelStatus::Ready)?;
+
+        Ok(node)
+    }
+
+    async fn set(&mut self, name: &str, node: &Node) -> Result<()> {
+        tracing::trace!("Setting QuickJS variable");
+
+        self.set_status(KernelStatus::Busy)?;
+
+        self.get_context()?
+            .with(|ctx| -> Result<(), Error> {
+                let globals = ctx.globals();
+                let value = node_to_value(ctx, node);
+                globals.set(name, value)
+            })
+            .await?;
+
+        self.set_status(KernelStatus::Ready)
+    }
+
+    async fn remove(&mut self, name: &str) -> Result<()> {
+        tracing::trace!("Removing QuickJS variable");
+
+        self.set_status(KernelStatus::Busy)?;
+
+        self.get_context()?
+            .with(|ctx| ctx.globals().remove(name))
+            .await?;
+
+        self.set_status(KernelStatus::Ready)
+    }
+
+    async fn fork(&mut self) -> Result<Box<dyn KernelInstance>> {
+        tracing::trace!("Forking QuickJS kernel instance");
+
+        // Create fork id
+        let id = format!(
+            "{}-fork-{}",
+            self.id,
+            self.forks.fetch_add(1, Ordering::SeqCst)
+        );
+
+        // Create instance
+        let mut fork = QuickJsKernelInstance::new(id);
+
+        // Clone global variables into fork
+        // Currently works by converting variables to/from Stencila nodes.
+        // A more efficient way to do this may be possible.
+        let vars = self
+            .get_context()?
+            .with(|ctx| -> HashMap<String, Node> {
+                let globals = ctx.globals();
+
+                let mut vars = HashMap::new();
+                for name in globals.keys::<String>().flatten() {
+                    let Ok(value): Result<Value, Error> = globals.get(&name) else {
+                        continue;
+                    };
+
+                    if value.is_constructor() || value.is_function() {
+                        continue;
+                    }
+
+                    if let Ok(node) = value_to_node(ctx.clone(), value) {
+                        vars.insert(name, node);
+                    }
+                }
+
+                vars
+            })
+            .await;
+        let runtime = AsyncRuntime::new()?;
+        let context = AsyncContext::full(&runtime).await?;
+        context
+            .with(|ctx| {
+                let globals = ctx.globals();
+                for (name, node) in vars {
+                    globals.set(name, node_to_value(ctx.clone(), &node)).ok();
+                }
+            })
+            .await;
+
+        fork.runtime = Some(runtime);
+        fork.context = Some(context);
+
+        Ok(Box::new(fork))
+    }
+}
+
+/// Convert a QuickJS value to a Stencila Node
+///
+/// Checks if the value is an object with a "type" property and if so attempts to
+/// use JSON and serde to do the conversion. Otherwise, converts as a primitive.
+fn value_to_node<'js>(ctx: Ctx<'js>, value: Value<'js>) -> Result<Node, Error> {
+    if let Some(object) = value.as_object() {
+        if object.get::<_, String>("type").is_ok() {
+            if let Some(node) = ctx
+                .json_stringify(value.clone())
+                .ok()
+                .flatten()
+                .and_then(|json| json.to_string().ok())
+                .and_then(|json| serde_json::from_str(&json).ok())
+            {
+                return Ok(node);
+            };
+        }
+    }
+
+    Ok(value_to_primitive(value)?.into())
+}
+
+/// Convert a QuickJS value to a Stencila Primitive
+fn value_to_primitive(value: Value) -> Result<Primitive, Error> {
+    if value.is_undefined() || value.is_null() {
+        Ok(Primitive::Null(Null))
+    } else if let Some(value) = value.as_bool() {
+        Ok(Primitive::Boolean(value))
+    } else if let Some(value) = value.as_int() {
+        Ok(Primitive::Integer(value as i64))
+    } else if let Some(value) = value.as_big_int() {
+        value
+            .clone()
+            .to_i64()
+            .map(Primitive::Integer)
+            .map_err(|_| Error::new_from_js(value.type_name(), "Integer"))
+    } else if let Some(value) = value.as_float().or(value.as_number()) {
+        Ok(Primitive::Number(value))
+    } else if let Some(value) = value.as_string() {
+        value
+            .to_string()
+            .map(Primitive::String)
+            .map_err(|_| Error::new_from_js(value.type_name(), "String"))
+    } else if let Some(value) = value.as_array() {
+        let mut array = Vec::new();
+        for item in value.iter().flatten() {
+            let item = value_to_primitive(item)?;
+            array.push(item);
+        }
+        Ok(Primitive::Array(Array(array)))
+    } else if let Some(value) = value.as_object() {
+        let mut object = IndexMap::new();
+        for (name, value) in value.clone().into_iter().flatten() {
+            let name = name.to_string().unwrap();
+            let value = value_to_primitive(value)?;
+            object.insert(name, value);
+        }
+        Ok(Primitive::Object(Object(object)))
+    } else {
+        Err(Error::new_from_js_message(
+            value.type_name(),
+            "Primitive",
+            &"Unhandled JavaScript to Stencila Primitive conversion".to_string(),
+        ))
+    }
+}
+
+/// Convert a QuickJS value to a Stencila [`NodeType`] and [`Hint`]
+fn value_to_type_hint(value: Value) -> (Option<String>, Option<Hint>) {
+    let (node_type, hint) = if value.is_undefined() || value.is_null() {
+        (NodeType::Null, None)
+    } else if let Some(value) = value.as_bool() {
+        (NodeType::Boolean, Some(Hint::Boolean(value)))
+    } else if let Some(value) = value.as_int() {
+        (NodeType::Integer, Some(Hint::Integer(value as i64)))
+    } else if let Some(value) = value.as_big_int() {
+        (
+            NodeType::Integer,
+            value.clone().to_i64().ok().map(Hint::Integer),
+        )
+    } else if let Some(value) = value.as_float().or(value.as_number()) {
+        (NodeType::Number, Some(Hint::Number(value)))
+    } else if let Some(value) = value.as_string() {
+        (
+            NodeType::String,
+            value
+                .to_string()
+                .ok()
+                .map(|value| Hint::StringHint(StringHint::new(value.chars().count() as i64))),
+        )
+    } else if let Some(value) = value.as_array() {
+        (
+            NodeType::Array,
+            Some(Hint::ArrayHint(ArrayHint::new(value.len() as i64))),
+        )
+    } else if let Some(object) = value.as_object() {
+        if let Ok(Some(node_type)) = object.get("type") {
+            return (Some(node_type), None);
+        }
+
+        let mut keys = Vec::new();
+        let mut hints = Vec::new();
+        for key in object.keys::<String>().flatten() {
+            if let Some(hint) = object
+                .get(&key)
+                .ok()
+                .and_then(|value| value_to_type_hint(value).1)
+            {
+                keys.push(key);
+                hints.push(hint);
+            }
+        }
+
+        (
+            NodeType::Object,
+            Some(Hint::ObjectHint(ObjectHint::new(
+                object.len() as i64,
+                keys,
+                hints,
+            ))),
+        )
+    } else {
+        return (None, None);
+    };
+
+    (Some(node_type.to_string()), hint)
+}
+
+/// Convert a Stencila Node to a QuickJS value
+fn node_to_value<'js>(ctx: Ctx<'js>, node: &Node) -> Result<Value<'js>, Error> {
+    Ok(match node {
+        Node::Null(..) => Value::new_null(ctx),
+        Node::Boolean(value) => Value::new_bool(ctx, *value),
+        Node::Integer(value) => Value::from_big_int(BigInt::from_i64(ctx, *value)?),
+        Node::UnsignedInteger(value) => Value::from_big_int(BigInt::from_u64(ctx, *value)?),
+        Node::Number(value) => Value::new_number(ctx, *value),
+        Node::String(value) => Value::from_string(JsString::from_str(ctx, value)?),
+        Node::Array(value) => array_to_js_array(ctx, value)?,
+        Node::Object(value) => object_to_js_object(ctx, value)?,
+        _ => {
+            let json = serde_json::to_string(node).map_err(|error| Error::IntoJs {
+                from: "Node",
+                to: "Value",
+                message: Some(error.to_string()),
+            })?;
+            ctx.json_parse(json)?
+        }
+    })
+}
+
+/// Convert a Stencila Primitive to a QuickJS value
+fn primitive_to_value<'js>(ctx: Ctx<'js>, primitive: &Primitive) -> Result<Value<'js>, Error> {
+    Ok(match primitive {
+        Primitive::Null(..) => Value::new_null(ctx),
+        Primitive::Boolean(value) => Value::new_bool(ctx, *value),
+        Primitive::Integer(value) => Value::from_big_int(BigInt::from_i64(ctx, *value)?),
+        Primitive::UnsignedInteger(value) => Value::from_big_int(BigInt::from_u64(ctx, *value)?),
+        Primitive::Number(value) => Value::new_number(ctx, *value),
+        Primitive::String(value) => Value::from_string(JsString::from_str(ctx, value)?),
+        Primitive::Array(value) => array_to_js_array(ctx, value)?,
+        Primitive::Object(value) => object_to_js_object(ctx, value)?,
+    })
+}
+
+/// Convert a Stencila Array to a QuickJS Array
+fn array_to_js_array<'js>(ctx: Ctx<'js>, array: &Array) -> Result<Value<'js>, Error> {
+    let js_array = JsArray::new(ctx.clone())?;
+    for (index, item) in array.iter().enumerate() {
+        js_array.set(index, primitive_to_value(ctx.clone(), item)?)?;
+    }
+    Ok(Value::from_array(js_array))
+}
+
+/// Convert a Stencila Object to a QuickJS Object
+fn object_to_js_object<'js>(ctx: Ctx<'js>, object: &Object) -> Result<Value<'js>, Error> {
+    let js_object = JsObject::new(ctx.clone())?;
+    for (name, item) in object.iter() {
+        js_object.set(name, primitive_to_value(ctx.clone(), item)?)?;
+    }
+    Ok(Value::from_object(js_object))
+}
+
+impl QuickJsKernelInstance {
+    /// Create a new kernel instance
+    fn new(id: String) -> Self {
+        let status = Arc::new(AtomicU8::new(KernelStatus::Pending.into()));
+        let (status_sender, ..) = watch::channel(KernelStatus::Pending);
+
+        let (signal_sender, mut signal_receiver) = mpsc::channel(1);
+
+        // Start a task to handle signals
+        let status_clone = status.clone();
+        tokio::spawn(async move {
+            while let Some(kernel_signal) = signal_receiver.recv().await {
+                if matches!(kernel_signal, KernelSignal::Terminate | KernelSignal::Kill) {
+                    status_clone.store(KernelStatus::Stopped.into(), Ordering::SeqCst);
+                }
+            }
+        });
+
+        Self {
+            id,
+            context: None,
+            runtime: None,
+            status,
+            status_sender,
+            signal_sender,
+            forks: Default::default(),
+        }
+    }
+
+    /// Get the status of the kernel
+    fn get_status(&self) -> KernelStatus {
+        self.status.load(Ordering::SeqCst).into()
+    }
+
+    /// Set the status of the kernel instance and notify watchers if there was a change
+    ///
+    /// Avoids overwriting of `Stopping` or `Stopped` status (which can happen when a
+    /// `Terminate` signal is received while a task is executing)
+    fn set_status(&mut self, status: KernelStatus) -> Result<()> {
+        let previous: KernelStatus = self.status.swap(status.into(), Ordering::SeqCst).into();
+        if previous >= KernelStatus::Stopping {
+            self.status.store(previous.into(), Ordering::SeqCst);
+            return Ok(());
+        }
+
+        self.status_sender.send_if_modified(|previous| {
+            if status != *previous {
+                tracing::trace!(
+                    "Status of `{}` kernel changed from `{previous}` to `{status}`",
+                    self.name()
+                );
+                *previous = status;
+                true
+            } else {
+                false
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Get the QuickJS runtime context for the kernel instance
+    fn get_context(&mut self) -> Result<&mut AsyncContext> {
+        self.context
+            .as_mut()
+            .ok_or_else(|| eyre!("Kernel not started yet"))
+    }
+
+    /// Run code in the kerne;
+    async fn run_code(&mut self, code: &str) -> Result<(Vec<Node>, Vec<ExecutionMessage>)> {
+        let trimmed = code.trim();
+        if trimmed.is_empty() {
+            return Ok((vec![], vec![]));
+        }
+
+        self.set_status(KernelStatus::Busy)?;
+
+        // Wrap code if begins and end with curly braces to avoid it being treated as a block
+        let code = if code.starts_with('{') && code.ends_with('}') {
+            ["(", code, ")"].concat()
+        } else {
+            code.to_string()
+        };
+
+        // Evaluate the code and convert any exception into a `ExecutionMessage`
+        let (outputs, messages) = self
+            .get_context()?
+            .with(|ctx| {
+                let console = Console::new();
+                ctx.globals().set("console", console).ok();
+
+                // Evaluate the code
+                let result = ctx.eval::<Value, _>(code);
+
+                let mut outputs: Vec<Node> = Vec::new();
+                let mut messages: Vec<ExecutionMessage> = Vec::new();
+
+                // Convert the outputs and messages captured using the `console` to
+                // nodes and `ExecutionMessage`s. Doing this here ensure that any `console` calls
+                // before any exceptions are in the right order
+                let console: Console = ctx.globals().get("console").expect("was set above");
+                for value in console.outputs {
+                    match value_to_node(ctx.clone(), value) {
+                        Ok(node) => outputs.push(node),
+                        Err(error) => messages.push(ExecutionMessage::new(
+                            MessageLevel::Error,
+                            error.to_string(),
+                        )),
+                    }
+                }
+                for (level, message) in console.messages {
+                    let level = match level {
+                        0 => MessageLevel::Trace,
+                        1 => MessageLevel::Debug,
+                        2 => MessageLevel::Info,
+                        3 => MessageLevel::Warning,
+                        _ => MessageLevel::Error,
+                    };
+                    messages.push(ExecutionMessage::new(level, message));
+                }
+
+                // Evaluate the code and handle any outputs or exceptions
+                match result {
+                    Ok(value) => {
+                        // Convert the
+                        if !value.is_undefined() {
+                            match value_to_node(ctx, value) {
+                                Ok(node) => outputs.push(node),
+                                Err(error) => messages.push(ExecutionMessage::new(
+                                    MessageLevel::Error,
+                                    error.to_string(),
+                                )),
+                            }
+                        }
+                    }
+                    Err(..) => {
+                        let exc = ctx.catch();
+                        let message = if let Some(exc) = exc.as_exception() {
+                            ExecutionMessage {
+                                level: MessageLevel::Exception,
+                                message: exc
+                                    .message()
+                                    .unwrap_or_else(|| "Unknown error".to_string()),
+                                stack_trace: exc.stack(),
+                                ..Default::default()
+                            }
+                        } else {
+                            ExecutionMessage {
+                                level: MessageLevel::Exception,
+                                message: "Unknown error".to_string(),
+                                ..Default::default()
+                            }
+                        };
+                        messages.push(message)
+                    }
+                }
+
+                (outputs, messages)
+            })
+            .await;
+
+        self.set_status(KernelStatus::Ready)?;
+
+        Ok((outputs, messages))
+    }
+}
+
+/// A struct for a Javascript console
+#[derive(Clone, Trace)]
+#[rquickjs::class]
+struct Console<'js> {
+    /// The outputs captured from `console.log` calls
+    outputs: Vec<Value<'js>>,
+
+    /// The level (0=Trace,..4=Error) and message for messages
+    messages: Vec<(u8, String)>,
+}
+
+#[rquickjs::methods]
+impl<'js> Console<'js> {
+    fn new() -> Console<'js> {
+        Console {
+            outputs: Vec::new(),
+            messages: Vec::new(),
+        }
+    }
+
+    fn log(&mut self, mut values: Rest<Value<'js>>) {
+        self.outputs.append(&mut values)
+    }
+
+    #[qjs(rename = "trace")]
+    fn trace_(&mut self, message: String) {
+        self.messages.push((0, message.to_string()))
+    }
+
+    #[qjs()]
+    fn debug(&mut self, message: String) {
+        self.messages.push((1, message.to_string()))
+    }
+
+    #[qjs()]
+    fn info(&mut self, message: String) {
+        self.messages.push((2, message.to_string()))
+    }
+
+    #[qjs()]
+    fn warn(&mut self, message: String) {
+        self.messages.push((3, message.to_string()))
+    }
+
+    #[qjs()]
+    fn error(&mut self, message: String) {
+        self.messages.push((4, message.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_dev::pretty_assertions::assert_eq;
+    use kernel::{
+        common::{indexmap::IndexMap, tokio},
+        schema::{Array, ArrayHint, Hint, Node, Object, ObjectHint, Primitive, StringHint},
+        tests::{create_instance, start_instance},
+    };
+
+    use super::*;
+
+    // Pro-tip! Use get logs for these tests use:
+    //
+    // ```sh
+    // RUST_LOG=trace cargo test -p kernel-JavaScript -- --nocapture
+    // ```
+
+    /// Standard kernel test for execution of code
+    #[test_log::test(tokio::test)]
+    async fn execution() -> Result<()> {
+        let Some(instance) = create_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        kernel::tests::execution(
+            instance,
+            vec![
+                // Empty code: no outputs
+                ("", vec![], vec![]),
+                (" ", vec![], vec![]),
+                ("\n\n", vec![], vec![]),
+                // Only an expression: one output
+                (
+                    "
+1 + 1",
+                    vec![Node::Integer(2)],
+                    vec![],
+                ),
+                // Prints and an expression: multiple, separate outputs
+                (
+                    "
+console.log(1);
+console.log(2, 3);
+2 + 2",
+                    vec![
+                        Node::Integer(1),
+                        Node::Integer(2),
+                        Node::Integer(3),
+                        Node::Integer(4),
+                    ],
+                    vec![],
+                ),
+                // Variables set in one chunk are available in the next
+                (
+                    "
+var a = 1;
+var b = 2;
+let c = 3;
+const d = 4;",
+                    vec![],
+                    vec![],
+                ),
+                (
+                    "
+console.log(a, b, c, d)",
+                    vec![
+                        Node::Integer(1),
+                        Node::Integer(2),
+                        Node::Integer(3),
+                        Node::Integer(4),
+                    ],
+                    vec![],
+                ),
+            ],
+        )
+        .await
+    }
+
+    /// Standard kernel test for evaluation of expressions
+    #[test_log::test(tokio::test)]
+    async fn evaluation() -> Result<()> {
+        let Some(instance) = create_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        kernel::tests::evaluation(
+            instance,
+            vec![
+                ("1 + 1", Node::Integer(2), None),
+                ("2.0 * 2.2", Node::Number(4.4), None),
+                ("Math.sqrt(16)", Node::Integer(4), None),
+                ("'a' + 'bc'", Node::String("abc".to_string()), None),
+                ("'ABC'.toLowerCase()", Node::String("abc".to_string()), None),
+                (
+                    "[...[1, 2], 3]",
+                    Node::Array(Array(vec![
+                        Primitive::Integer(1),
+                        Primitive::Integer(2),
+                        Primitive::Integer(3),
+                    ])),
+                    None,
+                ),
+                (
+                    "({...{a: 1}, ['b']: 2.3})",
+                    Node::Object(Object(IndexMap::from([
+                        (String::from("a"), Primitive::Integer(1)),
+                        (String::from("b"), Primitive::Number(2.3)),
+                    ]))),
+                    None,
+                ),
+                ("", Node::Null(Null), None),
+                (
+                    "@",
+                    Node::Null(Null),
+                    Some("unexpected token in expression: '@'"),
+                ),
+                ("foo", Node::Null(Null), Some("'foo' is not defined")),
+            ],
+        )
+        .await
+    }
+
+    /// Standard kernel test for printing nodes
+    #[test_log::test(tokio::test)]
+    async fn printing() -> Result<()> {
+        let Some(instance) = create_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        kernel::tests::printing(
+            instance,
+            r#"console.log('str')"#,
+            r#"console.log('str1', 'str2')"#,
+            r#"console.log(null, true, 1, 2.3, 'str', [1, 2.3, 'str'], {a:1, b:2.3, c:'str'})"#,
+            r#"console.log({type:'Paragraph', content:[]})"#,
+        )
+        .await
+    }
+
+    /// Custom test for execution messages
+    #[tokio::test]
+    async fn messages() -> Result<()> {
+        let Some(mut kernel) = start_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        // Syntax error
+        let (outputs, messages) = kernel.execute("bad ^ # syntax").await?;
+        assert_eq!(
+            messages[0].message,
+            "invalid first character of private name"
+        );
+        assert!(messages[0].stack_trace.is_some());
+        assert_eq!(outputs, vec![]);
+
+        // Runtime error
+        let (outputs, messages) = kernel.execute("foo").await?;
+        assert_eq!(messages[0].message, "'foo' is not defined");
+        assert!(messages[0].stack_trace.is_some());
+        assert_eq!(outputs, vec![]);
+
+        // Console methods
+        let (.., messages) = kernel
+            .execute(
+                r#"
+console.debug("Debug message");
+console.info("Info message");
+console.warn("Warning message");
+console.error("Error message");
+"#,
+            )
+            .await?;
+
+        assert_eq!(
+            messages,
+            vec![
+                ExecutionMessage {
+                    level: MessageLevel::Debug,
+                    message: "Debug message".to_string(),
+                    ..Default::default()
+                },
+                ExecutionMessage {
+                    level: MessageLevel::Info,
+                    message: "Info message".to_string(),
+                    ..Default::default()
+                },
+                ExecutionMessage {
+                    level: MessageLevel::Warning,
+                    message: "Warning message".to_string(),
+                    ..Default::default()
+                },
+                ExecutionMessage {
+                    level: MessageLevel::Error,
+                    message: "Error message".to_string(),
+                    ..Default::default()
+                }
+            ]
+        );
+
+        Ok(())
+    }
+
+    /// Standard kernel test for getting runtime information
+    #[test_log::test(tokio::test)]
+    async fn info() -> Result<()> {
+        let Some(instance) = create_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        let sw = kernel::tests::info(instance).await?;
+        assert_eq!(sw.name, "QuickJS");
+        assert!(sw.options.software_version.is_some());
+        assert!(sw.options.operating_system.is_some());
+
+        Ok(())
+    }
+
+    /// Standard kernel test for listing installed packages
+    #[test_log::test(tokio::test)]
+    async fn packages() -> Result<()> {
+        let Some(instance) = start_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        let pkgs = kernel::tests::packages(instance).await?;
+        assert!(pkgs.is_empty());
+
+        Ok(())
+    }
+
+    /// Standard kernel test for variable listing
+    #[test_log::test(tokio::test)]
+    async fn var_listing() -> Result<()> {
+        let Some(instance) = create_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        kernel::tests::var_listing(
+            instance,
+            r#"
+var nul = null;
+var bool = true;
+var int = 123n;
+var num = 1.23;
+var str = "abc👍";
+var arr = [1, 2, 3];
+var obj = {a:1, b:2.3};
+var para = {type: "Paragraph", content:[]}
+"#,
+            vec![
+                Variable {
+                    name: "nul".to_string(),
+                    native_type: Some("null".to_string()),
+                    node_type: Some("Null".to_string()),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+                Variable {
+                    name: "bool".to_string(),
+                    native_type: Some("boolean".to_string()),
+                    node_type: Some("Boolean".to_string()),
+                    hint: Some(Hint::Boolean(true)),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+                Variable {
+                    name: "int".to_string(),
+                    native_type: Some("bigint".to_string()),
+                    node_type: Some("Integer".to_string()),
+                    hint: Some(Hint::Integer(123)),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+                Variable {
+                    name: "num".to_string(),
+                    native_type: Some("number".to_string()),
+                    node_type: Some("Number".to_string()),
+                    hint: Some(Hint::Number(1.23)),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+                Variable {
+                    name: "str".to_string(),
+                    native_type: Some("string".to_string()),
+                    node_type: Some("String".to_string()),
+                    hint: Some(Hint::StringHint(StringHint::new(4))),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+                Variable {
+                    name: "arr".to_string(),
+                    native_type: Some("array".to_string()),
+                    node_type: Some("Array".to_string()),
+                    hint: Some(Hint::ArrayHint(ArrayHint::new(3))),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+                Variable {
+                    name: "obj".to_string(),
+                    native_type: Some("object".to_string()),
+                    node_type: Some("Object".to_string()),
+                    hint: Some(Hint::ObjectHint(ObjectHint::new(
+                        2,
+                        vec!["a".to_string(), "b".to_string()],
+                        vec![Hint::Integer(1), Hint::Number(2.3)],
+                    ))),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+                Variable {
+                    name: "para".to_string(),
+                    native_type: Some("object".to_string()),
+                    node_type: Some("Paragraph".to_string()),
+                    programming_language: Some("JavaScript".to_string()),
+                    ..Default::default()
+                },
+            ],
+        )
+        .await
+    }
+
+    /// Standard kernel test for variable management
+    #[test_log::test(tokio::test)]
+    async fn var_management() -> Result<()> {
+        let Some(instance) = create_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        kernel::tests::var_management(instance).await
+    }
+
+    /// Standard kernel test for forking
+    #[test_log::test(tokio::test)]
+    async fn forking() -> Result<()> {
+        let Some(instance) = create_instance::<QuickJsKernel>().await? else {
+            return Ok(());
+        };
+
+        kernel::tests::forking(instance).await
+    }
+}

--- a/rust/kernels/Cargo.toml
+++ b/rust/kernels/Cargo.toml
@@ -12,6 +12,7 @@ kernel-bash = { path = "../kernel-bash" }
 kernel-jinja = { path = "../kernel-jinja" }
 kernel-node = { path = "../kernel-node" }
 kernel-python = { path = "../kernel-python" }
+kernel-quickjs = { path = "../kernel-quickjs" }
 kernel-r = { path = "../kernel-r" }
 kernel-rhai = { path = "../kernel-rhai" }
 kernel-style = { path = "../kernel-style" }

--- a/rust/kernels/src/lib.rs
+++ b/rust/kernels/src/lib.rs
@@ -23,6 +23,7 @@ use kernel_bash::BashKernel;
 use kernel_jinja::JinjaKernel;
 use kernel_node::NodeKernel;
 use kernel_python::PythonKernel;
+use kernel_quickjs::QuickJsKernel;
 use kernel_r::RKernel;
 use kernel_rhai::RhaiKernel;
 use kernel_style::StyleKernel;
@@ -33,6 +34,9 @@ pub mod cli;
 /// Get a list of available kernels
 pub async fn list() -> Vec<Box<dyn Kernel>> {
     let mut kernels = vec![
+        // First so that it gets used for `js` rather than `NodeKernel`
+        Box::<QuickJsKernel>::default() as Box<dyn Kernel>,
+        
         Box::<AsciiMathKernel>::default() as Box<dyn Kernel>,
         Box::<BashKernel>::default() as Box<dyn Kernel>,
         Box::<JinjaKernel>::default() as Box<dyn Kernel>,
@@ -52,7 +56,7 @@ pub async fn list() -> Vec<Box<dyn Kernel>> {
 
 /// Get the default kernel (used when no language is specified)
 pub fn default() -> Box<dyn Kernel> {
-    Box::<RhaiKernel>::default() as Box<dyn Kernel>
+    Box::<QuickJsKernel>::default() as Box<dyn Kernel>
 }
 
 /// An entry for a kernel instance

--- a/rust/kernels/src/lib.rs
+++ b/rust/kernels/src/lib.rs
@@ -36,7 +36,6 @@ pub async fn list() -> Vec<Box<dyn Kernel>> {
     let mut kernels = vec![
         // First so that it gets used for `js` rather than `NodeKernel`
         Box::<QuickJsKernel>::default() as Box<dyn Kernel>,
-        
         Box::<AsciiMathKernel>::default() as Box<dyn Kernel>,
         Box::<BashKernel>::default() as Box<dyn Kernel>,
         Box::<JinjaKernel>::default() as Box<dyn Kernel>,


### PR DESCRIPTION
Currently the Rhai kernel is used as the default kernel for executing and evaluating code that does not have a specified language. Rhai was chosen because it is embed-able and so does not rely on an external process. This PR adds a QuickJS kernel which is also embed-able but uses a language that is far more widely known.