### PR TITLE
refactor: node chip behaviour

### DIFF
--- a/web/src/ui/nodes/mixins/toggle-chip.ts
+++ b/web/src/ui/nodes/mixins/toggle-chip.ts
@@ -60,12 +60,11 @@ export const ToggleChipMixin = <T extends Constructor<UIBaseClass>>(
       const [library, icon] = icons
 
       const styles = apply([
-        (this.toggle || this.docViewContext.nodeChipState === 'hidden') &&
-          'pointer-events-none',
+        this.docViewContext.nodeChipState === 'hidden' && 'pointer-events-none',
         !this.toggle &&
           this.docViewContext.nodeChipState !== 'hidden' &&
           'group-hover:opacity-100',
-        this.docViewContext.nodeChipState === 'show-all' && !this.toggle
+        this.docViewContext.nodeChipState === 'show-all' || this.toggle
           ? 'opacity-100'
           : 'opacity-0',
         'h-8',
@@ -86,8 +85,8 @@ export const ToggleChipMixin = <T extends Constructor<UIBaseClass>>(
         <div class=${`chip -ml-[40px] ${this.toggleChipPosition}`}>
           <div class=${`${styles}`} @click=${this.toggleChip}>
             <sl-icon
-              library=${library}
-              name=${icon}
+              library=${this.toggle ? 'default' : library}
+              name=${this.toggle ? 'chevron-up' : icon}
               class="text-base"
             ></sl-icon>
           </div>

--- a/web/src/ui/nodes/mixins/toggle-chip.ts
+++ b/web/src/ui/nodes/mixins/toggle-chip.ts
@@ -67,6 +67,7 @@ export const ToggleChipMixin = <T extends Constructor<UIBaseClass>>(
         this.docViewContext.nodeChipState === 'show-all' || this.toggle
           ? 'opacity-100'
           : 'opacity-0',
+        'hover:z-50',
         'h-8',
         'flex items-center',
         'transition duration-200',

--- a/web/src/ui/nodes/mixins/toggle-chip.ts
+++ b/web/src/ui/nodes/mixins/toggle-chip.ts
@@ -87,7 +87,7 @@ export const ToggleChipMixin = <T extends Constructor<UIBaseClass>>(
           <div class=${`${styles}`} @click=${this.toggleChip}>
             <sl-icon
               library=${this.toggle ? 'default' : library}
-              name=${this.toggle ? 'chevron-up' : icon}
+              name=${this.toggle ? 'chevron-down' : icon}
               class="text-base"
             ></sl-icon>
           </div>

--- a/web/src/ui/nodes/node-card/on-demand/block.ts
+++ b/web/src/ui/nodes/node-card/on-demand/block.ts
@@ -57,17 +57,14 @@ export class UIBlockOnDemand extends ToggleChipMixin(UIBaseCard) {
 
   protected override renderContent() {
     const contentStyles = apply([
-      !this.displayContent && this.toggle ? 'hidden' : 'block',
-      'relative',
       'transition-[padding] ease-in-out duration-[250ms]',
-      'px-0',
       this.toggle && 'p-3',
     ])
 
     return html`
-      <div class=${`${contentStyles}`}>
+      <div class=${!this.displayContent && this.toggle ? 'hidden' : 'block'}>
         ${this.renderChip(this.getIcon(), this.ui)}
-        <div class="content-block">
+        <div class="content-block ${contentStyles}">
           <slot name="content" class="w-full"></slot>
         </div>
       </div>

--- a/web/src/ui/nodes/node-card/on-demand/block.ts
+++ b/web/src/ui/nodes/node-card/on-demand/block.ts
@@ -57,6 +57,7 @@ export class UIBlockOnDemand extends ToggleChipMixin(UIBaseCard) {
 
   protected override renderContent() {
     const contentStyles = apply([
+      'relative',
       'transition-[padding] ease-in-out duration-[250ms]',
       this.toggle && 'p-3',
     ])

--- a/web/src/ui/nodes/node-card/on-demand/in-line.ts
+++ b/web/src/ui/nodes/node-card/on-demand/in-line.ts
@@ -22,8 +22,7 @@ export class UIInlineOnDemand extends ToggleChipMixin(UIBaseCard) {
 
   protected override restrictTitleWidth: boolean = true
 
-  protected override toggleChipPosition: string =
-    'top-1/2 -translate-y-1/2 absolute'
+  protected override toggleChipPosition: string = '-top-1/2 absolute'
 
   private tw: Twind
 


### PR DESCRIPTION
**details**

changes some simple positional and behavioural properties of the node card toggle chip

- Node chips remain visible when the card is expanded. and clicking again will collapse.
- chip icon is swapped to chevron when card is open.
- node chips are now positioned relative to the 'stencila-ui-collapsible-animation' component, instead of the content container, this keeps them inline with the top corner of the NodeCard. and also helps spread out the card chips.
- inline chips have be re-positioned, to avoid overlapping the inline card when it opens.

![image](https://github.com/stencila/stencila/assets/73506758/9ba0c57c-4159-42e3-acb0-1b5a9f1b13e1)

![image](https://github.com/stencila/stencila/assets/73506758/937f7a90-e5be-4145-85f5-8a1b8c580060)


**related issue**:  #2236 
