### PR TITLE
refactor: use inline for code output datatype nodes

### DIFF
--- a/web/src/assets/icons/array.svg
+++ b/web/src/assets/icons/array.svg
@@ -1,3 +1,3 @@
-<svg fill="none" height="16" viewBox="0 0 16 16" fill="currentColor" width="16" xmlns="http://www.w3.org/2000/svg">
+<svg height="16" viewBox="0 0 16 16" fill="currentColor" width="16" xmlns="http://www.w3.org/2000/svg">
   <path clip-rule="evenodd" d="m2.5 2c-.27614 0-.5.22386-.5.5v10c0 .2761.22386.5.5.5h2c.27614 0 .5-.2239.5-.5s-.22386-.5-.5-.5h-1.5v-9h1.5c.27614 0 .5-.22386.5-.5s-.22386-.5-.5-.5zm8 0c-.2761 0-.5.22386-.5.5s.2239.5.5.5h1.5v9h-1.5c-.2761 0-.5.2239-.5.5s.2239.5.5.5h2c.2761 0 .5-.2239.5-.5v-10c0-.27614-.2239-.5-.5-.5zm-4.5 5h-1v1h1zm1 0h1v1h-1zm3 0h-1v1h1z" fill-rule="evenodd"/>
 </svg>

--- a/web/src/nodes/array.ts
+++ b/web/src/nodes/array.ts
@@ -8,7 +8,7 @@ import { withTwind } from '../twind'
 import { Entity } from './entity'
 
 import './array-item'
-import '../ui/nodes/node-card/on-demand/block'
+import '../ui/nodes/node-card/on-demand/in-line'
 
 /**
  * Web component representing a Stencila Schema `Array` node
@@ -23,11 +23,11 @@ import '../ui/nodes/node-card/on-demand/block'
 export class Array extends Entity {
   override render() {
     return html`
-      <stencila-ui-block-on-demand type="Array" view="dynamic">
+      <stencila-ui-inline-on-demand type="Array" view="dynamic">
         <div slot="content">
           <slot></slot>
         </div>
-      </stencila-ui-block-on-demand>
+      </stencila-ui-inline-on-demand>
     `
   }
 }

--- a/web/src/nodes/boolean.ts
+++ b/web/src/nodes/boolean.ts
@@ -6,7 +6,7 @@ import { withTwind } from '../twind'
 
 import { Entity } from './entity'
 
-import '../ui/nodes/node-card/on-demand/block'
+import '../ui/nodes/node-card/on-demand/in-line'
 
 /**
  * Web component representing a Stencila Schema `Boolean` node
@@ -26,9 +26,9 @@ export class Boolean extends Entity {
    */
   override render() {
     return html`
-      <stencila-ui-block-on-demand type="Boolean" view="dynamic">
+      <stencila-ui-inline-on-demand type="Boolean" view="dynamic">
         <div slot="content" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-block-on-demand>
+      </stencila-ui-inline-on-demand>
     `
   }
 }

--- a/web/src/nodes/integer.ts
+++ b/web/src/nodes/integer.ts
@@ -6,7 +6,7 @@ import { withTwind } from '../twind'
 
 import { Entity } from './entity'
 
-import '../ui/nodes/node-card/on-demand/block'
+import '../ui/nodes/node-card/on-demand/in-line'
 
 /**
  * Web component representing a Stencila Schema `Integer` node
@@ -26,9 +26,9 @@ export class Integer extends Entity {
    */
   override render() {
     return html`
-      <stencila-ui-block-on-demand type="Integer" view="dynamic">
+      <stencila-ui-inline-on-demand type="Integer" view="dynamic">
         <div slot="content" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-block-on-demand>
+      </stencila-ui-inline-on-demand>
     `
   }
 }

--- a/web/src/nodes/number.ts
+++ b/web/src/nodes/number.ts
@@ -3,6 +3,7 @@ import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
 import '../ui/nodes/node-card/on-demand/block'
+import '../ui/nodes/node-card/on-demand/in-line'
 
 import { withTwind } from '../twind'
 
@@ -26,9 +27,9 @@ export class Number extends Entity {
    */
   override render() {
     return html`
-      <stencila-ui-block-on-demand type="Number" view="dynamic">
+      <stencila-ui-inline-on-demand type="Number" view="dynamic">
         <div slot="content" class=${this.bodyStyles}><slot></slot></div>
-      </stencila-ui-block-on-demand>
+      </stencila-ui-inline-on-demand>
     `
   }
 }

--- a/web/src/nodes/object.ts
+++ b/web/src/nodes/object.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
-import '../ui/nodes/node-card/in-flow/block'
+import '../ui/nodes/node-card/on-demand/in-line'
 
 import { withTwind } from '../twind'
 
@@ -24,11 +24,11 @@ export class Object extends Entity {
    */
   override render() {
     return html`
-      <stencila-ui-block-on-demand type="Object" view="dynamic">
+      <stencila-ui-inline-on-demand type="Object" view="dynamic">
         <div slot="content">
           <slot></slot>
         </div>
-      </stencila-ui-block-on-demand>
+      </stencila-ui-inline-on-demand>
     `
   }
 }

--- a/web/src/nodes/string.ts
+++ b/web/src/nodes/string.ts
@@ -2,7 +2,7 @@ import { apply } from '@twind/core'
 import { html } from 'lit'
 import { customElement } from 'lit/decorators.js'
 
-import '../ui/nodes/node-card/on-demand/block'
+import '../ui/nodes/node-card/on-demand/in-line'
 
 import { withTwind } from '../twind'
 
@@ -26,11 +26,11 @@ export class String extends Entity {
     const bodyStyles = apply(['w-full'])
 
     return html`
-      <stencila-ui-block-on-demand type="String" view="dynamic">
+      <stencila-ui-inline-on-demand type="String" view="dynamic">
         <div slot="content" class=${bodyStyles}>
           <q><slot></slot></q>
         </div>
-      </stencila-ui-block-on-demand>
+      </stencila-ui-inline-on-demand>
     `
   }
 }


### PR DESCRIPTION
**details**

Have swapped out the data type nodes form the block display to an inline, this allows them to be used in paragraphs etc without breaking the document flow.



