### PR TITLE
refactor(views/vscode.ts): create new webviewclient to handle events

### DIFF
--- a/vscode/src/webviews.ts
+++ b/vscode/src/webviews.ts
@@ -45,7 +45,10 @@ export async function createDocumentViewPanel(
 
     // if `nodeId` param is defined, scroll webview to target node.
     if (nodeId) {
-      panel.webview.postMessage({ scrollTarget: nodeId });
+      panel.webview.postMessage({ 
+        type: 'scroll-to-element', 
+        payload: { scrollTarget: nodeId }
+      });
     }
 
     return panel;
@@ -87,25 +90,32 @@ export async function createDocumentViewPanel(
 
     // Note that that attribute view="dynamic" is used to
     // trigger Web Component to render as if they are in dynamic view
-    return `<!DOCTYPE html>
-<html lang="en">
-  <head>
-      <title>Stencila: Document Preview</title>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link rel="preconnect" href="https://fonts.googleapis.com">
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-      <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10..0,100..900&family=IBM+Plex+Mono:wght@400&display=swap" rel="stylesheet">
-      <link title="theme:${themeName}" rel="stylesheet" type="text/css" href="${themeCss}">
-      <link rel="stylesheet" type="text/css" href="${viewCss}">
-      <script type="text/javascript" src="${viewJs}"></script>
-  </head>
-  <body style="background: white;">
-    <stencila-vscode-view view="dynamic" theme="default">
-      ${content}
-    </stencila-vscode-view>
-  </body>
-</html>`;
+    return `
+    <!DOCTYPE html>
+      <html lang="en">
+        <head>
+            <title>Stencila: Document Preview</title>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <link rel="preconnect" href="https://fonts.googleapis.com">
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+            <link href="https://fonts.googleapis.com/css2?family=Inter:slnt,wght@-10..0,100..900&family=IBM+Plex+Mono:wght@400&display=swap" rel="stylesheet">
+            <link title="theme:${themeName}" rel="stylesheet" type="text/css" href="${themeCss}">
+            <link rel="stylesheet" type="text/css" href="${viewCss}">
+            <script type="text/javascript" src="${viewJs}"></script>
+        </head>
+        <body style="background: white;">
+          <stencila-vscode-view view="dynamic" theme="default">
+            ${content}
+          </stencila-vscode-view>
+
+          <!-- set vscode api -->
+          <script>
+            const vscode = acquireVsCodeApi()
+          </script>
+        </body>
+    </html>
+  `;
   };
 
   const FORMAT = "dom.html";
@@ -143,8 +153,24 @@ export async function createDocumentViewPanel(
     
   // if `nodeId` param is defined, scroll webview panel to target node.
   if (nodeId) {
-    panel.webview.postMessage({ scrollTarget: nodeId });
+    panel.webview.postMessage({ 
+      type: 'scroll-to-element', 
+      payload: { scrollTarget: nodeId }
+    });
   }
+
+  // Handle messages from the webview
+  panel.webview.onDidReceiveMessage(
+    message => {
+      switch (message.command) {
+        case 'error':
+          vscode.window.showErrorMessage(message.text);
+          return;
+      }
+    },
+    undefined,
+    context.subscriptions
+  );
 
   return panel;
 }

--- a/vscode/src/webviews.ts
+++ b/vscode/src/webviews.ts
@@ -43,11 +43,11 @@ export async function createDocumentViewPanel(
 
     panel.reveal();
 
-    // if `nodeId` param is defined, scroll webview to target node.
+    // If `nodeId` param is defined, scroll webview to target node.
     if (nodeId) {
-      panel.webview.postMessage({ 
-        type: 'scroll-to-element', 
-        payload: { scrollTarget: nodeId }
+      panel.webview.postMessage({
+        type: "view-node",
+        nodeId,
       });
     }
 
@@ -145,27 +145,29 @@ export async function createDocumentViewPanel(
 
   // Track the webview by adding it to the map
   documentViewPanels.set(documentUri, panel);
-  
+
   // Handle when the webview is disposed
   panel.onDidDispose(() => {
     documentViewPanels.delete(documentUri);
   }, null);
-    
-  // if `nodeId` param is defined, scroll webview panel to target node.
+
+  // If `nodeId` param is defined, scroll webview panel to target node.
   if (nodeId) {
-    panel.webview.postMessage({ 
-      type: 'scroll-to-element', 
-      payload: { scrollTarget: nodeId }
+    panel.webview.postMessage({
+      type: "view-node",
+      nodeId,
     });
   }
 
   // Handle messages from the webview
   panel.webview.onDidReceiveMessage(
-    message => {
+    (message) => {
       switch (message.command) {
-        case 'error':
+        case "error":
           vscode.window.showErrorMessage(message.text);
           return;
+        default:
+          throw new Error(`Unhandled message: ${message}`);
       }
     },
     undefined,
@@ -173,10 +175,4 @@ export async function createDocumentViewPanel(
   );
 
   return panel;
-}
-
-export function addScroll () {
-  vscode.window.onDidChangeTextEditorVisibleRanges(e => {
-
-  });
 }

--- a/web/src/clients/webview.ts
+++ b/web/src/clients/webview.ts
@@ -1,0 +1,98 @@
+import { InlineTypeList } from '@stencila/types'
+
+import { Entity } from '../nodes/entity'
+import { ChipToggleInterface } from '../ui/nodes/mixins/toggle-chip'
+import { UIBaseClass } from '../ui/nodes/mixins/ui-base-class'
+
+type MessageType = 'scroll-to-element' | 'scroll-track'
+
+type MessagePayload = {
+  type: MessageType
+  payload: {
+    // the id of the node to scroll the view to
+    scrollTarget?: string
+  }
+}
+
+type VSCodeMessage = {
+  command: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [k: string]: any
+}
+
+interface VSCode {
+  postMessage(message: VSCodeMessage): void
+}
+
+declare const vscode: VSCode
+
+/**
+ *
+ */
+export class WebViewClient {
+  constructor(element: HTMLElement) {
+    this.element = element
+    this.setWindowListener()
+  }
+
+  private element: HTMLElement
+
+  static postMessage(message: VSCodeMessage) {
+    console.log('vscode api instance', vscode)
+    vscode.postMessage(message)
+  }
+
+  private setWindowListener() {
+    window.addEventListener('message', this.receiveMessage)
+  }
+
+  /**
+   * Handles 'message' events sent from vscode to the `window`.
+   * uses the event data to determine which handler fucntion to use.
+   * @param e `Event` instance with `data` property carrying payload
+   * @returns `void`
+   */
+  // !!!must be arrow function
+  private receiveMessage = (e: Event & { data: MessagePayload }) => {
+    const { type, payload } = e.data
+
+    switch (type) {
+      case 'scroll-to-element':
+        if (payload.scrollTarget) {
+          this.handleScroll(payload.scrollTarget)
+        }
+        break
+      default:
+        return
+    }
+  }
+
+  /**
+   * handles the 'scroll-to-element' message event
+   * @param scrollTarget #id of target node
+   */
+  // !!!must be arrow function
+  private handleScroll = (scrollTarget: string) => {
+    const targetEl = this.element.querySelector(`#${scrollTarget}`) as Entity
+    console.log('scroll handler', this.element)
+    if (targetEl) {
+      targetEl.scrollIntoView({
+        block: 'start',
+        inline: 'nearest',
+        behavior: 'smooth',
+      })
+
+      let cardType = 'stencila-ui-block-on-demand'
+
+      if (InlineTypeList.includes(scrollTarget.constructor.name)) {
+        cardType = 'stencila-ui-inline-on-demand'
+      }
+      const card = targetEl.shadowRoot.querySelector(cardType) as UIBaseClass &
+        ChipToggleInterface
+
+      if (card) {
+        card.openCard()
+      }
+    }
+  }
+}

--- a/web/src/clients/webview.ts
+++ b/web/src/clients/webview.ts
@@ -24,10 +24,11 @@ interface VSCode {
   postMessage(message: VSCodeMessage): void
 }
 
+// make sure the compiler is aware of the existing `vscode` api instance
 declare const vscode: VSCode
 
 /**
- *
+ * a client object to allow for sending recie
  */
 export class WebViewClient {
   constructor(element: HTMLElement) {
@@ -37,11 +38,21 @@ export class WebViewClient {
 
   private element: HTMLElement
 
+  /**
+   * Sends message to webview panel, via the vscode api instance
+   */
   static postMessage(message: VSCodeMessage) {
-    console.log('vscode api instance', vscode)
     vscode.postMessage(message)
   }
 
+  /**
+   * add an event listener to the window instance for 'message'
+   * events from the webview panel
+   *
+   * nb. any class methods used for/in the event callback must be bound to `this`
+   * if they wish to use properties of `this`. using arrow function
+   * syntax when declaring methods will achieve this.
+   */
   private setWindowListener() {
     window.addEventListener('message', this.receiveMessage)
   }
@@ -74,7 +85,6 @@ export class WebViewClient {
   // !!!must be arrow function
   private handleScroll = (scrollTarget: string) => {
     const targetEl = this.element.querySelector(`#${scrollTarget}`) as Entity
-    console.log('scroll handler', this.element)
     if (targetEl) {
       targetEl.scrollIntoView({
         block: 'start',

--- a/web/src/views/vscode.ts
+++ b/web/src/views/vscode.ts
@@ -1,20 +1,12 @@
-import { InlineTypeList } from '@stencila/types'
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
-import { Entity } from '../nodes/entity'
+import { WebViewClient } from '../clients/webview'
 import { DocumentPreviewBase } from '../ui/nodes/mixins/preview-base'
-import { ChipToggleInterface } from '../ui/nodes/mixins/toggle-chip'
-import { UIBaseClass } from '../ui/nodes/mixins/ui-base-class'
 
 import '../nodes'
 import '../shoelace'
 import '../ui/preview-menu'
-
-type MessagePayload = {
-  // the id of the node to scroll the view to
-  scrollTarget?: string
-}
 
 /**
  * A view for a VSCode WebView preview panel
@@ -23,43 +15,15 @@ type MessagePayload = {
  */
 @customElement('stencila-vscode-view')
 export class VsCodeView extends DocumentPreviewBase {
+  /**
+   * client for handling the messages to and from the vscode webview api
+   */
+  protected webviewClient: WebViewClient
+
   protected override createRenderRoot(): this {
     const lightDom = super.createRenderRoot()
 
-    /**
-     * must be declared here as an arrow func,
-     * in order to bind `this` to the function.
-     */
-    const handleMessages = (e: Event & { data: MessagePayload }) => {
-      const { scrollTarget } = e.data
-      if (scrollTarget) {
-        const targetEl = this.querySelector(`#${e.data.scrollTarget}`) as Entity
-
-        if (targetEl) {
-          targetEl.scrollIntoView({
-            block: 'start',
-            inline: 'nearest',
-            behavior: 'smooth',
-          })
-
-          let cardType = 'stencila-ui-block-on-demand'
-
-          if (InlineTypeList.includes(scrollTarget.constructor.name)) {
-            cardType = 'stencila-ui-inline-on-demand'
-          }
-          const card = targetEl.shadowRoot.querySelector(
-            cardType
-          ) as UIBaseClass & ChipToggleInterface
-
-          if (card) {
-            card.openCard()
-          }
-        }
-      }
-    }
-
-    // add message event listener for messages from the vscode window
-    window.addEventListener('message', handleMessages)
+    this.webviewClient = new WebViewClient(lightDom)
 
     return lightDom
   }


### PR DESCRIPTION
**details**

Created a new client class for the vscode webview (`WebViewClient`)

This client recieves and handles the 'message' events.

right now, in practice this is merely a refactoring of current functionality. as we only have one event type active, but this can be expanded upon.
For sending messages it has a static method `postMessage` which can be used to send commands to the panel vis the `vscode` api instance which has to be declared in the `panel.webview.html` string.

if you want to test this works add the line to a lifecycle hook of any element and you should see an error alert pop up in vscode.
```
WebViewClient.postMessage({ command: 'error', text: 'test' } )
```
