### PR TITLE
refactor(dom html): add label to captions of `Table`, `Figure`, and `CodeChunk`

### DIFF
--- a/examples/nodes/article-ark/article-ark.dom.html
+++ b/examples/nodes/article-ark/article-ark.dom.html
@@ -252,33 +252,35 @@
       </div>
     </stencila-styled-block>
     <stencila-table id=xxx depth=1 ancestors=Article>
-      <table slot=rows>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>A</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
+      <table>
+        <tbody slot=rows>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>A</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+        </tbody>
       </table>
     </stencila-table>
     <stencila-thematic-break id=xxx depth=1 ancestors=Article>

--- a/examples/nodes/article-labels/article-labels.dom.html
+++ b/examples/nodes/article-labels/article-labels.dom.html
@@ -36,14 +36,15 @@
             </stencila-image-object>
           </p>
         </stencila-paragraph>
+        <figcaption slot=caption>
+          <stencila-paragraph id=xxx depth=2 ancestors=Article.Figure>
+            <p slot=content>
+              <span class=figure-label>Figure</span>
+              <stencila-text id=xxx depth=3 ancestors=Article.Figure.Paragraph>Some white text on orange an background.</stencila-text>
+            </p>
+          </stencila-paragraph>
+        </figcaption>
       </figure>
-      <figcaption slot=caption>
-        <stencila-paragraph id=xxx depth=2 ancestors=Article.Figure>
-          <p slot=content>
-            <stencila-text id=xxx depth=3 ancestors=Article.Figure.Paragraph>Some white text on orange an background.</stencila-text>
-          </p>
-        </stencila-paragraph>
-      </figcaption>
     </stencila-figure>
     <stencila-paragraph id=xxx depth=1 ancestors=Article>
       <p slot=content>
@@ -54,6 +55,7 @@
       <div slot=caption>
         <stencila-paragraph id=xxx depth=2 ancestors=Article.CodeChunk>
           <p slot=content>
+            <span class=figure-label>Figure</span>
             <stencila-text id=xxx depth=3 ancestors=Article.CodeChunk.Paragraph>A plot.</stencila-text>
           </p>
         </stencila-paragraph>
@@ -65,143 +67,146 @@
       </p>
     </stencila-paragraph>
     <stencila-table id=xxx depth=1 ancestors=Article>
-      <caption slot=caption>
-        <stencila-paragraph id=xxx depth=2 ancestors=Article.Table>
-          <p slot=content>
-            <stencila-text id=xxx depth=3 ancestors=Article.Table.Paragraph>A little table about fish.</stencila-text>
-          </p>
-        </stencila-paragraph>
-        <stencila-paragraph id=xxx depth=2 ancestors=Article.Table>
-          <p slot=content>
-            <stencila-text id=xxx depth=3 ancestors=Article.Table.Paragraph>This caption has two paragraphs.</stencila-text>
-          </p>
-        </stencila-paragraph>
-      </caption>
-      <table slot=rows>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Species</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Average Length (cm)</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Average Weight (kg)</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Goldfish</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>20.0</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>0.45</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Clownfish</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>10.0</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>0.25</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Trout</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>40.0</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1.50</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
+      <table>
+        <caption slot=caption>
+          <stencila-paragraph id=xxx depth=2 ancestors=Article.Table>
+            <p slot=content>
+              <span class=table-label>Table</span>
+              <stencila-text id=xxx depth=3 ancestors=Article.Table.Paragraph>A little table about fish.</stencila-text>
+            </p>
+          </stencila-paragraph>
+          <stencila-paragraph id=xxx depth=2 ancestors=Article.Table>
+            <p slot=content>
+              <stencila-text id=xxx depth=3 ancestors=Article.Table.Paragraph>This caption has two paragraphs.</stencila-text>
+            </p>
+          </stencila-paragraph>
+        </caption>
+        <tbody slot=rows>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Species</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Average Length (cm)</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Average Weight (kg)</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Goldfish</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>20.0</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>0.45</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Clownfish</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>10.0</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>0.25</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>Trout</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>40.0</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1.50</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+        </tbody>
       </table>
     </stencila-table>
     <stencila-paragraph id=xxx depth=1 ancestors=Article>
@@ -213,6 +218,7 @@
       <div slot=caption>
         <stencila-paragraph id=xxx depth=2 ancestors=Article.CodeChunk>
           <p slot=content>
+            <span class=table-label>Table</span>
             <stencila-text id=xxx depth=3 ancestors=Article.CodeChunk.Paragraph>Some cars</stencila-text>
           </p>
         </stencila-paragraph>

--- a/examples/nodes/code-chunk/code-chunk.dom.html
+++ b/examples/nodes/code-chunk/code-chunk.dom.html
@@ -38,6 +38,7 @@ a = 3' programming-language=python>
       <div slot=caption>
         <stencila-paragraph id=xxx depth=2 ancestors=Article.CodeChunk>
           <p slot=content>
