### PR TITLE
Draft: style captions for fig and codechunk

### DIFF
--- a/web/src/nodes/code-chunk.ts
+++ b/web/src/nodes/code-chunk.ts
@@ -3,6 +3,7 @@ import { html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
+import { createCaptionLabel } from '../ui/nodes/properties/captions'
 
 import '../ui/nodes/node-card/in-flow/block'
 import '../ui/nodes/commands/execution-commands'
@@ -10,7 +11,6 @@ import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code/code'
 import '../ui/nodes/properties/execution-details'
 import '../ui/nodes/properties/execution-messages'
-import '../ui/nodes/properties/label-and-caption'
 import '../ui/nodes/properties/outputs'
 import '../ui/nodes/properties/provenance/provenance'
 
@@ -32,6 +32,12 @@ export class CodeChunk extends CodeExecutable {
 
   @property({ attribute: 'is-invisible', type: Boolean })
   isInvisible?: boolean = false
+
+  override connectedCallback(): void {
+    super.connectedCallback()
+
+    createCaptionLabel(this, 'CodeChunk')
+  }
 
   /**
    * In static view just render the outputs, label and caption
@@ -104,16 +110,21 @@ export class CodeChunk extends CodeExecutable {
         </stencila-ui-node-code>
       </div>
       <div slot="content">
+        ${this.labelType === 'TableLabel'
+          ? html`<caption>
+              ${this.renderCaption()}
+            </caption>`
+          : ''}
         ${this.isInvisible ? '' : html`<slot name="outputs"></slot>`}
-        <stencila-ui-node-label-and-caption
-          type="CodeChunk"
-          label-type=${this.labelType}
-          label=${this.label}
-        >
-          <slot name="caption" slot="caption"></slot>
-        </stencila-ui-node-label-and-caption>
+        ${this.labelType === 'FigureLabel'
+          ? html`<figcaption>${this.renderCaption()}</figcaption>`
+          : ''}
       </div>
     </stencila-ui-block-on-demand>`
+  }
+
+  private renderCaption() {
+    return html`<slot name="caption"></slot>`
   }
 
   /**

--- a/web/src/nodes/figure.ts
+++ b/web/src/nodes/figure.ts
@@ -1,10 +1,12 @@
 import { html } from 'lit'
-import { customElement } from 'lit/decorators.js'
+import { customElement, property } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
+import { createCaptionLabel } from '../ui/nodes/properties/captions'
 
 import { Entity } from './entity'
 
+import '../ui/nodes/properties/captions/caption-label'
 import '../ui/nodes/properties/provenance/provenance'
 
 /**
@@ -15,6 +17,15 @@ import '../ui/nodes/properties/provenance/provenance'
 @customElement('stencila-figure')
 @withTwind()
 export class Figure extends Entity {
+  @property()
+  label: string
+
+  override connectedCallback(): void {
+    super.connectedCallback()
+
+    createCaptionLabel(this, 'Figure')
+  }
+
   /**
    * In static view just render the figure
    */
@@ -39,9 +50,12 @@ export class Figure extends Entity {
             <slot name="provenance"></slot>
           </stencila-ui-node-provenance>
         </div>
-        <figure slot="content" class="m-0">
+        <div slot="content" class="m-0">
           <slot name="content"></slot>
-        </figure>
+          <figcaption>
+            <slot name="caption" slot="caption"></slot>
+          </figcaption>
+        </div>
       </stencila-ui-block-on-demand>
     `
   }

--- a/web/src/nodes/table.ts
+++ b/web/src/nodes/table.ts
@@ -1,7 +1,8 @@
 import { html } from 'lit'
-import { customElement } from 'lit/decorators'
+import { customElement, property } from 'lit/decorators'
 
 import { withTwind } from '../twind'
+import { createCaptionLabel } from '../ui/nodes/properties/captions'
 
 import { Entity } from './entity'
 
@@ -15,6 +16,15 @@ import '../ui/nodes/properties/provenance/provenance'
 @customElement('stencila-table')
 @withTwind()
 export class Table extends Entity {
+  @property()
+  label: string
+
+  override connectedCallback(): void {
+    super.connectedCallback()
+
+    createCaptionLabel(this, 'Table')
+  }
+
   /**
    * render table and any additional content
    */
@@ -43,10 +53,12 @@ export class Table extends Entity {
           </stencila-ui-node-provenance>
         </div>
         <div class="content" slot="content">
+          <caption>
+            <slot slot="caption"></slot>
+          </caption>
           <div class="overflow-x-scroll">
             <slot name="rows"></slot>
           </div>
-          <slot></slot>
         </div>
       </stencila-ui-block-on-demand>
     `

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -21,8 +21,7 @@ figure {
   @apply mx-0;
 }
 
-@media print {
-}
+@media print {}
 
 @page {
   size: 21cm 29.7cm;
@@ -32,7 +31,7 @@ figure {
 [root] {
   @apply text-black prose lg:prose-lg;
 
-  > section {
+  >section {
     @apply min-w-80 w-full max-w-prose mx-auto;
   }
 
@@ -59,14 +58,6 @@ figure {
 
   figure {
     @apply my-4 mx-0;
-  }
-
-  figcaption {
-    @apply text-black;
-
-    p {
-      @apply italic;
-    }
   }
 
   table {
@@ -141,7 +132,7 @@ figure {
       }
     }
 
-    + stencila-paragraph {
+    +stencila-paragraph {
       p {
         @apply mt-0;
       }
@@ -152,7 +143,7 @@ figure {
     display: block;
     border: 1px solid transparent;
 
-    + stencila-paragraph {
+    +stencila-paragraph {
       p {
         margin-top: 0;
       }
@@ -230,6 +221,7 @@ figure {
 
   stencila-code-chunk {
     [slot='outputs'] {
+
       stencila-boolean,
       stencila-integer,
       stencila-number,
@@ -244,7 +236,7 @@ figure {
 
 [view='dynamic'],
 [view='vscode'] {
-  > [root] {
+  >[root] {
     @apply max-w-prose;
     max-width: 100%;
 
@@ -295,9 +287,33 @@ figure {
       }
     }
 
+    stencila-table,
+    stencila-figure,
     stencila-code-chunk {
-      [slot='caption'] {
+      [slot="caption"] {
         @apply block;
+
+        stencila-paragraph {
+          p {
+            @apply text-sm text-black italic text-left;
+          }
+        }
+      }
+
+      &[label-type="FigureLabel"] {
+        [slot="caption"] {
+          @apply mb-4;
+
+          stencila-paragraph:first-child {
+            p {
+              @apply mt-0;
+            }
+          }
+        }
+      }
+
+      [slot="caption"]+[slot="outputs"] {
+        @apply mt-0;
       }
     }
   }

--- a/web/src/ui/nodes/properties/captions/caption-label.ts
+++ b/web/src/ui/nodes/properties/captions/caption-label.ts
@@ -2,15 +2,15 @@ import { LabelType, NodeType } from '@stencila/types'
 import { LitElement, html } from 'lit'
 import { customElement, property } from 'lit/decorators'
 
-import { withTwind } from '../../../twind'
+import { withTwind } from '../../../../twind'
 
-import './generic/simple'
+import '../generic/simple'
 
 /**
  * A component for displaying the `label` and `caption`
  * properties of `Table`, `Figure` and `CodeChunk` nodes
  */
-@customElement('stencila-ui-node-label-and-caption')
+@customElement('stencila-ui-node-caption-label')
 @withTwind()
 export class UINodeExecutionDuration extends LitElement {
   @property()
@@ -35,12 +35,11 @@ export class UINodeExecutionDuration extends LitElement {
           : this.labelType === 'TableLabel'
             ? 'Table'
             : this.type
-      text += ` ${this.label} `
+      text += ` ${this.label}: `
     }
 
-    return html`<div>
+    return html`
       ${text !== '' ? html`<span class="font-bold">${text}</span>` : ''}
-      <slot name="caption"></slot>
-    </div>`
+    `
   }
 }

--- a/web/src/ui/nodes/properties/captions/index.ts
+++ b/web/src/ui/nodes/properties/captions/index.ts
@@ -1,0 +1,33 @@
+import { LabelType, NodeType } from '@stencila/types'
+
+import { Entity } from '../../../../nodes/entity'
+
+import './caption-label'
+
+/**
+ * Finds a 'caption' slot from a node's light dom and prepends
+ * the label to the first 'content' element of the captions
+ */
+export const createCaptionLabel = <
+  T extends Entity & { label?: string; labelType?: LabelType },
+>(
+  node: T,
+  type: NodeType
+) => {
+  const captions = node.querySelector('[slot="caption"]')
+  if (captions) {
+    // find the 'content' element of the first child node in the caption
+    const firstChildContent = captions.querySelector(
+      '*:first-child [slot="content"]'
+    )
+
+    // create label element and set attributes
+    const labelEl = document.createElement('stencila-ui-node-caption-label')
+    labelEl.setAttribute('type', type)
+    labelEl.setAttribute('label-type', node.labelType)
+    labelEl.setAttribute('label', node.label)
+
+    // prepend the label to the content
+    firstChildContent.prepend(labelEl)
+  }
+}


### PR DESCRIPTION
**details**

add a label and caption to the Table, Figure and the table/figure outputs of CoideChunks

Is incomplete currently as there is no [slot="caption"] element inside the stencila-tablem which is needed for the logic top work,

This also does not work in the vscode webview, and cannot figure out why yet

