### PR TITLE
NGI - Updating licensing aspects according to REUSE

### DIFF
--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/python/stencila/Cargo.toml
+++ b/python/stencila/Cargo.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "stencila"
 version = "2.0.0-beta.1"

--- a/python/stencila/Makefile
+++ b/python/stencila/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 all: fix audit test build
 
 # Bootstrap the project

--- a/python/stencila/README.md
+++ b/python/stencila/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 Nokome Bentley
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Stencila SDK for Python
 
 **Bindings for using Stencila from Python**

--- a/python/stencila/pyproject.toml
+++ b/python/stencila/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # See https://packaging.python.org/en/latest/specifications/declaring-project-metadata/ for `project` keys
 
 [project]

--- a/python/stencila/python/stencila/__init__.py
+++ b/python/stencila/python/stencila/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/python/stencila/python/stencila/_stencila.pyi
+++ b/python/stencila/python/stencila/_stencila.pyi
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import TypedDict
 
 class DecodeOptions(TypedDict):

--- a/python/stencila/python/stencila/convert.py
+++ b/python/stencila/python/stencila/convert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from stencila_types.types import Node
 from stencila_types.utilities import from_json, to_json
 

--- a/python/stencila/python/tests/bench_convert.py
+++ b/python/stencila/python/tests/bench_convert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Performance benchmarking of functions in the `convert` module
 