+            <span class=figure-label>Figure 1</span>
             <stencila-text id=xxx depth=3 ancestors=Article.CodeChunk.Paragraph>Y against X.</stencila-text>
           </p>
         </stencila-paragraph>
@@ -52,6 +53,7 @@ a = 3' programming-language=python>
       <div slot=caption>
         <stencila-paragraph id=xxx depth=2 ancestors=Article.CodeChunk>
           <p slot=content>
+            <span class=table-label>Table 1</span>
             <stencila-text id=xxx depth=3 ancestors=Article.CodeChunk.Paragraph>Some cars.</stencila-text>
           </p>
         </stencila-paragraph>

--- a/examples/nodes/figure/figure.dom.html
+++ b/examples/nodes/figure/figure.dom.html
@@ -22,14 +22,15 @@
             </stencila-image-object>
           </p>
         </stencila-paragraph>
+        <figcaption slot=caption>
+          <stencila-paragraph id=xxx depth=2 ancestors=Article.Figure>
+            <p slot=content>
+              <span class=figure-label>Figure 2</span>
+              <stencila-text id=xxx depth=3 ancestors=Article.Figure.Paragraph>A dog.</stencila-text>
+            </p>
+          </stencila-paragraph>
+        </figcaption>
       </figure>
-      <figcaption slot=caption>
-        <stencila-paragraph id=xxx depth=2 ancestors=Article.Figure>
-          <p slot=content>
-            <stencila-text id=xxx depth=3 ancestors=Article.Figure.Paragraph>A dog.</stencila-text>
-          </p>
-        </stencila-paragraph>
-      </figcaption>
     </stencila-figure>
     <stencila-section id=xxx depth=1 ancestors=Article>
       <section slot=content>
@@ -43,14 +44,15 @@
                 </stencila-image-object>
               </p>
             </stencila-paragraph>
+            <figcaption slot=caption>
+              <stencila-paragraph id=xxx depth=3 ancestors=Article.Section.Figure>
+                <p slot=content>
+                  <span class=figure-label>Figure</span>
+                  <stencila-text id=xxx depth=4 ancestors=Article.Section.Figure.Paragraph>A figure of a mouse inside a section.</stencila-text>
+                </p>
+              </stencila-paragraph>
+            </figcaption>
           </figure>
-          <figcaption slot=caption>
-            <stencila-paragraph id=xxx depth=3 ancestors=Article.Section.Figure>
-              <p slot=content>
-                <stencila-text id=xxx depth=4 ancestors=Article.Section.Figure.Paragraph>A figure of a mouse inside a section.</stencila-text>
-              </p>
-            </stencila-paragraph>
-          </figcaption>
         </stencila-figure>
       </section>
     </stencila-section>

--- a/examples/nodes/table/table.dom.html
+++ b/examples/nodes/table/table.dom.html
@@ -6,100 +6,102 @@
       </p>
     </stencila-paragraph>
     <stencila-table id=xxx depth=1 ancestors=Article>
-      <table slot=rows>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>A</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>B</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>C</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>2</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>3</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>4</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>5</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>6</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
+      <table>
+        <tbody slot=rows>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>A</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>B</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>C</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>2</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>3</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>4</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>5</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>6</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+        </tbody>
       </table>
     </stencila-table>
     <stencila-paragraph id=xxx depth=1 ancestors=Article>
@@ -108,59 +110,61 @@
       </p>
     </stencila-paragraph>
     <stencila-table id=xxx depth=1 ancestors=Article>
-      <table slot=rows>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>D</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>E</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>2</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
+      <table>
+        <tbody slot=rows>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>D</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>E</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>2</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+        </tbody>
       </table>
     </stencila-table>
     <stencila-paragraph id=xxx depth=1 ancestors=Article>
@@ -169,58 +173,61 @@
       </p>
     </stencila-paragraph>
     <stencila-table id=xxx depth=1 ancestors=Article label=3 label-automatically=false>
-      <caption slot=caption>
-        <stencila-paragraph id=xxx depth=2 ancestors=Article.Table>
-          <p slot=content>
-            <stencila-text id=xxx depth=3 ancestors=Article.Table.Paragraph>The caption.</stencila-text>
-          </p>
-        </stencila-paragraph>
-      </caption>
-      <table slot=rows>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>A</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>B</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
-        <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
-          <tr slot=cells>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-            <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
-              <td slot=content>
-                <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
-                  <p slot=content>
-                    <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>2</stencila-text>
-                  </p>
-                </stencila-paragraph>
-              </td>
-            </stencila-table-cell>
-          </tr>
-        </stencila-table-row>
+      <table>
+        <caption slot=caption>
+          <stencila-paragraph id=xxx depth=2 ancestors=Article.Table>
+            <p slot=content>
+              <span class=table-label>Table 3</span>
+              <stencila-text id=xxx depth=3 ancestors=Article.Table.Paragraph>The caption.</stencila-text>
+            </p>
+          </stencila-paragraph>
+        </caption>
+        <tbody slot=rows>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table row-type=HeaderRow>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>A</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>B</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+          <stencila-table-row id=xxx depth=2 ancestors=Article.Table>
+            <tr slot=cells>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>1</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+              <stencila-table-cell id=xxx depth=3 ancestors=Article.Table.TableRow>
+                <td slot=content>
+                  <stencila-paragraph id=xxx depth=4 ancestors=Article.Table.TableRow.TableCell>
+                    <p slot=content>
+                      <stencila-text id=xxx depth=5 ancestors=Article.Table.TableRow.TableCell.Paragraph>2</stencila-text>
+                    </p>
+                  </stencila-paragraph>
+                </td>
+              </stencila-table-cell>
+            </tr>
+          </stencila-table-row>
+        </tbody>
       </table>
       <aside slot=notes>
         <stencila-paragraph id=xxx depth=2 ancestors=Article.Table>

