### PR TITLE
fix(if block): improve web component

### DIFF
--- a/examples/kernels/if-block/standalone-polyglot.json
+++ b/examples/kernels/if-block/standalone-polyglot.json
@@ -8,7 +8,51 @@
       "clauses": [
         {
           "type": "IfBlockClause",
-          "code": "false",
+          "code": {
+            "string": "false"
+          },
+          "programmingLanguage": "js",
+          "isActive": false,
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "Text",
+                  "value": {
+                    "string": "QuickJS is falsy"
+                  }
+                }
+              ]
+            }
+          ],
+          "compilationDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 10842557425490069685
+          },
+          "executionDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 10842557425490069685
+          },
+          "executionCount": 1,
+          "executionRequired": "No",
+          "executionStatus": "Succeeded",
+          "executionEnded": {
+            "type": "Timestamp",
+            "value": 1720133120967,
+            "timeUnit": "Millisecond"
+          },
+          "executionDuration": {
+            "type": "Duration",
+            "value": 5,
+            "timeUnit": "Millisecond"
+          }
+        },
+        {
+          "type": "IfBlockClause",
+          "code": {
+            "string": "false"
+          },
           "programmingLanguage": "nodejs",
           "isActive": false,
           "content": [
@@ -17,28 +61,40 @@
               "content": [
                 {
                   "type": "Text",
-                  "value": "Node.js is wrong"
+                  "value": {
+                    "string": "Node.js is falsy"
+                  }
                 }
               ]
             }
           ],
+          "compilationDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 10146776635162061319
+          },
+          "executionDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 10146776635162061319
+          },
           "executionCount": 1,
           "executionRequired": "No",
           "executionStatus": "Succeeded",
           "executionEnded": {
             "type": "Timestamp",
-            "value": 1714644393620,
+            "value": 1720133121112,
             "timeUnit": "Millisecond"
           },
           "executionDuration": {
             "type": "Duration",
-            "value": 170,
+            "value": 144,
             "timeUnit": "Millisecond"
           }
         },
         {
           "type": "IfBlockClause",
-          "code": "False",
+          "code": {
+            "string": "False"
+          },
           "programmingLanguage": "python",
           "isActive": false,
           "content": [
@@ -47,28 +103,40 @@
               "content": [
                 {
                   "type": "Text",
-                  "value": "Python is wrong"
+                  "value": {
+                    "string": "Python is falsy"
+                  }
                 }
               ]
             }
           ],
+          "compilationDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 13742482793603365424
+          },
+          "executionDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 13742482793603365424
+          },
           "executionCount": 1,
           "executionRequired": "No",
           "executionStatus": "Succeeded",
           "executionEnded": {
             "type": "Timestamp",
-            "value": 1714644394116,
+            "value": 1720133121601,
             "timeUnit": "Millisecond"
           },
           "executionDuration": {
             "type": "Duration",
-            "value": 496,
+            "value": 489,
             "timeUnit": "Millisecond"
           }
         },
         {
           "type": "IfBlockClause",
-          "code": "FALSE",
+          "code": {
+            "string": "FALSE"
+          },
           "programmingLanguage": "r",
           "isActive": false,
           "content": [
@@ -77,28 +145,40 @@
               "content": [
                 {
                   "type": "Text",
-                  "value": "R is wrong"
+                  "value": {
+                    "string": "R is falsy"
+                  }
                 }
               ]
             }
           ],
+          "compilationDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 15000900910887471719
+          },
+          "executionDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 15000900910887471719
+          },
           "executionCount": 1,
           "executionRequired": "No",
           "executionStatus": "Succeeded",
           "executionEnded": {
             "type": "Timestamp",
-            "value": 1714644394388,
+            "value": 1720133121859,
             "timeUnit": "Millisecond"
           },
           "executionDuration": {
             "type": "Duration",
-            "value": 271,
+            "value": 258,
             "timeUnit": "Millisecond"
           }
         },
         {
           "type": "IfBlockClause",
-          "code": "false",
+          "code": {
+            "string": "false"
+          },
           "programmingLanguage": "rhai",
           "isActive": false,
           "content": [
@@ -107,17 +187,27 @@
               "content": [
                 {
                   "type": "Text",
-                  "value": "Rhai is wrong"
+                  "value": {
+                    "string": "Rhai is falsy"
+                  }
                 }
               ]
             }
           ],