--- a/python/stencila/python/tests/test_convert.py
+++ b/python/stencila/python/tests/test_convert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tests of functions in the `convert` module
 """

--- a/python/stencila/src/convert.rs
+++ b/python/stencila/src/convert.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Nokome Bentley
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Exposes format conversion functionality provided by Rust codecs
 
 use std::path::PathBuf;

--- a/python/stencila/src/lib.rs
+++ b/python/stencila/src/lib.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Nokome Bentley
+//
+// SPDX-License-Identifier: Apache-2.0
+
 use pyo3::prelude::*;
 
 mod convert;

--- a/python/stencila/src/utilities.rs
+++ b/python/stencila/src/utilities.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Nokome Bentley
+//
+// SPDX-License-Identifier: Apache-2.0
+
 //! Internal utility functions
 
 use pyo3::exceptions::{PyRuntimeError, PyValueError};

--- a/python/stencila_plugin/Makefile
+++ b/python/stencila_plugin/Makefile
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 all: fix audit test build
 
 # Bootstrap the project

--- a/python/stencila_plugin/README.md
+++ b/python/stencila_plugin/README.md
@@ -1,3 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2024 Brett Calcott
+SPDX-FileCopyrightText: 2024 Nokome Bentley
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Stencila Plugin
 
 [![stencila_plugin](https://img.shields.io/pypi/v/stencila_plugin.svg?logo=python&label=stencila_plugin&style=for-the-badge&color=1d3bd1&logoColor=66ff66&labelColor=3219a8)](https://pypi.org/project/stencila_plugin/)

--- a/python/stencila_plugin/pyproject.toml
+++ b/python/stencila_plugin/pyproject.toml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [project]
 name = "stencila_plugin"
 version = "2.0.0b1"

--- a/python/stencila_plugin/src/stencila_plugin/__init__.py
+++ b/python/stencila_plugin/src/stencila_plugin/__init__.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from .assistant import Assistant, GenerateOptions, GenerateOutput, GenerateTask
 from .kernel import Kernel
 from .plugin import Plugin, structure, unstructure

--- a/python/stencila_plugin/src/stencila_plugin/assistant.py
+++ b/python/stencila_plugin/src/stencila_plugin/assistant.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeAlias

--- a/python/stencila_plugin/src/stencila_plugin/kernel.py
+++ b/python/stencila_plugin/src/stencila_plugin/kernel.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass

--- a/python/stencila_plugin/src/stencila_plugin/plugin.py
+++ b/python/stencila_plugin/src/stencila_plugin/plugin.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import json
 import os

--- a/python/stencila_plugin/src/stencila_plugin/testing.py
+++ b/python/stencila_plugin/src/stencila_plugin/testing.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Test harnesses for simplifying plugin testing.
 

--- a/python/stencila_plugin/tests/__init__.py
+++ b/python/stencila_plugin/tests/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/python/stencila_plugin/tests/conftest.py
+++ b/python/stencila_plugin/tests/conftest.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from pathlib import Path
 
 import pytest

--- a/python/stencila_plugin/tests/plugin_example.py
+++ b/python/stencila_plugin/tests/plugin_example.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 
 from stencila_types import shortcuts as S

--- a/python/stencila_plugin/tests/test_plugin.py
+++ b/python/stencila_plugin/tests/test_plugin.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Brett Calcott
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import pytest
 from stencila_types import shortcuts as S
 from stencila_types import types as T

--- a/python/stencila_types/Makefile
+++ b/python/stencila_types/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 all: fix audit test build
 
 # Bootstrap the project

--- a/python/stencila_types/README.md
+++ b/python/stencila_types/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 Nokome Bentley
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Stencila Types for Python
 
 [![stencila_types](https://img.shields.io/pypi/v/stencila_types.svg?logo=python&label=stencila_types&style=for-the-badge&color=1d3bd1&logoColor=66ff66&labelColor=3219a8)](https://pypi.org/project/stencila_types/)

--- a/python/stencila_types/pyproject.toml
+++ b/python/stencila_types/pyproject.toml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 [project]
 name = "stencila_types"
 version = "2.0.0b1"

--- a/python/stencila_types/src/stencila_types/__init__.py
+++ b/python/stencila_types/src/stencila_types/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/python/stencila_types/src/stencila_types/shortcuts.py
+++ b/python/stencila_types/src/stencila_types/shortcuts.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import Iterable
 from typing import TypeAlias
 

--- a/python/stencila_types/src/stencila_types/types.py
+++ b/python/stencila_types/src/stencila_types/types.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Generated file; do not edit. See the Rust `schema-gen` crate.
 # We override the Literal `type` in each class so...
 # pyright: reportIncompatibleVariableOverride=false

--- a/python/stencila_types/src/stencila_types/utilities.py
+++ b/python/stencila_types/src/stencila_types/utilities.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import re
 from typing import Any

--- a/python/stencila_types/tests/__init__.py
+++ b/python/stencila_types/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/python/stencila_types/tests/conftest.py
+++ b/python/stencila_types/tests/conftest.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/python/stencila_types/tests/test_shortcuts.py
+++ b/python/stencila_types/tests/test_shortcuts.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 
 import pytest

--- a/python/stencila_types/tests/test_shortcuts/test_emphasis.yml
+++ b/python/stencila_types/tests/test_shortcuts/test_emphasis.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 content:
 - id: null
   type: Text

--- a/python/stencila_types/tests/test_shortcuts/test_link.yml
+++ b/python/stencila_types/tests/test_shortcuts/test_link.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 content:
 - id: null
   type: Text

--- a/python/stencila_types/tests/test_shortcuts/test_quote.yml
+++ b/python/stencila_types/tests/test_shortcuts/test_quote.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cite: null
 content:
 - id: null

--- a/python/stencila_types/tests/test_types.py
+++ b/python/stencila_types/tests/test_types.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Nokome Bentley
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass, field
 
 import pytest


### PR DESCRIPTION
Hello,

I work for the Free Software Foundation Europe (FSFE), and we have been working with the NGI framework, helping projects with their licensing and copyright management. After a quick check on your repository, I would like to propose some updates regarding copyright and licensing information. [REUSE](https://reuse.software/) is an FSFE-developed initiative intended to make licensing easier by establishing a single way to display all copyright and licensing information through comment headers on source files that can be human- and machine-readable.

## REUSE Features:

### Copyright and Licensing Information in each file

One of the main features of REUSE is that each file in the repository contains copyright and license information with the help of a comment header. To serve as a guideline and a practical example of how REUSE looks, I have added the header to some of the files in your repository in the directory `python/`. As you can see the copyright year is set for the current year (2024) since I didn't specify a different entry for the [year to be included in the headers](https://reuse.readthedocs.io/en/stable/man/reuse-annotate.html#cmdoption-y). However, you can also change this depending on your [preference](https://reuse.software/faq/#years-copyright). 

The legal information I've added on the headers,  I extracted it from the files `pyproject.toml`. Please also double-check if the personal information in the headers is correct and consistent, in the case of several copyright holders please update that information in the headers. In case you want to license certain files under a different license, special attention should also be paid to that aspect and such files should contain the appropriate SPDX tag.

Please note that REUSE has also an option to add this legal information for [binary and uncommentable files](https://reuse.software/tutorial/#binary-and-uncommentable-files), as well as for [insignificant files ](https://reuse.software/tutorial/#insignificant-files)- no copyrightable files such as `.gitignore`. An appropriate license for such files and documentation files is also encouraged. 

###   LICENSES directory in the root of the project with the licenses used on the repository:

I included in this directory a file with the text of the Apache 2.0 license. I did not do anything with the existing `LICENSE` file in the root of the directory. It is up to you if you want to keep it or delete it, however, this won't affect the REUSE specification. Please also be aware, that if some pieces of your project use a different license, such license text should be added to the` LICENSES/` directory as well as to the specific files.

I'd also like to point to the possibility of associating Licensing Information with a [REUSE.toml file](https://reuse.software/spec-3.2/#reusetoml) in cases where because of large directories including a comment header in each file (or in .license companion files) is impossible or undesirable.

Please feel free to check the [REUSE documentation](https://reuse.readthedocs.io/en/stable/) and the [helper tool ](https://reuse.software/dev/#tool), and if you are interested in making your project REUSE compliant, please add the legal information to the missing files. I am also available if you want support with the process.


## Wide range of tools

In case you find REUSE useful, we offer other tools to help you continuously check and display compliance with the REUSE guidelines. For instance, you can automatically run reuse lint on every commit as[ a pre-commit hook](https://reuse.software/dev/#pre-commit-hook) for Git. And, it can be easily [integrated into your existing CI/CD processes](https://reuse.software/dev/#ci) to continuously test your repository and its changes for REUSE compliance

Hope that helps and thank you very much for the amazing job!