--- a/json/CodeChunk.schema.json
+++ b/json/CodeChunk.schema.json
@@ -9,6 +9,9 @@
   ],
   "category": "code",
   "description": "A executable chunk of code.",
+  "dom": {
+    "derive": false
+  },
   "jats": {
     "elem": "code",
     "attrs": {

--- a/json/Figure.schema.json
+++ b/json/Figure.schema.json
@@ -8,6 +8,9 @@
   ],
   "category": "works",
   "description": "Encapsulates one or more images, videos, tables, etc, and provides captions and labels for them.",
+  "dom": {
+    "derive": false
+  },
   "html": {
     "elem": "figure"
   },

--- a/json/Table.schema.json
+++ b/json/Table.schema.json
@@ -12,6 +12,9 @@
   "patch": {
     "takeAuthors": true
   },
+  "dom": {
+    "derive": false
+  },
   "html": {
     "special": true
   },

--- a/rust/schema/src/implem/code_chunk.rs
+++ b/rust/schema/src/implem/code_chunk.rs
@@ -1,6 +1,96 @@
 use codec_info::{lost_exec_options, lost_options};
 
-use crate::{prelude::*, CodeChunk, LabelType};
+use crate::{prelude::*, CodeChunk, Duration, LabelType, Timestamp};
+
+use super::utils::caption_to_dom;
+
+impl DomCodec for CodeChunk {
+    fn to_dom(&self, context: &mut DomEncodeContext) {
+        context.enter_node(self.node_type(), self.node_id());
+
+        if let Some(auto_exec) = &self.auto_exec {
+            context.push_attr("auto-exec", &auto_exec.to_string());
+        }
+
+        self.code.to_dom_attr("code", context);
+
+        if let Some(programming_language) = &self.programming_language {
+            context.push_attr("programming-language", programming_language);
+        }
+
+        if let Some(label_type) = &self.label_type {
+            context.push_attr("label-type", &label_type.to_string());
+        }
+
+        if let Some(label) = &self.label {
+            context.push_attr("label", label);
+        }
+
+        if let Some(label_automatically) = &self.label_automatically {
+            context.push_attr("label-automatically", &label_automatically.to_string());
+        }
+
+        if let Some(is_invisible) = &self.is_invisible {
+            context.push_attr("is-invisible", &is_invisible.to_string());
+        }
+
+        macro_rules! exec_option {
+            ($name:literal, $prop: ident) => {
+                if let Some(value) = &self.options.$prop {
+                    value.to_dom_attr($name, context)
+                }
+            };
+        }
+        exec_option!("execution-count", execution_count);
+        exec_option!("execution-required", execution_required);
+        exec_option!("execution-status", execution_status);
+
+        if let Some(value) = &self.options.execution_ended {
+            Timestamp::to_dom_attr("execution-ended", value, context);
+        }
+        if let Some(value) = &self.options.execution_duration {
+            Duration::to_dom_attr("execution-duration", value, context);
+        }
+
+        if let Some(compilation_messages) = &self.options.compilation_messages {
+            context.push_slot_fn("div", "compilation-messages", |context| {
+                compilation_messages.to_dom(context)
+            });
+        }
+
+        if let Some(execution_messages) = &self.options.execution_messages {
+            context.push_slot_fn("div", "execution-messages", |context| {
+                execution_messages.to_dom(context)
+            });
+        }
+
+        if let Some(authors) = &self.authors {
+            context.push_slot_fn("div", "authors", |context| authors.to_dom(context));
+        }
+
+        if let Some(provenance) = &self.provenance {
+            context.push_slot_fn("div", "provenance", |context| provenance.to_dom(context));
+        }
+
+        if let (Some(LabelType::TableLabel), Some(caption)) = (&self.label_type, &self.caption) {
+            context.push_slot_fn("div", "caption", |context| {
+                caption_to_dom(context, "table-label", "Table", &self.label, caption)
+            });
+        }
+
+        if let Some(outputs) = &self.outputs {
+            context.push_slot_fn("div", "outputs", |context| outputs.to_dom(context));
+        }
+
+        if let (Some(LabelType::FigureLabel), Some(caption)) = (&self.label_type, &self.caption) {
+            context.push_slot_fn("div", "caption", |context| {
+                caption_to_dom(context, "figure-label", "Figure", &self.label, caption)
+            });
+        }
+
+        context.exit_node();
+    }
+}
 
 impl MarkdownCodec for CodeChunk {
     fn to_markdown(&self, context: &mut MarkdownEncodeContext) {

--- a/rust/schema/src/implem/figure.rs
+++ b/rust/schema/src/implem/figure.rs
@@ -2,6 +2,42 @@ use codec_info::lost_options;
 
 use crate::{prelude::*, Figure};
 
+use super::utils::caption_to_dom;
+
+impl DomCodec for Figure {
+    fn to_dom(&self, context: &mut DomEncodeContext) {
+        context.enter_node(self.node_type(), self.node_id());
+
+        if let Some(label) = &self.label {
+            context.push_attr("label", label);
+        }
+
+        if let Some(label_automatically) = &self.label_automatically {
+            context.push_attr("label-automatically", &label_automatically.to_string());
+        }
+
+        if let Some(authors) = &self.authors {
+            context.push_slot_fn("div", "authors", |context| authors.to_dom(context));
+        }
+
+        if let Some(provenance) = &self.provenance {
+            context.push_slot_fn("div", "provenance", |context| provenance.to_dom(context));
+        }
+        
+        context.enter_elem_attrs("figure", [("slot", "content")]);
+
+        self.content.to_dom(context);
+
+        if let Some(caption) = &self.caption {
+            context.push_slot_fn("figcaption", "caption", |context| {
+                caption_to_dom(context, "figure-label", "Figure", &self.label, caption)
+            });
+        }
+
+        context.exit_elem().exit_node();
+    }
+}
+
 impl MarkdownCodec for Figure {
     fn to_markdown(&self, context: &mut MarkdownEncodeContext) {
         context

--- a/rust/schema/src/implem/mod.rs
+++ b/rust/schema/src/implem/mod.rs
@@ -68,4 +68,6 @@ mod time;
 mod timestamp;
 mod validators;
 
+mod utils;
+
 pub use author::AuthorType;

--- a/rust/schema/src/implem/table.rs
+++ b/rust/schema/src/implem/table.rs
@@ -56,17 +56,16 @@ impl DomCodec for Table {
             context.push_slot_fn("div", "provenance", |context| provenance.to_dom(context));
         }
 
-        context.enter_elem("table");
-
+        // Strictly, <caption> should be within <table>, but that causes issues for styling of web component,
+        // so we make it a sibling.
+        // See https://github.com/stencila/stencila/pull/2240#issuecomment-2136358172
         if let Some(caption) = &self.caption {
             context.push_slot_fn("caption", "caption", |context| {
                 caption_to_dom(context, "table-label", "Table", &self.label, caption)
             });
         }
 
-        context.push_slot_fn("tbody", "rows", |context| self.rows.to_dom(context));
-
-        context.exit_elem(); // Exit <table>
+        context.push_slot_fn("table", "rows", |context| self.rows.to_dom(context));
 
         if let Some(notes) = &self.notes {
             context.push_slot_fn("aside", "notes", |context| notes.to_dom(context));

--- a/rust/schema/src/implem/utils.rs
+++ b/rust/schema/src/implem/utils.rs
@@ -1,0 +1,42 @@
+use codec_dom_trait::{DomCodec, DomEncodeContext};
+
+use crate::Block;
+
+/// Encode the `caption` of a `Figure`, `Table` of `CodeChunk` to DOM HTML
+///
+/// Injects a `<span>` for the label into the first paragraph.
+pub(super) fn caption_to_dom(
+    context: &mut DomEncodeContext,
+    class: &str,
+    kind: &str,
+    label: &Option<String>,
+    caption: &[Block],
+) {
+    for (index, block) in caption.iter().enumerate() {
+        if let (0, Block::Paragraph(paragraph)) = (index, block) {
+            context.enter_node(paragraph.node_type(), paragraph.node_id());
+
+            if let Some(authors) = &paragraph.authors {
+                context.push_slot_fn("div", "authors", |context| authors.to_dom(context));
+            }
+
+            if let Some(provenance) = &paragraph.provenance {
+                context.push_slot_fn("div", "provenance", |context| provenance.to_dom(context));
+            }
+
+            context
+                .enter_elem_attrs("p", [("slot", "content")])
+                .enter_elem_attrs("span", [("class", class)])
+                .push_text(kind);
+            if let Some(label) = label {
+                context.push_text(" ").push_text(label);
+            }
+            context.exit_elem().push_text(" ");
+
+            paragraph.content.to_dom(context);
+            context.exit_elem().exit_node();
+        } else {
+            block.to_dom(context);
+        }
+    }
+}

--- a/rust/schema/src/types/code_chunk.rs
+++ b/rust/schema/src/types/code_chunk.rs
@@ -26,7 +26,7 @@ use super::timestamp::Timestamp;
 /// A executable chunk of code.
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(derive_more::Display)]
@@ -77,14 +77,12 @@ pub struct CodeChunk {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(authors)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "span")]
     pub authors: Option<Vec<Author>>,
 
     /// A summary of the provenance of the code.
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(provenance)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "span")]
     pub provenance: Option<Vec<ProvenanceCount>>,
 
     /// The type of the label for the chunk.
@@ -118,7 +116,6 @@ pub struct CodeChunk {
     #[cfg_attr(feature = "proptest-low", proptest(strategy = r#"option::of(vec_paragraphs(2))"#))]
     #[cfg_attr(feature = "proptest-high", proptest(strategy = r#"option::of(vec_paragraphs(2))"#))]
     #[cfg_attr(feature = "proptest-max", proptest(strategy = r#"option::of(vec_paragraphs(2))"#))]
-    #[dom(elem = "div")]
     pub caption: Option<Vec<Block>>,
 
     /// Outputs from executing the chunk.
@@ -126,7 +123,6 @@ pub struct CodeChunk {
     #[serde(default)]
     #[strip(output)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "div")]
     pub outputs: Option<Vec<Node>>,
 
     /// Whether the outputs of the code chunk should be invisible to the reader.
@@ -149,7 +145,7 @@ pub struct CodeChunk {
 
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub struct CodeChunkOptions {
@@ -157,7 +153,6 @@ pub struct CodeChunkOptions {
     #[serde(alias = "compilation-digest", alias = "compilation_digest")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(skip)]
     pub compilation_digest: Option<CompilationDigest>,
 
     /// Messages generated while compiling the code.
@@ -165,14 +160,12 @@ pub struct CodeChunkOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "span")]
     pub compilation_messages: Option<Vec<CompilationMessage>>,
 
     /// The `compilationDigest` of the node when it was last executed.
     #[serde(alias = "execution-digest", alias = "execution_digest")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(skip)]
     pub execution_digest: Option<CompilationDigest>,
 
     /// The upstream dependencies of this node.
@@ -180,7 +173,6 @@ pub struct CodeChunkOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "span")]
     pub execution_dependencies: Option<Vec<ExecutionDependency>>,
 
     /// The downstream dependants of this node.
@@ -188,7 +180,6 @@ pub struct CodeChunkOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "span")]
     pub execution_dependants: Option<Vec<ExecutionDependant>>,
 
     /// Tags in the code which affect its execution.
@@ -196,7 +187,6 @@ pub struct CodeChunkOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "span")]
     pub execution_tags: Option<Vec<ExecutionTag>>,
 
     /// A count of the number of times that the node has been executed.