+          "compilationDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 3301966588861366618
+          },
+          "executionDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 3301966588861366618
+          },
           "executionCount": 1,
           "executionRequired": "No",
           "executionStatus": "Succeeded",
           "executionEnded": {
             "type": "Timestamp",
-            "value": 1714644394391,
+            "value": 1720133121862,
             "timeUnit": "Millisecond"
           },
           "executionDuration": {
@@ -128,7 +218,9 @@
         },
         {
           "type": "IfBlockClause",
-          "code": "",
+          "code": {
+            "string": ""
+          },
           "isActive": true,
           "content": [
             {
@@ -136,17 +228,27 @@
               "content": [
                 {
                   "type": "Text",
-                  "value": "They are all right!"
+                  "value": {
+                    "string": "They are all falsy!"
+                  }
                 }
               ]
             }
           ],
+          "compilationDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 9336520420413539212
+          },
+          "executionDigest": {
+            "type": "CompilationDigest",
+            "stateDigest": 9336520420413539212
+          },
           "executionCount": 1,
           "executionRequired": "No",
           "executionStatus": "Succeeded",
           "executionEnded": {
             "type": "Timestamp",
-            "value": 1714644394391,
+            "value": 1720133121862,
             "timeUnit": "Millisecond"
           },
           "executionDuration": {
@@ -156,17 +258,25 @@
           }
         }
       ],
+      "compilationDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 14171230512661982567
+      },
+      "executionDigest": {
+        "type": "CompilationDigest",
+        "stateDigest": 14171230512661982567
+      },
       "executionCount": 1,
       "executionRequired": "No",
       "executionStatus": "Succeeded",
       "executionEnded": {
         "type": "Timestamp",
-        "value": 1714644394391,
+        "value": 1720133121862,
         "timeUnit": "Millisecond"
       },
       "executionDuration": {
         "type": "Duration",
-        "value": 941,
+        "value": 901,
         "timeUnit": "Millisecond"
       }
     }
@@ -176,12 +286,12 @@
   "executionStatus": "Succeeded",
   "executionEnded": {
     "type": "Timestamp",
-    "value": 1714644394391,
+    "value": 1720133121862,
     "timeUnit": "Millisecond"
   },
   "executionDuration": {
     "type": "Duration",
-    "value": 942,
+    "value": 901,
     "timeUnit": "Millisecond"
   }
 }

--- a/examples/kernels/if-block/standalone-polyglot.md
+++ b/examples/kernels/if-block/standalone-polyglot.md
@@ -1,21 +1,25 @@
-::: if false {nodejs}
+::: if false {js}
 
-Node.js is wrong
+QuickJS is falsy
+
+::: elif false {nodejs}
+
+Node.js is falsy
 
 ::: elif False {python}
 
-Python is wrong
+Python is falsy
 
 ::: elif FALSE {r}
 
-R is wrong
+R is falsy
 
 ::: elif false {rhai}
 
-Rhai is wrong
+Rhai is falsy
 
 ::: else
 
-They are all right!
+They are all falsy!
 
 :::

