### PR TITLE
Fix/instruction block UI

### DIFF
--- a/web/src/ui/nodes/properties/author/index.ts
+++ b/web/src/ui/nodes/properties/author/index.ts
@@ -85,10 +85,10 @@ export class UINodeAuthor extends LitElement {
   override render() {
     return html`<div class="@container">
       <div class="flex flex-col gap-x-2 font-sans mb-4 @xs:flex-row @xs:mb-0">
-        <div class="flex flex-col flex-grow @xs:flex-row">
+        <div class="flex flex-row flex-grow">
           <div class="flex items-center justify-center mr-2">
             <div
-              class="w-6 h-6 flex items-center justify-center grow-0 stretch-0 mb-4 @xs:mb-0"
+              class="w-6 h-6 flex items-center justify-center grow-0 stretch-0"
             >
               ${this.renderIconOrAvatar()}
             </div>

--- a/web/src/ui/nodes/properties/execution-details.ts
+++ b/web/src/ui/nodes/properties/execution-details.ts
@@ -61,7 +61,7 @@ export class UINodeExecutionDetails extends LitElement {
     const { borderColour } = nodeUi(this.type)
 
     const classes = apply([
-      'flex flex-col gap-3',
+      'flex flex-row flex-wrap gap-3',
       'text-xs leading-tight',
       'py-1.5 px-4',
       `bg-[${borderColour}]`,
@@ -70,8 +70,8 @@ export class UINodeExecutionDetails extends LitElement {
     ])
 
     return html`
-      <div class="@container">
-        <div class=${`${classes} @[30rem]:flex-row`}>
+      <div>
+        <div class=${`${classes}`}>
           <stencila-ui-node-execution-state
             status=${this.status}
             required=${this.required}

--- a/web/src/ui/nodes/properties/provenance/provenance.ts
+++ b/web/src/ui/nodes/properties/provenance/provenance.ts
@@ -1,12 +1,14 @@
 import '@shoelace-style/shoelace/dist/components/icon/icon'
 import { NodeType } from '@stencila/types'
+import { css } from '@twind/core'
 import { html, LitElement, PropertyValues } from 'lit'
 import { customElement, property, state } from 'lit/decorators'
 
 import { withTwind } from '../../../../twind'
+import { nodeUi } from '../../icons-and-colours'
+
 import '../../node-card/section-header'
 import '../generic/collapsible-details'
-import { nodeUi } from '../../icons-and-colours'
 
 /**
  * A component for displaying the `provenance` property of a node.
@@ -42,15 +44,23 @@ export class UINodeProvenance extends LitElement {
   override render() {
     const { borderColour: headerBg } = nodeUi(this.type)
 
-    return html`<div>
+    // apply flex to the slotted container
+    const countStyles = css`
+      & ::slotted([slot='provenance']) {
+        display: flex;
+        column-gap: 0.5rem;
+      }
+    `
+
+    return html`<div class="border-b border-black/20">
       <stencila-ui-node-card-section-header
         icon-name="handshake"
         icon-library="lucide"
         headerBg=${headerBg}
-        wrapper-css=${this.hasItems ? '' : 'hidden'}
+        wrapper-css="flex-wrap gap-y-2 ${this.hasItems ? '' : 'hidden'}"
       >
         <div slot="title" class="not-italic">Provenance</div>
-        <div slot="right-side" class="flex gap-x-2">
+        <div slot="right-side" class="${countStyles}">
           <slot></slot>
         </div>
       </stencila-ui-node-card-section-header>


### PR DESCRIPTION
**details**

Make the following changes:

- [ ] the pills for provenance are stacked vertical rather than being horizontal.
- [ ] no horizontal line between Provenance and Chat to separate them.
- [ ] when made a little narrower, the status details collapse to a single column and take up a lot of vertical space, just wrapping or two or three columns would feel less drastic.

And also fixes the authors property layout on smaller screens.

![image](https://github.com/stencila/stencila/assets/73506758/616d2041-3a88-4059-a22e-e0bc872d831e)

![image](https://github.com/stencila/stencila/assets/73506758/1b21a581-9060-4c6b-875e-3b7b24efd95c)


*related issue*: #2209 