@@ -227,14 +217,12 @@ pub struct CodeChunkOptions {
     #[serde(alias = "execution-ended", alias = "execution_ended")]
     #[strip(execution, timestamps)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(with = "Timestamp::to_dom_attr")]
     pub execution_ended: Option<Timestamp>,
 
     /// Duration of the last execution.
     #[serde(alias = "execution-duration", alias = "execution_duration")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(with = "Duration::to_dom_attr")]
     pub execution_duration: Option<Duration>,
 
     /// Messages emitted while executing the node.
@@ -242,7 +230,6 @@ pub struct CodeChunkOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(execution)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "span")]
     pub execution_messages: Option<Vec<ExecutionMessage>>,
 
     /// Whether the code should be treated as side-effect free when executed.

--- a/rust/schema/src/types/figure.rs
+++ b/rust/schema/src/types/figure.rs
@@ -24,7 +24,7 @@ use super::thing_type::ThingType;
 /// Encapsulates one or more images, videos, tables, etc, and provides captions and labels for them.
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(derive_more::Display)]
@@ -48,14 +48,12 @@ pub struct Figure {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(authors)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub authors: Option<Vec<Author>>,
 
     /// A summary of the provenance of the content within the work.
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(provenance)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "div")]
     pub provenance: Option<Vec<ProvenanceCount>>,
 
     /// The content of the figure.