--- a/web/src/assets/icons/clause-elif.svg
+++ b/web/src/assets/icons/clause-elif.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+<g>
+<path d="M15.5 19.5L19 16L15.5 12.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18 16H10C7.79086 16 6 14.2091 6 12V5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10 5L10 13" stroke-width="1.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/web/src/assets/icons/clause-else.svg
+++ b/web/src/assets/icons/clause-else.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+<g>
+<path d="M7 15L11 18.5L15 15" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 18V5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 5L15 11" stroke-width="1.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/web/src/assets/icons/clause-if.svg
+++ b/web/src/assets/icons/clause-if.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" xmlns="http://www.w3.org/2000/svg">
+<g>
+<path d="M13.25 19.25L16.75 15.75L13.25 12.25" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.75 15.75H10.75C8.54086 15.75 6.75 13.9591 6.75 11.75V4.75" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/web/src/nodes/code-block.ts
+++ b/web/src/nodes/code-block.ts
@@ -34,9 +34,11 @@ export class CodeBlock extends CodeStatic {
           <stencila-ui-node-code
             type="CodeBlock"
             code=${this.code}
-            code-authorship=${this.codeAuthorship}
+            .code-authorship=${this.codeAuthorship}
             language=${this.programmingLanguage}
             read-only
+            no-gutters
+            containerClasses="border border-black/20"
           >
           </stencila-ui-node-code>
         </div>

--- a/web/src/nodes/code-chunk.ts
+++ b/web/src/nodes/code-chunk.ts
@@ -78,7 +78,7 @@ export class CodeChunk extends CodeExecutable {
         <stencila-ui-node-code
           type="CodeChunk"
           code=${this.code}
-          code-authorship=${this.codeAuthorship}
+          .code-authorship=${this.codeAuthorship}
           language=${this.programmingLanguage}
           read-only
         >

--- a/web/src/nodes/if-block-clause.ts
+++ b/web/src/nodes/if-block-clause.ts
@@ -1,8 +1,9 @@
 import { html } from 'lit'
-import { customElement, property } from 'lit/decorators.js'
+import { customElement, property, state } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
 import '../ui/nodes/card'
+import { nodeUi } from '../ui/nodes/icons-and-colours'
 
 import { CodeExecutable } from './code-executable'
 
@@ -15,96 +16,108 @@ import { CodeExecutable } from './code-executable'
 @withTwind()
 export class IfBlockClause extends CodeExecutable {
   /**
+   * Whether the clause is the active branch of the parent `IfBlock`
+   *
+   * Note: this is not a boolean property, it is a string that looks
+   * like a boolean :)
+   */
+  @property({ attribute: 'is-active' })
+  isActive?: 'true' | 'false'
+
+  /**
    * Whether the clause has any content
    *
    * This state is used to determine whether to render placeholder
-   * text if there is no content.
+   * text if there is no content for the clause.
    *
    * @see this.renderContent()
    */
-  // @state()
-  // private hasContent = false
+  @state()
+  private hasContent = false
 
   /**
    * A mutation observer to update the `hasContent` state when
    * the `content` slot changes
    */
-  // private contentObserver: MutationObserver
+  private contentObserver: MutationObserver
 
   /**
    * Handle a change, including on initial load, of the `content` slot
    */
-  // private onContentSlotChange(event: Event) {
-  //   // Get the slot element
-  //   const contentElem = (event.target as HTMLSlotElement).assignedElements({
-  //     flatten: true,
-  //   })[0]
+  private onContentSlotChange(event: Event) {
+    // Get the slot element
+    const contentElem = (event.target as HTMLSlotElement).assignedElements({
+      flatten: true,
+    })[0]
 
-  //   // Set current state
-  //   this.hasContent = contentElem.childElementCount > 0
+    // Set current state
+    this.hasContent = contentElem.childElementCount > 0
 
-  //   // Update the state when the slot is mutated
-  //   this.contentObserver = new MutationObserver(() => {
-  //     this.hasContent = contentElem.childElementCount > 0
-  //   })
-  //   this.contentObserver.observe(contentElem, {
-  //     childList: true,
-  //   })
-  // }
-
-  /**
-   * will be true if this clause is the current 'path' of the parent `IfBlock`
-   */
-  @property({ type: Boolean, attribute: 'is-active' })
-  isActive: boolean
-
-  override render() {
-    return html`
-      <stencila-ui-block-on-demand
-        type="IfBlockClause"
-        view="dynamic"
-        depth=${this.depth}
-        ancestors=${this.ancestors}
-      >
-        <div slot="body" class="h-full">
-          <stencila-ui-node-authors type="IfBlockClause">
-            <stencila-ui-node-provenance slot="provenance">
-              <slot name="provenance"></slot>
-            </stencila-ui-node-provenance>
-            <slot name="authors"></slot>
-          </stencila-ui-node-authors>
-          <stencila-ui-node-code
-            type="IfBlockClause"
-            code=${this.code}
-            language=${this.programmingLanguage}
-            read-only
-          >
-            <slot name="execution-messages"></slot>
-          </stencila-ui-node-code>
-        </div>
-        <div slot="content">
-          <slot name="content"></slot>
-        </div>
-      </stencila-ui-block-on-demand>
-    `
+    // Update the state when the slot is mutated
+    this.contentObserver = new MutationObserver(() => {
+      this.hasContent = contentElem.childElementCount > 0
+    })
+    this.contentObserver.observe(contentElem, {
+      childList: true,
+    })
   }
 
-  // override render() {
-  //   return html` <div>${this.renderHeader()} ${this.renderContent()}</div> `
-  // }
+  override render() {
+    const { colour, borderColour, textColour } = nodeUi('IfBlock')
 
-  // private renderHeader() {
-  //   return html` <div contenteditable="false">${this.renderMessages()}</div> `
-  // }
+    const isActive = this.isActive == 'true'
 
-  // private renderContent() {
-  //   return html`
-  //     <div>
-  //       <p class="text-grey-400" contenteditable="false">
-  //         ${this.hasContent ? '' : 'No content'}
-  //       </p>
-  //       <slot name="content" @slotchange=${this.onContentSlotChange}></slot>
-  //     </div>
-  //   `
-  // }
+    const siblings = [...this.parentElement.children]
+    const index = siblings.findIndex((elem) => elem === this)
+    let label
+    if (index === 0) {
+      label = 'if'
+    } else if (index == siblings.length - 1 && this.code.length == 0) {
+      label = 'else'
+    } else {
+      label = 'elif'
+    }
+
+    const borderPosition = index == siblings.length - 1 ? '0' : 'b'
+
+    return html`
+      <!-- TODO: this header should hidden when the parent IfBlock is collapsed -->
+      <div
+        class="px-1 py-3 bg-[${colour}] border-${borderPosition} border-[${borderColour}]"
+      >
+        <!-- TODO: add icon, preferably different for if, elif and else -->
+
+        <span class="${isActive
+          ? `rounded ring-2 ring-[${textColour}] ring-offset-4 ring-offset-[${colour}]`
+          : ''} font-bold font-mono text-[${textColour}] m-3"
+          >${label}</span>
+
+        <!-- TODO: improve appearance of this code: rounded borders?, minimum width or full width-->
+        <stencila-ui-node-code
+          type="IfBlock"
+          code=${this.code}
+          .code-authorship=${this.codeAuthorship}
+          language=${this.programmingLanguage}
+          read-only
+          no-gutters
+          containerClasses="inline-block border border-[${borderColour}]"
+          class=${label === 'else' ? 'hidden' : ''}
+        >
+          <slot name="execution-messages"></slot>
+        </stencila-ui-node-code>
+
+        <!-- TODO: use icon for lang if available, if not then the name in a pill or something -->
+        <span class="font-mono text-[${textColour}]">${this.programmingLanguage ?? ''}</span>
+
+        <!-- TODO: Add a chevron to collapse/expand the content, regardless of if active or not -->
+      </div>
+
+      <div class="p-1 ${isActive ? '' : 'hidden'}">
+        <p class="text-center text-grey-400 italic" contenteditable="false">
+          ${this.hasContent ? '' : 'No content'}
+        </p>
+        <slot name="content" @slotchange=${this.onContentSlotChange}></slot>
+      </div>
+    `
+  }
 }

--- a/web/src/nodes/if-block-clause.ts
+++ b/web/src/nodes/if-block-clause.ts
@@ -134,12 +134,12 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
         class="p-3 flex items-center text-[${textColour}] bg-[${colour}] border-${borderPosition} border-[${borderColour}]"
       >
         <sl-icon
-          name=${label === 'else' ? 'node-minus' : 'node-plus'}
-          library="default"
-          class="text-lg"
+          name="clause-${label}"
+          library="stencila"
+          class="text-lg text-${textColour}"
         >
         </sl-icon>
-        <span class="font-bold font-mono mx-3 min-w-[4rem]">
+        <span class="font-bold font-mono mx-3 min-w-[3rem]">
           <span
             class="${this.isActive === 'true'
               ? `rounded ring-2 ring-[${textColour}] ring-offset-4 ring-offset-[${colour}]`
@@ -155,8 +155,10 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
           language=${this.programmingLanguage}
           read-only
           no-gutters
-          containerClasses="inline-block border border-[${borderColour}] rounded overflow-hidden mr-2"
-          class=${label === 'else' ? 'hidden' : 'flex items-center'}
+          containerClasses="inline-block w-full border border-[${borderColour}] rounded overflow-hidden"
+          class=${label === 'else'
+            ? 'hidden'
+            : 'flex-grow flex items-center mr-4'}
         >
           <slot name="execution-messages"></slot>
         </stencila-ui-node-code>
@@ -188,12 +190,14 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
             }
 
       return html`
-        <sl-icon
-          class="text-lg"
-          name=${iconName}
-          library=${iconLibrary}
-        ></sl-icon
-        ><span class="text-sm ml-1">${displayName}</span>
+        <div class="mr-4 flex items-center">
+          <sl-icon
+            class="text-lg"
+            name=${iconName}
+            library=${iconLibrary}
+          ></sl-icon
+          ><span class="text-sm ml-1">${displayName}</span>
+        </div>
       `
     }
     return ''

--- a/web/src/nodes/if-block-clause.ts
+++ b/web/src/nodes/if-block-clause.ts
@@ -168,15 +168,23 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
   }
 
   protected renderLang() {
+    const { textColour } = nodeUi('IfBlock')
     if (this.programmingLanguage) {
       if (this.programmingLanguage in this.languages) {
         const lang =
           this.languages[this.programmingLanguage as AvailableLanguages]
         return html`
-          <sl-icon name=${lang.icon[0]} library=${lang.icon[1]}></sl-icon>
+          <sl-icon
+            class="text-lg"
+            name=${lang.icon[0]}
+            library=${lang.icon[1]}
+          ></sl-icon>
         `
       } else {
-        return html`<span class="font-mono">${this.programmingLanguage}</span>`
+        return html`<span
+          class="font-mono text-sm px-2 border border-[${textColour}] rounded-full"
+          >${this.programmingLanguage}</span
+        > `
       }
     }
     return ''

--- a/web/src/nodes/if-block-clause.ts
+++ b/web/src/nodes/if-block-clause.ts
@@ -1,12 +1,13 @@
 import { consume } from '@lit/context'
-import { html } from 'lit'
+import { html, PropertyValues } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 
 import '../ui/nodes/card'
-
 import { withTwind } from '../twind'
+import { AvailableLanguages } from '../types'
 import { EntityContext, entityContext } from '../ui/nodes/context'
 import { nodeUi } from '../ui/nodes/icons-and-colours'
+import { AvailableLanguagesMixin } from '../ui/nodes/mixins/language'
 
 import { CodeExecutable } from './code-executable'
 
@@ -17,7 +18,7 @@ import { CodeExecutable } from './code-executable'
  */
 @customElement('stencila-if-block-clause')
 @withTwind()
-export class IfBlockClause extends CodeExecutable {
+export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
   /**
    * Whether the clause is the active branch of the parent `IfBlock`
    *
@@ -76,15 +77,35 @@ export class IfBlockClause extends CodeExecutable {
     })
   }
 
-  override connectedCallback(): void {
-    super.connectedCallback()
-    this.isFolded = this.isActive === 'false'
+  protected override update(changedProperties: PropertyValues): void {
+    super.update(changedProperties)
+
+    if (changedProperties.has('ifBlockConsumer')) {
+      // if card is closed only active path stays open
+      if (!this.ifBlockConsumer.cardOpen) {
+        this.isFolded = this.isActive === 'false'
+      }
+    }
   }
 
   override render() {
-    const { colour, borderColour, textColour } = nodeUi('IfBlock')
+    return html`
+      ${this.ifBlockConsumer.cardOpen ? this.renderHeader() : ''}
+      <stencila-ui-collapsible-animation
+        class=${!this.isFolded ? 'opened' : ''}
+      >
+        <div class="p-3">
+          <p class="text-center text-grey-400 italic" contenteditable="false">
+            ${this.hasContent ? '' : 'No content'}
+          </p>
+          <slot name="content" @slotchange=${this.onContentSlotChange}></slot>
+        </div>
+      </stencila-ui-collapsible-animation>
+    `
+  }
 
-    const isActive = this.isActive == 'true'
+  protected renderHeader() {
+    const { colour, borderColour, textColour } = nodeUi('IfBlock')
 
     const siblings = [...this.parentElement.children]
     const index = siblings.findIndex((elem) => elem === this)
@@ -97,65 +118,67 @@ export class IfBlockClause extends CodeExecutable {
       label = 'elif'
     }
 
-    const borderPosition = index == siblings.length - 1 ? '0' : 'b'
+    const borderPosition = index === siblings.length - 1 ? '0' : 'b'
+
     return html`
-      <!-- TODO: this header should hidden when the parent IfBlock is collapsed -->
-      ${this.ifBlockConsumer.cardOpen
-        ? html`<div
-            class="p-3 flex items-center text-[${textColour}] bg-[${colour}] border-${borderPosition} border-[${borderColour}]"
-          >
-            <!-- TODO: add icon, preferably different for if, elif and else -->
-            <sl-icon
-              name=${label === 'else' ? 'node-minus' : 'node-plus'}
-              library="default"
-              class="text-lg"
-            >
-            </sl-icon>
-            <span
-              class="${isActive
-                ? `rounded ring-2 ring-[${textColour}] ring-offset-4 ring-offset-[${colour}]`
-                : ''} font-bold font-mono mx-3"
-              >${label}</span
-            >
-
-            <!-- TODO: improve appearance of this code: rounded borders?, minimum width or full width-->
-            <stencila-ui-node-code
-              type="IfBlock"
-              code=${this.code}
-              .code-authorship=${this.codeAuthorship}
-              language=${this.programmingLanguage}
-              read-only
-              no-gutters
-              containerClasses="inline-block border border-[${borderColour}]"
-              class=${label === 'else' ? 'hidden' : ''}
-            >
-              <slot name="execution-messages"></slot>
-            </stencila-ui-node-code>
-
-            <!-- TODO: use icon for lang if available, if not then the name in a pill or something -->
-            <span class="font-mono">${this.programmingLanguage ?? ''}</span>
-
-            <stencila-chevron-button
-              class="ml-auto"
-              default-pos=${this.isFolded ? 'left' : 'down'}
-              slot="right-side"
-              custom-class="flex items-center"
-              .clickEvent=${() => (this.isFolded = !this.isFolded)}
-            ></stencila-chevron-button>
-
-            <!-- TODO: Add a chevron to collapse/expand the content, regardless of if active or not -->
-          </div>`
-        : ''}
-      <stencila-ui-collapsible-animation
-        class=${!this.isFolded ? 'opened' : ''}
+      <div
+        class="p-3 flex items-center text-[${textColour}] bg-[${colour}] border-${borderPosition} border-[${borderColour}]"
       >
-        <div class="p-3">
-          <p class="text-center text-grey-400 italic" contenteditable="false">
-            ${this.hasContent ? '' : 'No content'}
-          </p>
-          <slot name="content" @slotchange=${this.onContentSlotChange}></slot>
-        </div>
-      </stencila-ui-collapsible-animation>
+        <sl-icon
+          name=${label === 'else' ? 'node-minus' : 'node-plus'}
+          library="default"
+          class="text-lg"
+        >
+        </sl-icon>
+        <span class="font-bold font-mono mx-3 min-w-[4rem]">
+          <span
+            class="${this.isActive === 'true'
+              ? `rounded ring-2 ring-[${textColour}] ring-offset-4 ring-offset-[${colour}]`
+              : ''}"
+            >${label}</span
+          >
+        </span>
+
+        <!-- TODO: improve appearance of this code: rounded borders?, minimum width or full width-->
+        <stencila-ui-node-code
+          type="IfBlock"
+          code=${this.code}
+          .code-authorship=${this.codeAuthorship}
+          language=${this.programmingLanguage}
+          read-only
+          no-gutters
+          containerClasses="inline-block border border-[${borderColour}] rounded overflow-hidden mr-2"
+          class=${label === 'else' ? 'hidden' : 'flex items-center'}
+        >
+          <slot name="execution-messages"></slot>
+        </stencila-ui-node-code>
+
+        <!-- TODO: use icon for lang if available, if not then the name in a pill or something -->
+        ${this.renderLang()}
+
+        <stencila-chevron-button
+          class="ml-auto"
+          default-pos=${this.isFolded ? 'left' : 'down'}
+          slot="right-side"
+          custom-class="flex items-center"
+          .clickEvent=${() => (this.isFolded = !this.isFolded)}
+        ></stencila-chevron-button>
+      </div>
     `
+  }
+
+  protected renderLang() {
+    if (this.programmingLanguage) {
+      if (this.programmingLanguage in this.languages) {
+        const lang =
+          this.languages[this.programmingLanguage as AvailableLanguages]
+        return html`
+          <sl-icon name=${lang.icon[0]} library=${lang.icon[1]}></sl-icon>
+        `
+      } else {
+        return html`<span class="font-mono">${this.programmingLanguage}</span>`
+      }
+    }
+    return ''
   }
 }

--- a/web/src/nodes/if-block-clause.ts
+++ b/web/src/nodes/if-block-clause.ts
@@ -139,7 +139,6 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
           >
         </span>
 
-        <!-- TODO: improve appearance of this code: rounded borders?, minimum width or full width-->
         <stencila-ui-node-code
           type="IfBlock"
           code=${this.code}
@@ -153,7 +152,6 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
           <slot name="execution-messages"></slot>
         </stencila-ui-node-code>
 
-        <!-- TODO: use icon for lang if available, if not then the name in a pill or something -->
         ${this.renderLang()}
 
         <stencila-chevron-button

--- a/web/src/nodes/if-block-clause.ts
+++ b/web/src/nodes/if-block-clause.ts
@@ -2,7 +2,9 @@ import { consume } from '@lit/context'
 import { html, PropertyValues } from 'lit'
 import { customElement, property, state } from 'lit/decorators.js'
 
-import '../ui/nodes/card'
+import '../ui/nodes/properties/code/code'
+import '../ui/animation/collapsible'
+
 import { withTwind } from '../twind'
 import { AvailableLanguages } from '../types'
 import { EntityContext, entityContext } from '../ui/nodes/context'
@@ -28,16 +30,23 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
   @property({ attribute: 'is-active' })
   isActive?: 'true' | 'false'
 
-  @state()
-  private isFolded: boolean = true
-
   /**
-   * consumer for the parent `IfBlock` node's entity context
-   * used to check the card status of the
+   * Consumer for the parent `IfBlock` node's entity context
+   *
+   * Used to check whether the card for the `IfBlock` that this clause
+   * is a member of is open or not. If it is open, the content of
+   * all clauses should be visible. If it is closed, only the content
+   * of the active clauses should be visible.
    */
   @consume({ context: entityContext, subscribe: true })
   @state()
   private ifBlockConsumer: EntityContext
+
+  /**
+   * Whether the clause is folded (i.e. its content is hidden)
+   */
+  @state()
+  private isFolded: boolean = true
 
   /**
    * Whether the clause has any content
@@ -152,7 +161,7 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
           <slot name="execution-messages"></slot>
         </stencila-ui-node-code>
 
-        ${this.renderLang()}
+        ${this.renderLanguage()}
 
         <stencila-chevron-button
           class="ml-auto"
@@ -165,25 +174,27 @@ export class IfBlockClause extends AvailableLanguagesMixin(CodeExecutable) {
     `
   }
 
-  protected renderLang() {
-    const { textColour } = nodeUi('IfBlock')
+  protected renderLanguage() {
     if (this.programmingLanguage) {
-      if (this.programmingLanguage in this.languages) {
-        const lang =
-          this.languages[this.programmingLanguage as AvailableLanguages]
-        return html`
-          <sl-icon
-            class="text-lg"
-            name=${lang.icon[0]}
-            library=${lang.icon[1]}
-          ></sl-icon>
-        `
-      } else {
-        return html`<span
-          class="font-mono text-sm px-2 border border-[${textColour}] rounded-full"
-          >${this.programmingLanguage}</span
-        > `
-      }
+      const {
+        displayName,
+        icon: [iconName, iconLibrary],
+      } =
+        this.programmingLanguage in this.languages
+          ? this.languages[this.programmingLanguage as AvailableLanguages]
+          : {
+              displayName: this.programmingLanguage,
+              icon: this.languages['default'].icon,
+            }
+
+      return html`
+        <sl-icon
+          class="text-lg"
+          name=${iconName}
+          library=${iconLibrary}
+        ></sl-icon
+        ><span class="text-sm ml-1">${displayName}</span>
+      `
     }
     return ''
   }

--- a/web/src/nodes/if-block.ts
+++ b/web/src/nodes/if-block.ts
@@ -21,7 +21,14 @@ export class IfBlock extends Executable {
         depth=${this.depth}
         ancestors=${this.ancestors}
       >
-        <span slot="header-right"></span>
+        <span slot="header-right">
+          <stencila-ui-node-execution-commands
+            type="IfBlock"
+            node-id=${this.id}
+          >
+          </stencila-ui-node-execution-commands>
+        </span>
+
         <div slot="body" class="h-full">
           <stencila-ui-node-execution-details
             type="IfBlock"
@@ -53,7 +60,9 @@ export class IfBlock extends Executable {
             <slot name="execution-messages"></slot>
           </stencila-ui-node-execution-messages>
         </div>
+
         <div slot="content">
+          <!-- TODO: remove padding because clauses have it around their content-->
           <slot name="clauses"></slot>
         </div>
       </stencila-ui-block-on-demand>

--- a/web/src/nodes/if-block.ts
+++ b/web/src/nodes/if-block.ts
@@ -20,6 +20,8 @@ export class IfBlock extends Executable {
         type="IfBlock"
         depth=${this.depth}
         ancestors=${this.ancestors}
+        node-id=${this.id}
+        ?removeContentPadding=${true}
       >
         <span slot="header-right">
           <stencila-ui-node-execution-commands
@@ -62,7 +64,6 @@ export class IfBlock extends Executable {
         </div>
 
         <div slot="content">
-          <!-- TODO: remove padding because clauses have it around their content-->
           <slot name="clauses"></slot>
         </div>
       </stencila-ui-block-on-demand>

--- a/web/src/ui/nodes/mixins/language.ts
+++ b/web/src/ui/nodes/mixins/language.ts
@@ -9,10 +9,15 @@ export declare class AvailableLanguagesInterface {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T> = new (...args: any[]) => T
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AbstractContructor<T> = abstract new (...args: any[]) => T
+
 /**
  * A mixin that supplies available programming languages & their icons.
  */
-export const AvailableLanguagesMixin = <T extends Constructor<LitElement>>(
+export const AvailableLanguagesMixin = <
+  T extends Constructor<LitElement> | AbstractContructor<LitElement>,
+>(
   superClass: T
 ) => {
   class AvailableLanguages extends superClass {

--- a/web/src/ui/nodes/node-card/on-demand/block.ts
+++ b/web/src/ui/nodes/node-card/on-demand/block.ts
@@ -1,7 +1,7 @@
 import '@shoelace-style/shoelace/dist/components/icon/icon'
 import { apply } from '@twind/core'
 import { html } from 'lit'
-import { customElement } from 'lit/decorators'
+import { customElement, property } from 'lit/decorators'
 
 import { withTwind } from '../../../../twind'
 import '../../../animation/collapsible'
@@ -17,6 +17,9 @@ import { UIBaseCard } from '../base-card'
 @customElement('stencila-ui-block-on-demand')
 @withTwind()
 export class UIBlockOnDemand extends ToggleChipMixin(UIBaseCard) {
+  @property({ type: Boolean })
+  removeContentPadding = false
+
   protected override toggleChipPosition: string = ''
 
   override render() {
@@ -58,7 +61,7 @@ export class UIBlockOnDemand extends ToggleChipMixin(UIBaseCard) {
   protected override renderContent() {
     const contentStyles = apply([
       'transition-[padding] ease-in-out duration-[250ms]',
-      this.toggle && 'p-3',
+      this.toggle && (this.removeContentPadding ? '' : 'p-3'),
     ])
 
     return html`

--- a/web/src/ui/nodes/properties/code/code.ts
+++ b/web/src/ui/nodes/properties/code/code.ts
@@ -33,6 +33,9 @@ import {
 @customElement('stencila-ui-node-code')
 @withTwind()
 export class UINodeCode extends LitElement {
+  /**
+   * The type of node whose code is being rendered
+   */
   @property()
   type: NodeType
 
@@ -43,10 +46,22 @@ export class UINodeCode extends LitElement {
   code: string
 
   /**
+   * The runs of authorship of the code
+   */
+  @property({ attribute: 'code-authorship', type: Array })
+  codeAuthorship?: AuthorshipRun[]
+
+  /**
    * The language of the code. Used to determine the syntax highlighting
    */
   @property()
   language: string
+
+  /**
+   * Whether line number and other gutters should be shown
+   */
+  @property({ type: Boolean, attribute: 'no-gutters' })
+  noGutters: boolean = false
 
   /**
    * Whether the code, and language, are readonly or not
@@ -55,16 +70,16 @@ export class UINodeCode extends LitElement {
   readOnly: boolean = false
 
   /**
-   * The runs of authorship of the code
-   */
-  @property({ attribute: 'code-authorship', type: Array })
-  codeAuthorship?: AuthorshipRun[]
-
-  /**
    * Whether the code shown be collapsed by default or not
    */
   @property({ type: Boolean })
   collapsed: boolean = false
+
+  /**
+   * Classes to apply to the editor container
+   */
+  @property()
+  containerClasses: string = 'border-t border-black/20'
 
   /**
    * A CodeMirror editor for the code
@@ -188,8 +203,7 @@ export class UINodeCode extends LitElement {
           ]
         : [],
       ...languageExtension,
-      this.type !== 'CodeBlock' ? [lineNumbers(), foldGutter()] : [],
-      // foldGutter(),
+      this.noGutters ? [] : [lineNumbers(), foldGutter()],
       syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
       executionMessages ? executionMessageLinter(executionMessages) : [],
       stencilaTheme,
@@ -307,15 +321,12 @@ export class UINodeCode extends LitElement {
   }
 
   override render() {
+    const containerClasses = apply(['relative z-0', this.containerClasses])
+
     const contentClasses = apply([
       'text-black',
       this.collapsed ? 'max-h-0' : 'max-h-full',
       'transition-max-h duration-200',
-    ])
-
-    const containerClasses = apply([
-      'relative z-0',
-      `${this.type !== 'CodeBlock' ? 'border-t' : 'border'} border-black/20`,
     ])
 
     // Unable to use `<stencila-ui-node-collapsible-property>` for this as that prevents


### PR DESCRIPTION
Our designs for `IfBlock`s look like this:

![image](https://github.com/stencila/stencila/assets/1152336/d215f02b-406b-4275-b930-26908356bebf)

My first iteration towards those designs are:

![Screenshot from 2024-07-05 10-44-35](https://github.com/stencila/stencila/assets/1152336/b39b9c48-7297-4ec5-b6a0-447bc9045fb4)

Note that we do not need the editing elements such as trash can, drag and drop grips, or language select right now.

@mike-parkin Could you take this over. There are several TODOs in `web/src/nodes/if-block.ts` and `web/src/nodes/if-block-clause.ts`.

Also, it would be good to fix this z-index issue if possible:

![Screenshot from 2024-07-05 10-25-14](https://github.com/stencila/stencila/assets/1152336/d6258f0b-6c0b-4b19-a76c-573afbe09e5b)
