### PR TITLE
feat(vscode): send message events to webview

### DIFF
--- a/vscode/src/webviews.ts
+++ b/vscode/src/webviews.ts
@@ -39,8 +39,15 @@ export async function createDocumentViewPanel(
 ): Promise<vscode.WebviewPanel> {
   if (documentViewPanels.has(documentUri)) {
     // If there is already a panel open for this document, reveal it
-    let panel = documentViewPanels.get(documentUri);
+    const panel = documentViewPanels.get(documentUri) as vscode.WebviewPanel;
+
     panel.reveal();
+
+    // if `nodeId` param is defined, scroll webview to target node.
+    if (nodeId) {
+      panel.webview.postMessage({ scrollTarget: nodeId });
+    }
+
     return panel;
   }
 
@@ -128,11 +135,22 @@ export async function createDocumentViewPanel(
 
   // Track the webview by adding it to the map
   documentViewPanels.set(documentUri, panel);
-
+  
   // Handle when the webview is disposed
   panel.onDidDispose(() => {
     documentViewPanels.delete(documentUri);
   }, null);
+    
+  // if `nodeId` param is defined, scroll webview panel to target node.
+  if (nodeId) {
+    panel.webview.postMessage({ scrollTarget: nodeId });
+  }
 
   return panel;
+}
+
+export function addScroll () {
+  vscode.window.onDidChangeTextEditorVisibleRanges(e => {
+
+  });
 }

--- a/web/src/ui/nodes/mixins/toggle-chip.ts
+++ b/web/src/ui/nodes/mixins/toggle-chip.ts
@@ -17,6 +17,9 @@ export declare class ChipToggleInterface {
   protected toggle: boolean
   protected toggleChipPosition: string
   protected toggleChip: () => void
+  protected dispatchToggleEvent: () => void
+  public openCard: () => void
+  public closeCard: () => void
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,8 +47,25 @@ export const ToggleChipMixin = <T extends Constructor<UIBaseClass>>(
      */
     protected toggleChipPosition: string = ''
 
+    // ----------------------
+    // public methods for allow opening / closing the card externally.
+    public openCard() {
+      this.toggle = true
+      this.dispatchToggleEvent()
+    }
+
+    public closeCard() {
+      this.toggle = false
+      this.dispatchToggleEvent()
+    }
+    // ---------------------
+
     protected toggleChip() {
       this.toggle = !this.toggle
+      this.dispatchToggleEvent()
+    }
+
+    protected dispatchToggleEvent() {
       this.shadowRoot.dispatchEvent(
         new CustomEvent(`toggle-${this.nodeId}`, {
           bubbles: true,

--- a/web/src/ui/nodes/node-card/on-demand/block.ts
+++ b/web/src/ui/nodes/node-card/on-demand/block.ts
@@ -74,16 +74,6 @@ export class UIBlockOnDemand extends ToggleChipMixin(UIBaseCard) {
 
   protected override toggleCardDisplay() {
     this.toggle = !this.toggle
-
-    this.shadowRoot.dispatchEvent(
-      new CustomEvent(`toggle-${this.nodeId}`, {
-        bubbles: true,
-        composed: true,
-        detail: {
-          cardOpen: this.toggle,
-          nodeId: this.nodeId,
-        },
-      })
-    )
+    this.dispatchToggleEvent()
   }
 }

--- a/web/src/ui/nodes/node-card/on-demand/in-line.ts
+++ b/web/src/ui/nodes/node-card/on-demand/in-line.ts
@@ -128,13 +128,6 @@ export class UIInlineOnDemand extends ToggleChipMixin(UIBaseCard) {
 
   protected override toggleCardDisplay() {
     this.toggle = !this.toggle
-
-    this.shadowRoot.dispatchEvent(
-      new CustomEvent(`toggle-${this.id}`, {
-        bubbles: true,
-        composed: true,
-        detail: { cardOpen: this.toggle, nodeId: this.nodeId },
-      })
-    )
+    this.dispatchToggleEvent()
   }
 }

--- a/web/src/views/vscode.ts
+++ b/web/src/views/vscode.ts
@@ -1,10 +1,20 @@
+import { InlineTypeList } from '@stencila/types'
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
+
+import { Entity } from '../nodes/entity'
+import { DocumentPreviewBase } from '../ui/nodes/mixins/preview-base'
+import { ChipToggleInterface } from '../ui/nodes/mixins/toggle-chip'
+import { UIBaseClass } from '../ui/nodes/mixins/ui-base-class'
 
 import '../nodes'
 import '../shoelace'
 import '../ui/preview-menu'
-import { DocumentPreviewBase } from '../ui/nodes/mixins/preview-base'
+
+type MessagePayload = {
+  // the id of the node to scroll the view to
+  scrollTarget?: string
+}
 
 /**
  * A view for a VSCode WebView preview panel
@@ -13,6 +23,47 @@ import { DocumentPreviewBase } from '../ui/nodes/mixins/preview-base'
  */
 @customElement('stencila-vscode-view')
 export class VsCodeView extends DocumentPreviewBase {
+  protected override createRenderRoot(): this {
+    const lightDom = super.createRenderRoot()
+
+    /**
+     * must be declared here as an arrow func,
+     * in order to bind `this` to the function.
+     */
+    const handleMessages = (e: Event & { data: MessagePayload }) => {
+      const { scrollTarget } = e.data
+      if (scrollTarget) {
+        const targetEl = this.querySelector(`#${e.data.scrollTarget}`) as Entity
+
+        if (targetEl) {
+          targetEl.scrollIntoView({
+            block: 'start',
+            inline: 'nearest',
+            behavior: 'smooth',
+          })
+
+          let cardType = 'stencila-ui-block-on-demand'
+
+          if (InlineTypeList.includes(scrollTarget.constructor.name)) {
+            cardType = 'stencila-ui-inline-on-demand'
+          }
+          const card = targetEl.shadowRoot.querySelector(
+            cardType
+          ) as UIBaseClass & ChipToggleInterface
+
+          if (card) {
+            card.openCard()
+          }
+        }
+      }
+    }
+
+    // add message event listener for messages from the vscode window
+    window.addEventListener('message', handleMessages)
+
+    return lightDom
+  }
+
   protected override render() {
     return html`
       <slot></slot>


### PR DESCRIPTION
**details**

In the vscode view, when the user clicks on the 'view' button above a node in the markdown it will scroll to the relevant node in the webview and open the card.

It uses the `webview.postMessage` method to send an event to the window, which can be picked up in the `vscode` component. 

in this case the message contains a `scrollTarget` property of the id for the node to scroll to.

**related issue**: #2251 