### PR TITLE
Fix/whitespace in authorship highlight #2223

### DIFF
--- a/web/src/ui/nodes/properties/authorship/authorship.ts
+++ b/web/src/ui/nodes/properties/authorship/authorship.ts
@@ -1,5 +1,6 @@
 import { consume } from '@lit/context'
 import { ProvenanceCategory } from '@stencila/types'
+import { apply } from '@twind/core'
 import { LitElement, html, css } from 'lit'
 import { property, customElement, state } from 'lit/decorators'
 
@@ -54,28 +55,60 @@ export class StencilaAuthorship extends LitElement {
   @property({ type: Number })
   mi: number
 
+  @state()
+  protected toggleTooltip: boolean = true
+
   // Ensure that <stencila-authorship> element is inline
   static override styles = css`
     :host {
       display: inline;
+      position: relative;
     }
   `
 
   override render() {
-    const bgColour = getProvenanceHighlight(this.mi as ProvenanceHighlightLevel)
-
     if (this.context.cardOpen) {
-      return html`
-        <sl-tooltip
-          style="--show-delay: 1000ms; background-color: white; display:inline;"
-          placement="bottom-start"
-          content=${getTooltipContent(this.count, this.provenance)}
-        >
-          <span style="background-color: ${bgColour};"><slot></slot></span>
-        </sl-tooltip>
-      `
+      return this.renderHighlights()
     } else {
       return html`<slot></slot>`
     }
+  }
+
+  renderHighlights() {
+    const bgColour = getProvenanceHighlight(this.mi as ProvenanceHighlightLevel)
+
+    const tooltipStyle = apply([
+      'absolute bottom-[calc(100%+0.5rem)] left-1/2 z-10',
+      'group-hover:opacity-100',
+      'w-32',
+      'opacity-0',
+      'rounded',
+      'p-2',
+      'transition-all delay-200 duration-300',
+      'text-white text-sm',
+      'bg-black',
+      'transform -translate-x-1/2',
+      'pointer-events-none',
+      'after:content[""]',
+      'after:absolute after:-bottom-1 after:left-1/2',
+      'after:w-2 after:h-2',
+      'after:bg-black',
+      'after:transform after:-translate-x-1/2 after:rotate-45',
+    ])
+
+    /*
+      Do not change the formatting of this template,
+      line breaks between tags will introduce 
+      whitespace into the text in the document preview.
+    */
+    // prettier-ignore
+    const htmlTemplate = html`<span
+          class="group"
+          style="background-color: ${bgColour}; position: relative;"
+        ><div class=${tooltipStyle}>${getTooltipContent(this.count, this.provenance)}</div
+        ><slot></slot
+      ></span>`
+
+    return htmlTemplate
   }
 }

--- a/web/src/ui/nodes/properties/code/code.ts
+++ b/web/src/ui/nodes/properties/code/code.ts
@@ -173,7 +173,7 @@ export class UINodeCode extends LitElement {
             EditorView.decorations.of(
               createProvenanceDecorations(provenanceMarkers)
             ),
-            provenanceTooltip(provenanceMarkers),
+            provenanceTooltip(provenanceMarkers, executionMessages),
           ]
         : [],
       ...languageExtension,
@@ -224,14 +224,14 @@ export class UINodeCode extends LitElement {
    * Looks for the `<span slot="execution-messages">` element within the
    * hidden #messages element, returns `undefined` if messsages our not found
    */
-  private getExecutionMessages(): ExecutionMessage[] | undefined {
+  private getExecutionMessages(): ExecutionMessage[] | null {
     const messageParentNode = this.shadowRoot
       .querySelector('div#messages slot')
       // @ts-expect-error "assignedElements method will will not detected"
       .assignedElements({ flatten: true })
-      .find((el: HTMLElement) => el.slot === 'execution-messages') as
-      | HTMLElement
-      | undefined
+      .find(
+        (el: HTMLElement) => el.slot === 'execution-messages'
+      ) as HTMLElement
 
     if (messageParentNode) {
       const messageObjects: ExecutionMessage[] = []
@@ -244,7 +244,7 @@ export class UINodeCode extends LitElement {
         return messageObjects
       }
     }
-    return undefined
+    return null
   }
 
   /**

--- a/web/src/ui/nodes/properties/code/utils.ts
+++ b/web/src/ui/nodes/properties/code/utils.ts
@@ -112,26 +112,32 @@ const createProvenanceDecorations = (marks: ProvenanceMarker[]) =>
  * @param marks `PorvenanceMarker[]`
  * @returns `Extension`
  */
-const provenanceTooltip = (marks: ProvenanceMarker[]) =>
+const provenanceTooltip = (
+  marks: ProvenanceMarker[],
+  messages: ExecutionMessage[] | null
+) =>
   hoverTooltip((_, pos) => {
-    for (const mark of marks) {
-      if (pos >= mark.from && pos <= mark.to) {
-        return {
-          pos,
-          above: false,
-          arrow: true,
-          create: () => {
-            const dom = document.createElement('div')
-            dom.className = 'cm-provenance-tooltip'
+    // disable tooltip if execution messages are active, to avoid a merged tooltip
+    const hasMessages = messages !== null && messages.length > 0
+    if (!hasMessages) {
+      for (const mark of marks) {
+        if (pos >= mark.from && pos <= mark.to) {
+          return {
+            pos,
+            above: false,
+            arrow: true,
+            create: () => {
+              const dom = document.createElement('div')
+              dom.className = 'cm-provenance-tooltip'
 
-            dom.textContent = getTooltipContent(mark.count, mark.provenance)
+              dom.textContent = getTooltipContent(mark.count, mark.provenance)
 
-            return { dom, offset: { x: 0, y: 10 } }
-          },
+              return { dom, offset: { x: 0, y: 10 } }
+            },
+          }
         }
       }
     }
-
     return null
   })
 


### PR DESCRIPTION
**details**

fixes the white-space issue with the `<stencila-authorship>` component,

the issue was with whitespace and new lines in the html`` templates, (probably due to the 'inline' nature of the host element) these new lines and any leading / trailing whitespaces within the elements were being compressed into a single whitespace. even if removing all these from the the template, the sl-tooltip element was still adding the white space, this is because in the template of that element in the shoelace library contains the whitespace.

I have removed the sl toolitp and replaced it with a simple custom tip that is absolutely positioned, and appears on group hover.

I have formatted the html template in a way that adds no whitespace between elements, and added a `// prettier-ignore` instruction so the file formatting will not alter the template.

Also due to codemirrors limitations, have the error messages tooltip and the provenance tooltip active at the same time, will munge the content together in a single ugly af tooltip, I have set the prov tooltip to deactivate if error messages are present for now. until we can make them look nice in the same tooltip / or e able to switch between them.

**related issue**: #2223 