### PR TITLE
Feat: use text opacity to display provenance

### DIFF
--- a/web/src/ui/nodes/icons-and-colours.ts
+++ b/web/src/ui/nodes/icons-and-colours.ts
@@ -154,19 +154,19 @@ export const executionMessageUI = (
 
 // Provenance Highlight Colours ----------------------------
 
-export const provenanceHighlights = {
-  0: 'transparent',
-  1: 'rgb(241, 245, 254, 0.9)', // blue-50
-  2: 'rgb(207, 222, 252, 0.9)', // blue-100
-  3: 'rgb(177, 201, 250, 0.9)', // blue-200
-  4: 'rgb(146, 179, 247, 0.8)', // blue-300 0.8 alpha
-  5: 'rgb(119, 160, 245, 0.8)', // blue-400 0.8 alpha
+export const provenanceOpacity = {
+  0: '1',
+  1: '0.9',
+  2: '0.8',
+  3: '0.7',
+  4: '0.6',
+  5: '0.5',
 }
 
-export type ProvenanceHighlightLevel = keyof typeof provenanceHighlights
+export type ProvenanceHighlightLevel = keyof typeof provenanceOpacity
 
 export const getProvenanceHighlight = (miLvl: ProvenanceHighlightLevel) => {
-  return provenanceHighlights[miLvl]
+  return provenanceOpacity[miLvl]
 }
 
 // ---------------------------------------------------------

--- a/web/src/ui/nodes/properties/authorship/authorship.ts
+++ b/web/src/ui/nodes/properties/authorship/authorship.ts
@@ -86,7 +86,9 @@ export class StencilaAuthorship extends LitElement {
   }
 
   renderHighlights() {
-    const bgColour = getProvenanceHighlight(this.mi as ProvenanceHighlightLevel)
+    const textOpacity = getProvenanceHighlight(
+      this.mi as ProvenanceHighlightLevel
+    )
 
     const tooltipStyle = apply([
       'absolute bottom-[calc(100%+0.5rem)] left-1/2 z-10',
@@ -115,7 +117,7 @@ export class StencilaAuthorship extends LitElement {
     // prettier-ignore
     const htmlTemplate = html`<span
           class="group"
-          style="background-color: ${bgColour}; position: relative;"
+          style="position: relative; --tw-text-opacity: ${textOpacity};"
         ><div class=${tooltipStyle}>${getTooltipContent(this.count, this.provenance)}</div
         ><slot></slot
       ></span>`

--- a/web/src/ui/nodes/properties/authorship/authorship.ts
+++ b/web/src/ui/nodes/properties/authorship/authorship.ts
@@ -89,7 +89,6 @@ export class StencilaAuthorship extends LitElement {
     const textOpacity = getProvenanceHighlight(
       this.mi as ProvenanceHighlightLevel
     )
-
     const tooltipStyle = apply([
       'absolute bottom-[calc(100%+0.5rem)] left-1/2 z-10',
       'group-hover:opacity-100',
@@ -116,7 +115,7 @@ export class StencilaAuthorship extends LitElement {
     */
     // prettier-ignore
     const htmlTemplate = html`<span
-          class="group"
+          class="group text-black"
           style="position: relative; --tw-text-opacity: ${textOpacity};"
         ><div class=${tooltipStyle}>${getTooltipContent(this.count, this.provenance)}</div
         ><slot></slot

--- a/web/src/ui/nodes/properties/code/utils.ts
+++ b/web/src/ui/nodes/properties/code/utils.ts
@@ -101,7 +101,7 @@ const createAuthorshipDecorations = (marks: AuthorshipMarker[]) =>
         attributes: {
           style:
             mark.mi >= 0 && mark.mi <= 5
-              ? `background-color: ${getProvenanceHighlight(mark.mi as ProvenanceHighlightLevel)}`
+              ? `opacity: ${getProvenanceHighlight(mark.mi as ProvenanceHighlightLevel)}`
               : '',
         },
       }).range(mark.from, mark.to)

--- a/web/src/ui/nodes/properties/code/utils.ts
+++ b/web/src/ui/nodes/properties/code/utils.ts
@@ -97,11 +97,11 @@ const createAuthorshipDecorations = (marks: AuthorshipMarker[]) =>
     marks.map((mark) => {
       return Decoration.mark({
         tagName: 'span',
-        class: `prov-lvl-${mark.mi}`,
+        class: `cm-authorship prov-lvl-${mark.mi}`,
         attributes: {
           style:
             mark.mi >= 0 && mark.mi <= 5
-              ? `opacity: ${getProvenanceHighlight(mark.mi as ProvenanceHighlightLevel)}`
+              ? `opacity: ${getProvenanceHighlight(mark.mi as ProvenanceHighlightLevel)};`
               : '',
         },
       }).range(mark.from, mark.to)


### PR DESCRIPTION
**details**

Have swapped the provenance highlight out for opacity of text
 -> has the 6 (0->5) mi levels from `1 -> 0.5` opacity

in the content <stencila-authorship> component, the opacity is set on the text only (via the `--tw-text-opacity` alpha variable)

for the provenance in the code view, I can only set the elements opacity, this is not ideal, but does have a side effect of varying opacity when the text is selected see image below.

As the text in the codemirror is colored by the language extensions, it would be virtualy impossible to apply the opacity to the text only (until css acutaly creates a `text-opacity` property)

![image](https://github.com/stencila/stencila/assets/73506758/9f59fb37-1947-46e8-afa8-7810c8601fae)




