### PR TITLE
fix: execution message font

### DIFF
--- a/web/src/ui/nodes/properties/code/utils.ts
+++ b/web/src/ui/nodes/properties/code/utils.ts
@@ -56,7 +56,7 @@ const executionMessageLinter = (messages: ExecutionMessage[]): Extension =>
  */
 const stencilaTheme = EditorView.theme({
   '.cm-diagnostic': {
-    fontFamily: 'mono',
+    fontFamily: 'Inter, mono',
     paddingLeft: '16px',
     paddingRight: '16px',
     borderBottom: '1px solid #dedede', // grey-200

--- a/web/src/ui/preview-menu/index.ts
+++ b/web/src/ui/preview-menu/index.ts
@@ -36,7 +36,7 @@ export class DocumentViewMenu extends LitElement {
 
   protected override render() {
     const styles = apply([
-      'fixed right-8 top-8',
+      'fixed right-8 top-8 z-50',
       !this.visible && 'opacity-0',
       !this.visible && 'pointer-events-none',
     ])


### PR DESCRIPTION
**details**

Use 'Inter' as the font for error messages, will default to a mono if this is not available

![image](https://github.com/stencila/stencila/assets/73506758/a2b39e1e-23fc-48fc-82d6-7e40ac0898b7)

(also patch the z-index of the preview burger menu)

**related issue** #2229 