@@ -66,7 +64,6 @@ pub struct Figure {
     #[cfg_attr(feature = "proptest-low", proptest(strategy = r#"vec_blocks_non_recursive(2)"#))]
     #[cfg_attr(feature = "proptest-high", proptest(strategy = r#"vec_blocks_non_recursive(2)"#))]
     #[cfg_attr(feature = "proptest-max", proptest(strategy = r#"vec_blocks_non_recursive(4)"#))]
-    #[dom(elem = "figure")]
     pub content: Vec<Block>,
 
     /// A short label for the figure.
@@ -91,7 +88,6 @@ pub struct Figure {
     #[cfg_attr(feature = "proptest-low", proptest(strategy = r#"option::of(vec_paragraphs(2))"#))]
     #[cfg_attr(feature = "proptest-high", proptest(strategy = r#"option::of(vec_paragraphs(2))"#))]
     #[cfg_attr(feature = "proptest-max", proptest(strategy = r#"option::of(vec_blocks_non_recursive(3))"#))]
-    #[dom(elem = "figcaption")]
     pub caption: Option<Vec<Block>>,
 
     /// Non-core optional fields
@@ -108,7 +104,7 @@ pub struct Figure {
 
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub struct FigureOptions {
@@ -158,7 +154,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub r#abstract: Option<Vec<Block>>,
 
     /// A secondary contributor to the `CreativeWork`.
@@ -166,7 +161,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub contributors: Option<Vec<Author>>,
 
     /// People who edited the `CreativeWork`.
@@ -174,7 +168,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub editors: Option<Vec<Person>>,
 
     /// The maintainers of the `CreativeWork`.
@@ -182,7 +175,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub maintainers: Option<Vec<PersonOrOrganization>>,
 
     /// Comments about this creative work.
@@ -190,7 +182,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub comments: Option<Vec<Comment>>,
 
     /// Date/time of creation.
@@ -233,7 +224,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub funders: Option<Vec<PersonOrOrganization>>,
 
     /// Grants that funded the `CreativeWork`; reverse of `fundedItems`.
@@ -241,7 +231,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub funded_by: Option<Vec<GrantOrMonetaryGrant>>,
 
     /// Genre of the creative work, broadcast channel or group.
@@ -270,7 +259,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub licenses: Option<Vec<CreativeWorkTypeOrText>>,
 
     /// Elements of the collection which can be a variety of different elements, such as Articles, Datatables, Tables and more.
@@ -278,14 +266,12 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(content)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub parts: Option<Vec<CreativeWorkType>>,
 
     /// A publisher of the CreativeWork.
     #[serde(default, deserialize_with = "option_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub publisher: Option<PersonOrOrganization>,
 
     /// References to other creative works, such as another publication, web page, scholarly article, etc.
@@ -293,7 +279,6 @@ pub struct FigureOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub references: Option<Vec<CreativeWorkTypeOrText>>,
 
     /// The textual content of this creative work.
@@ -307,7 +292,6 @@ pub struct FigureOptions {
     #[strip(metadata)]
     #[patch(format = "md")]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "h1")]
     pub title: Option<Vec<Inline>>,
 
     /// The version of the creative work.

--- a/rust/schema/src/types/table.rs
+++ b/rust/schema/src/types/table.rs
@@ -25,7 +25,7 @@ use super::thing_type::ThingType;
 /// A table.
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(derive_more::Display)]
@@ -48,14 +48,12 @@ pub struct Table {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(authors)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub authors: Option<Vec<Author>>,
 
     /// A summary of the provenance of the content within the work.
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(provenance)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "div")]
     pub provenance: Option<Vec<ProvenanceCount>>,
 
     /// A short label for the table.
@@ -77,7 +75,6 @@ pub struct Table {
     #[cfg_attr(feature = "proptest-low", proptest(strategy = r#"option::of(vec_paragraphs(2))"#))]
     #[cfg_attr(feature = "proptest-high", proptest(strategy = r#"option::of(vec_paragraphs(2))"#))]
     #[cfg_attr(feature = "proptest-max", proptest(strategy = r#"option::of(vec_blocks_non_recursive(3))"#))]
-    #[dom(elem = "caption")]
     pub caption: Option<Vec<Block>>,
 
     /// Rows of cells in the table.
@@ -89,7 +86,6 @@ pub struct Table {
     #[cfg_attr(feature = "proptest-low", proptest(strategy = r#"table_rows_with_header(3,3)"#))]
     #[cfg_attr(feature = "proptest-high", proptest(strategy = r#"vec(TableRow::arbitrary(), size_range(1..=4))"#))]
     #[cfg_attr(feature = "proptest-max", proptest(strategy = r#"vec(TableRow::arbitrary(), size_range(1..=8))"#))]
-    #[dom(elem = "table")]
     pub rows: Vec<TableRow>,
 
     /// Notes for the table.
@@ -101,7 +97,6 @@ pub struct Table {
     #[cfg_attr(feature = "proptest-low", proptest(strategy = r#"option::of(vec_paragraphs(1))"#))]
     #[cfg_attr(feature = "proptest-high", proptest(strategy = r#"option::of(vec_paragraphs(1))"#))]
     #[cfg_attr(feature = "proptest-max", proptest(strategy = r#"option::of(vec_blocks_non_recursive(2))"#))]
-    #[dom(elem = "aside")]
     pub notes: Option<Vec<Block>>,
 
     /// Non-core optional fields
@@ -118,7 +113,7 @@ pub struct Table {
 
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub struct TableOptions {
@@ -168,7 +163,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub r#abstract: Option<Vec<Block>>,
 
     /// A secondary contributor to the `CreativeWork`.
@@ -176,7 +170,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub contributors: Option<Vec<Author>>,
 
     /// People who edited the `CreativeWork`.
@@ -184,7 +177,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub editors: Option<Vec<Person>>,
 
     /// The maintainers of the `CreativeWork`.
@@ -192,7 +184,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub maintainers: Option<Vec<PersonOrOrganization>>,
 
     /// Comments about this creative work.
@@ -200,7 +191,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub comments: Option<Vec<Comment>>,
 
     /// Date/time of creation.
@@ -243,7 +233,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub funders: Option<Vec<PersonOrOrganization>>,
 
     /// Grants that funded the `CreativeWork`; reverse of `fundedItems`.
@@ -251,7 +240,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub funded_by: Option<Vec<GrantOrMonetaryGrant>>,
 
     /// Genre of the creative work, broadcast channel or group.
@@ -280,7 +268,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub licenses: Option<Vec<CreativeWorkTypeOrText>>,
 
     /// Elements of the collection which can be a variety of different elements, such as Articles, Datatables, Tables and more.
@@ -288,14 +275,12 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(content)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub parts: Option<Vec<CreativeWorkType>>,
 
     /// A publisher of the CreativeWork.
     #[serde(default, deserialize_with = "option_string_or_object")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub publisher: Option<PersonOrOrganization>,
 
     /// References to other creative works, such as another publication, web page, scholarly article, etc.
@@ -303,7 +288,6 @@ pub struct TableOptions {
     #[serde(default, deserialize_with = "option_one_or_many")]
     #[strip(metadata)]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "section")]
     pub references: Option<Vec<CreativeWorkTypeOrText>>,
 
     /// The textual content of this creative work.
@@ -317,7 +301,6 @@ pub struct TableOptions {
     #[strip(metadata)]
     #[patch(format = "md")]
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
-    #[dom(elem = "h1")]
     pub title: Option<Vec<Inline>>,
 
     /// The version of the creative work.

--- a/schema/CodeChunk.yaml
+++ b/schema/CodeChunk.yaml
@@ -4,6 +4,8 @@ nick: cdc
 extends: CodeExecutable
 category: code
 description: A executable chunk of code.
+dom:
+  derive: false
 jats:
   elem: code
   attrs:

--- a/schema/Figure.yaml
+++ b/schema/Figure.yaml
@@ -3,6 +3,8 @@ title: Figure
 extends: CreativeWork
 category: works
 description: Encapsulates one or more images, videos, tables, etc, and provides captions and labels for them.
+dom:
+  derive: false
 html:
   elem: figure
 jats:

--- a/schema/Table.yaml
+++ b/schema/Table.yaml
@@ -6,6 +6,8 @@ category: works
 description: A table.
 patch:
   takeAuthors: true
+dom:
+  derive: false
 html:
   special: true
 markdown:

--- a/web/src/nodes/code-chunk.ts
+++ b/web/src/nodes/code-chunk.ts
@@ -104,14 +104,19 @@ export class CodeChunk extends CodeExecutable {
         </stencila-ui-node-code>
       </div>
       <div slot="content">
-        ${this.isInvisible ? '' : html`<slot name="outputs"></slot>`}
-        <stencila-ui-node-label-and-caption
-          type="CodeChunk"
-          label-type=${this.labelType}
-          label=${this.label}
-        >
-          <slot name="caption" slot="caption"></slot>
-        </stencila-ui-node-label-and-caption>
+        ${this.isInvisible
+          ? ''
+          : html`
+              ${this.labelType === 'TableLabel'
+                ? html`<caption>
+                    <slot name="caption"></slot>
+                  </caption>`
+                : ''}
+              <slot name="outputs"></slot>
+              ${this.labelType === 'FigureLabel'
+                ? html`<figcaption><slot name="caption"></slot></figcaption>`
+                : ''}
+            `}
       </div>
     </stencila-ui-block-on-demand>`
   }

--- a/web/src/nodes/table.ts
+++ b/web/src/nodes/table.ts
@@ -43,10 +43,10 @@ export class Table extends Entity {
           </stencila-ui-node-provenance>
         </div>
         <div class="content" slot="content">
+          <slot></slot>
           <div class="overflow-x-auto">
             <slot name="rows"></slot>
-          <div>
-          <slot name="caption"></slot>
+          </div>
         </div>
       </stencila-ui-block-on-demand>
     `

--- a/web/src/nodes/table.ts
+++ b/web/src/nodes/table.ts
@@ -43,10 +43,10 @@ export class Table extends Entity {
           </stencila-ui-node-provenance>
         </div>
         <div class="content" slot="content">
-          <div class="overflow-x-scroll">
+          <div class="overflow-x-auto">
             <slot name="rows"></slot>
-          </div>
-          <slot></slot>
+          <div>
+          <slot name="caption"></slot>
         </div>
       </stencila-ui-block-on-demand>
     `

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -21,8 +21,7 @@ figure {
   @apply mx-0;
 }
 
-@media print {
-}
+@media print {}
 
 @page {
   size: 21cm 29.7cm;
@@ -32,7 +31,7 @@ figure {
 [root] {
   @apply text-black prose lg:prose-lg;
 
-  > section {
+  >section {
     @apply min-w-80 w-full max-w-prose mx-auto;
   }
 
@@ -141,7 +140,7 @@ figure {
       }
     }
 
-    + stencila-paragraph {
+    +stencila-paragraph {
       p {
         @apply mt-0;
       }
@@ -152,7 +151,7 @@ figure {
     display: block;
     border: 1px solid transparent;
 
-    + stencila-paragraph {
+    +stencila-paragraph {
       p {
         margin-top: 0;
       }
@@ -230,6 +229,7 @@ figure {
 
   stencila-code-chunk {
     [slot='outputs'] {
+
       stencila-boolean,
       stencila-integer,
       stencila-number,
@@ -244,7 +244,7 @@ figure {
 
 [view='dynamic'],
 [view='vscode'] {
-  > [root] {
+  >[root] {
     @apply max-w-prose;
     max-width: 100%;
 
@@ -298,6 +298,46 @@ figure {
     stencila-code-chunk {
       [slot='caption'] {
         @apply block;
+      }
+    }
+
+    stencila-table,
+    stencila-figure,
+    stencila-code-chunk {
+      caption {
+        @apply text-left;
+      }
+
+      [slot="caption"] {
+        @apply block;
+
+        stencila-paragraph {
+
+          .table-label,
+          .figure-label {
+            @apply font-bold after:content-[":"];
+          }
+
+          p {
+            @apply text-sm text-black italic text-left;
+          }
+        }
+      }
+
+      &[label-type="FigureLabel"] {
+        [slot="caption"] {
+          @apply mb-4;
+
+          stencila-paragraph:first-child {
+            p {
+              @apply mt-0;
+            }
+          }
+        }
+      }
+
+      [slot="caption"]+[slot="outputs"] {
+        @apply mt-0;
       }
     }
   }

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -240,6 +240,63 @@ figure {
       }
     }
   }
+
+  /* table and fig caption */
+
+  stencila-table {
+    &>stencila-paragraph {
+      p {
+        @apply mt-4;
+        @apply text-sm text-black text-left;
+      }
+
+      .table-label {
+        @apply font-bold after:content-[":"]
+      }
+    }
+  }
+
+
+  stencila-figure,
+  stencila-code-chunk {
+    caption {
+      @apply text-left;
+    }
+
+    [slot="caption"] {
+      @apply block;
+
+      stencila-paragraph {
+        p {
+          @apply mt-4;
+          @apply text-sm text-black text-left;
+        }
+
+        .table-label,
+        .figure-label {
+          @apply font-bold after:content-[":"];
+        }
+      }
+    }
+
+    &[label-type="FigureLabel"] {
+      [slot="caption"] {
+        @apply mb-4;
+
+        stencila-paragraph:first-child {
+          p {
+            @apply mt-0;
+          }
+        }
+      }
+    }
+
+    [slot="caption"]+[slot="outputs"] {
+      @apply mt-0;
+    }
+  }
+
+  /* ----------------- */
 }
 
 [view='dynamic'],
@@ -298,46 +355,6 @@ figure {
     stencila-code-chunk {
       [slot='caption'] {
         @apply block;
-      }
-    }
-
-    stencila-table,
-    stencila-figure,
-    stencila-code-chunk {
-      caption {
-        @apply text-left;
-      }
-
-      [slot="caption"] {
-        @apply block;
-
-        stencila-paragraph {
-
-          .table-label,
-          .figure-label {
-            @apply font-bold after:content-[":"];
-          }
-
-          p {
-            @apply text-sm text-black italic text-left;
-          }
-        }
-      }
-
-      &[label-type="FigureLabel"] {
-        [slot="caption"] {
-          @apply mb-4;
-
-          stencila-paragraph:first-child {
-            p {
-              @apply mt-0;
-            }
-          }
-        }
-      }
-
-      [slot="caption"]+[slot="outputs"] {
-        @apply mt-0;
       }
     }
   }

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -60,14 +60,6 @@ figure {
     @apply my-4 mx-0;
   }
 
-  figcaption {
-    @apply text-black;
-
-    p {
-      @apply italic;
-    }
-  }
-
   table {
     @apply my-4 border-collapse border-spacing-0 table-auto;
 


### PR DESCRIPTION
This add a `<span class="figure-label">` or a `<span class="table-label">` to the first paragraph of the `caption` (if any) of `Figure`, `Table` and `CodeChunk` nodes. This is done because doing this via CSS and/or CSS was proving difficult.

There are some other changes which make the generated HTML more semantically correct:

- for `Figure`, nest `<figcaption>` within `<figure>`
- for `Table`, nest `<caption>` within `<table>`
- for `CodeChunk`,  put the caption before the `outputs` if the label type is a table, and after if it is a figure

See the diffs for the HTML snapshots.