### PR TITLE
refactor(web): single view pages

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,19 +22,14 @@
   ],
   "type": "module",
   "source": [
-    "src/apps/main.ts",
     "src/images/favicon.png",
     "src/themes/default.css",
     "src/themes/latex.css",
     "src/themes/tufte.css",
-    "src/views/directory.ts",
     "src/views/dynamic.ts",
     "src/views/live.ts",
     "src/views/print.ts",
-    "src/views/source.ts",
-    "src/views/split.ts",
-    "src/views/static.ts",
-    "src/views/visual.ts"
+    "src/views/static.ts"
   ],
   "staticFiles": [
     {

--- a/web/src/apps/main.css
+++ b/web/src/apps/main.css
@@ -4,15 +4,3 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
 }
-
-/*
- * Customize Shoelace
-  *
- * See https://shoelace.style/getting-started/customizing
- */
-:root {
-  /* Shoelace's default prefixed with Lato */
-  --sl-font-sans: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-    'Segoe UI Symbol';
-}

--- a/web/src/apps/main.ts
+++ b/web/src/apps/main.ts
@@ -36,7 +36,7 @@ import { VIEWS } from '../views/views'
 
 import './main.css'
 
-import './shoelace'
+import '../shoelace'
 
 /**
  * Application Wrapper

--- a/web/src/shoelace.css
+++ b/web/src/shoelace.css
@@ -1,0 +1,11 @@
+/*
+ * Customize Shoelace
+ *
+ * See https://shoelace.style/getting-started/customizing
+ */
+:root {
+  /* Shoelace's default prefixed with Inter */
+  --sl-font-sans: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
+}

--- a/web/src/shoelace.ts
+++ b/web/src/shoelace.ts
@@ -1,6 +1,8 @@
-import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js'
-import { registerIconLibrary } from '@shoelace-style/shoelace/dist/utilities/icon-library.js'
+/**
+ * Configuration of Shoelace
+ */
 
+// TODO: These imports would be better to be done where needed
 import '@shoelace-style/shoelace/dist/components/button/button.js'
 import '@shoelace-style/shoelace/dist/components/divider/divider.js'
 import '@shoelace-style/shoelace/dist/components/dropdown/dropdown.js'
@@ -12,14 +14,16 @@ import '@shoelace-style/shoelace/dist/components/menu/menu.js'
 import '@shoelace-style/shoelace/dist/components/tree-item/tree-item.js'
 import '@shoelace-style/shoelace/dist/components/tree/tree.js'
 
-import { version } from '../../package.json'
+import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js'
+import { registerIconLibrary } from '@shoelace-style/shoelace/dist/utilities/icon-library.js'
+
+import { version } from '../package.json'
 
 const { NODE_ENV } = process.env
 const base = NODE_ENV === 'development' ? 'dev' : version
 
 setBasePath(`/~static/${base}/shoelace-style/`)
 
-// Add custom icons
 registerIconLibrary('stencila', {
   resolver: (name) => `/~static/${base}/app-assets/icons/${name}.svg`,
 })

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -6,13 +6,12 @@
  * print mode.
 */
 
-[root] {
+:root {
   @apply mx-auto prose max-w-none lg:prose-xl;
+  font-family: Georgia, 'Times New Roman', Times, serif;
 }
 
 @media print {
-  [root] {
-  }
 }
 
 @page {

--- a/web/src/ui/nodes/card.ts
+++ b/web/src/ui/nodes/card.ts
@@ -131,6 +131,7 @@ export class UINodeCard extends LitElement {
       `bg-[${borderColour}]`,
       `border border-[${borderColour}]`,
       this.view === 'source' ? '' : 'rounded-t',
+      'font-sans',
       'font-medium',
     ])
 

--- a/web/src/ui/nodes/properties/author/index.ts
+++ b/web/src/ui/nodes/properties/author/index.ts
@@ -83,7 +83,7 @@ export class UINodeAuthor extends LitElement {
   details?: string
 
   override render() {
-    return html`<div class="flex flex-row gap-x-2">
+    return html`<div class="flex flex-row gap-x-2 font-sans">
       <div class="flex items-center justify-center">
         <div class="w-6 h-6 flex items-center justify-center grow-0 stretch-0">
           ${this.renderIconOrAvatar()}

--- a/web/src/ui/nodes/properties/execution-details.ts
+++ b/web/src/ui/nodes/properties/execution-details.ts
@@ -66,6 +66,7 @@ export class UINodeExecutionDetails extends LitElement {
       'py-1.5 px-4',
       `bg-[${borderColour}]`,
       'border-t border-b border-black/20',
+      'font-sans'
     ])
 
     return html`

--- a/web/src/ui/nodes/properties/generic/collapsible.ts
+++ b/web/src/ui/nodes/properties/generic/collapsible.ts
@@ -36,7 +36,7 @@ export class UINodeCollapsibleProperty extends LitElement {
     return html`
       <div class=${`${this.wrapperCSS ?? ''}`}>
         <div
-          class=${`flex flex-row items-center px-4 py-1.5 cursor-pointer ${headerBg ? `bg-[${headerBg}]` : ''}`}
+          class=${`flex flex-row items-center px-4 py-1.5 cursor-pointer font-sans ${headerBg ? `bg-[${headerBg}]` : ''}`}
           @click=${() => (this.collapsed = !this.collapsed)}
         >
           ${this.iconName &&

--- a/web/src/ui/nodes/properties/instruction-messages.ts
+++ b/web/src/ui/nodes/properties/instruction-messages.ts
@@ -25,7 +25,7 @@ export class UINodeInstructionMessages extends LitElement {
         <div slot="title">
           <span>Chat</span>
         </div>
-        <div slot="content" class="p-3">
+        <div slot="content" class="p-3 font-sans">
           <slot></slot>
         </div>
       </stencila-ui-node-collapsible-property>

--- a/web/src/views/dynamic.ts
+++ b/web/src/views/dynamic.ts
@@ -6,6 +6,8 @@ import { DomClient } from '../clients/dom'
 import type { DocumentId, DocumentAccess } from '../types'
 
 import '../nodes'
+import '../shoelace.css'
+import '../shoelace.ts'
 
 import { outputCSS } from './styles/global-styles'
 
@@ -51,6 +53,14 @@ export class DynamicView extends LitElement {
 
   // Add outputCSS to view
   static override styles?: CSSResultGroup = [outputCSS]
+
+  /**
+   * Override so that this component has a Light DOM so that
+   * theme styles apply to it.
+   */
+  protected override createRenderRoot() {
+    return this
+  }
 
   /**
    * Override so that clients are instantiated _after_ this


### PR DESCRIPTION
Serve a document view (e.g. `?view=dynamic`; default is `static`) rather than app. The `apps/main.ts` is still there but likely to be removed.

@simonwinter & @mike-parkin you might want to review the commits to follow the approach taken here.