### PR TITLE
Feature/add commands to suggestion blocks

### DIFF
--- a/web/src/clients/commands.ts
+++ b/web/src/clients/commands.ts
@@ -20,6 +20,9 @@ export interface DocumentCommand {
     | 'execute-nodes'
     | 'interrupt-document'
     | 'interrupt-nodes'
+    | 'accept-node'
+    | 'reject-node'
+    | 'revise-node'
 
   /**
    * The type of the node that the command is being executed on.
@@ -39,6 +42,11 @@ export interface DocumentCommand {
    * The scope for the command
    */
   scope?: 'only' | 'plus-before' | 'plus-after' | 'plus-upstream-downstream'
+
+  /**
+   * Instructions for assisntants
+   */
+  instruction?: string
 }
 
 /**

--- a/web/src/nodes/code-chunk.ts
+++ b/web/src/nodes/code-chunk.ts
@@ -4,7 +4,6 @@ import { customElement, property } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
 
-import '../ui/nodes/node-card/in-flow/block'
 import '../ui/nodes/commands/execution-commands'
 import '../ui/nodes/properties/authors'
 import '../ui/nodes/properties/code/code'

--- a/web/src/nodes/instruction-block.ts
+++ b/web/src/nodes/instruction-block.ts
@@ -27,7 +27,7 @@ export class InstructionBlock extends Instruction {
   /**
    * toggle the visibilty of the suggestions
    */
-  private toggleSuggestions() {
+  protected toggleSuggestions() {
     this.showSuggestions = !this.showSuggestions
   }
 
@@ -96,26 +96,9 @@ export class InstructionBlock extends Instruction {
 
     return html`
       <div>
-        ${this.context.cardOpen ? this.renderSuggestionsToggle() : ''}
         <div class=${styles}>
           <slot name="suggestions"></slot>
         </div>
-      </div>
-    `
-  }
-
-  protected renderSuggestionsToggle() {
-    return html`
-      <div>
-        <button
-          class="flex items-center gap-x-1 text-gray-300 hover:text-blue-500"
-          @click=${() => this.toggleSuggestions()}
-        >
-          <sl-icon name=${this.showSuggestions ? 'eye' : 'eye-slash'}></sl-icon>
-          <span class="text-sm">
-            ${this.showSuggestions ? 'Hide' : 'Show'}${' '}suggestions
-          </span>
-        </button>
       </div>
     `
   }

--- a/web/src/nodes/suggestion-block.ts
+++ b/web/src/nodes/suggestion-block.ts
@@ -33,6 +33,12 @@ export class SuggestionBlock extends Entity {
       ?collapsed=${true}
     >
       <div slot="body">
+        <stencila-ui-node-execution-details
+          type="SuggestionBlock"
+          ended=${this.executionEnded}
+          duration=${this.executionDuration}
+        >
+        </stencila-ui-node-execution-details>
         <stencila-ui-node-authors type="SuggestionBlock">
           <stencila-ui-node-provenance slot="provenance">
             <slot name="provenance"></slot>

--- a/web/src/nodes/suggestion-block.ts
+++ b/web/src/nodes/suggestion-block.ts
@@ -6,6 +6,8 @@ import { withTwind } from '../twind'
 
 import { Entity } from './entity'
 
+import '../ui/nodes/commands/suggestion-commands'
+
 /**
  * Web component representing a Stencila Schema `SuggestionBlock` node
  *
@@ -32,6 +34,13 @@ export class SuggestionBlock extends Entity {
       node-id=${this.id}
       ?collapsed=${true}
     >
+      <span slot="header-right">
+        <stencila-ui-suggestion-commands
+          node-id=${this.id}
+          type="SuggestionBlock"
+        >
+        </stencila-ui-suggestion-commnads>
+      </span>
       <div slot="body">
         <stencila-ui-node-execution-details
           type="SuggestionBlock"

--- a/web/src/nodes/suggestion-block.ts
+++ b/web/src/nodes/suggestion-block.ts
@@ -29,7 +29,11 @@ export class SuggestionBlock extends Entity {
   feedback?: string
 
   override render() {
+    const showSuggestion =
+      !this.suggestionStatus || this.suggestionStatus === 'Proposed'
+
     return html`<stencila-ui-block-in-flow
+      class=${!showSuggestion ? 'hidden' : ''}
       type="SuggestionBlock"
       node-id=${this.id}
       ?collapsed=${true}

--- a/web/src/ui/nodes/commands/suggestion-commands.ts
+++ b/web/src/ui/nodes/commands/suggestion-commands.ts
@@ -90,7 +90,7 @@ export class UINodeSuggestionCommands extends UIBaseClass {
           e.stopImmediatePropagation()
         }}
       >
-        <sl-tooltip content="Accept Suggestion">
+        <sl-tooltip content="Accept suggestion">
           <sl-icon
             name="hand-thumbs-up"
             @click=${(e: Event) => {
@@ -99,7 +99,7 @@ export class UINodeSuggestionCommands extends UIBaseClass {
             class="hover:text-gray-900"
           ></sl-icon>
         </sl-tooltip>
-        <sl-tooltip content="Reject Suggestion">
+        <sl-tooltip content="Reject suggestion">
           <sl-icon
             name="hand-thumbs-down"
             @click=${(e: Event) => {
@@ -109,12 +109,11 @@ export class UINodeSuggestionCommands extends UIBaseClass {
           ></sl-icon>
         </sl-tooltip>
         <sl-tooltip
-          content="Revision instruction"
+          content="Revise suggestion with feedback"
           style="--show-delay: 1000ms;"
         >
           <sl-icon
-            name="instruction-block"
-            library="stencila"
+            name="arrow-repeat"
             @click=${() => {
               this.showInstructInput = !this.showInstructInput
             }}
@@ -142,25 +141,23 @@ export class UINodeSuggestionCommands extends UIBaseClass {
     return html`
       <div class=${containerStyles} @click=${(e: Event) => e.stopPropagation()}>
         <div class="flex flex-row items-center text-sm">
-          <sl-icon name="instruction-block" library="stencila"></sl-icon>
-          <input
+          <textarea
             ${ref(this.inputRef)}
-            class="w-42 mx-2 px-1 text-black rounded-sm"
-            type="text"
-            placeholder="further instructions"
+            class="mx-2 px-1 text-gray-800 text-xs rounded-sm resize-none"
+            cols="40"
+            rows="3"
+            placeholder="Provide feedback or leave empty for machine generated feedback"
             ?disabled=${this.reviseStatus === 'pending'}
-          />
-          <sl-tooltip content="Revise Suggestion">
-            <sl-icon
-              name="arrow-repeat"
-              class="text-lg hover:text-gray-500 cursor-pointer ${this
-                .reviseStatus === 'pending' && 'animate-spin'}"
-              @click=${(e: Event) => {
-                this.emitEvent(e, 'revise', this.inputRef.value.value)
-                this.reviseStatus = 'pending'
-              }}
-            ></sl-icon>
-          </sl-tooltip>
+          ></textarea>
+          <sl-icon
+            name="arrow-repeat"
+            class="text-lg hover:text-gray-500 cursor-pointer ${this
+              .reviseStatus === 'pending' && 'animate-spin'}"
+            @click=${(e: Event) => {
+              this.emitEvent(e, 'revise', this.inputRef.value.value)
+              this.reviseStatus = 'pending'
+            }}
+          ></sl-icon>
         </div>
       </div>
     `

--- a/web/src/ui/nodes/commands/suggestion-commands.ts
+++ b/web/src/ui/nodes/commands/suggestion-commands.ts
@@ -1,0 +1,57 @@
+import { apply } from '@twind/core'
+import { html } from 'lit'
+import { customElement } from 'lit/decorators'
+
+import { withTwind } from '../../../twind'
+import { UIBaseClass } from '../mixins/ui-base-class'
+
+@customElement('stencila-ui-suggestion-commands')
+@withTwind()
+export class UINodeSuggestionCommands extends UIBaseClass {
+  /**
+   * Emit a custom event to execute the document with this
+   * node id and command scope
+   */
+  private emitEvent(e: Event) {
+    e.stopImmediatePropagation()
+  }
+
+  protected override render() {
+    const containerClasses = apply([
+      'flex flex-row gap-x-3 items-center flex-shrink-0',
+      `text-${this.ui.textColour}`,
+    ])
+
+    return html`
+      <div class=${containerClasses}>
+        <sl-tooltip content="Accept Suggestion">
+          <sl-icon
+            name="hand-thumbs-up"
+            @click=${(e: Event) => {
+              this.emitEvent(e)
+            }}
+            class="hover:text-gray-900"
+          ></sl-icon>
+        </sl-tooltip>
+        <sl-tooltip content="Reject Suggestion">
+          <sl-icon
+            name="hand-thumbs-down"
+            @click=${(e: Event) => {
+              this.emitEvent(e)
+            }}
+            class="hover:text-gray-900"
+          ></sl-icon>
+        </sl-tooltip>
+        <sl-tooltip content="Revise">
+          <sl-icon
+            name="arrow-repeat"
+            @click=${(e: Event) => {
+              this.emitEvent(e)
+            }}
+            class="hover:text-gray-900"
+          ></sl-icon>
+        </sl-tooltip>
+      </div>
+    `
+  }
+}

--- a/web/src/ui/nodes/commands/suggestion-commands.ts
+++ b/web/src/ui/nodes/commands/suggestion-commands.ts
@@ -132,32 +132,46 @@ export class UINodeSuggestionCommands extends UIBaseClass {
       'max-w-[24rem]',
       'transform -translate-y-full',
       `bg-[${this.ui.borderColour}]`,
-      'p-2',
+      'p-1',
       `text-[${this.ui.textColour}] text-sm`,
       'rounded shadow',
       'cursor-auto',
     ])
+
+    const submitRevision = (e: Event) => {
+      this.emitEvent(e, 'revise', this.inputRef.value.value)
+      this.reviseStatus = 'pending'
+      this.inputRef.value.value = ''
+      this.showInstructInput = false
+    }
 
     return html`
       <div class=${containerStyles} @click=${(e: Event) => e.stopPropagation()}>
         <div class="flex flex-row items-center text-sm">
           <textarea
             ${ref(this.inputRef)}
-            class="mx-2 px-1 text-gray-800 text-xs rounded-sm resize-none"
+            class="mr-2 px-1 text-gray-800 text-xs rounded-sm resize-none outline-black"
             cols="40"
             rows="3"
             placeholder="Provide feedback or leave empty for machine generated feedback"
             ?disabled=${this.reviseStatus === 'pending'}
-          ></textarea>
-          <sl-icon
-            name="arrow-repeat"
-            class="text-lg hover:text-gray-500 cursor-pointer ${this
-              .reviseStatus === 'pending' && 'animate-spin'}"
-            @click=${(e: Event) => {
-              this.emitEvent(e, 'revise', this.inputRef.value.value)
-              this.reviseStatus = 'pending'
+            @keydown=${(e: KeyboardEvent) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault()
+                submitRevision(e)
+              }
             }}
-          ></sl-icon>
+          ></textarea>
+          <button
+            @click=${submitRevision}
+            class="flex items-center cursor-pointer hover:text-gray-500"
+          >
+            <sl-icon
+              name="arrow-repeat"
+              class="text-lg"
+              ?disabled=${this.reviseStatus === 'pending'}
+            ></sl-icon>
+          </button>
         </div>
       </div>
     `

--- a/web/src/ui/nodes/commands/suggestion-commands.ts
+++ b/web/src/ui/nodes/commands/suggestion-commands.ts
@@ -141,7 +141,7 @@ export class UINodeSuggestionCommands extends UIBaseClass {
 
     return html`
       <div class=${containerStyles} @click=${(e: Event) => e.stopPropagation()}>
-        <div class="flex flex-row items-center mt-1 text-sm">
+        <div class="flex flex-row items-center text-sm">
           <sl-icon name="instruction-block" library="stencila"></sl-icon>
           <input
             ${ref(this.inputRef)}

--- a/web/src/ui/nodes/properties/execution-details.ts
+++ b/web/src/ui/nodes/properties/execution-details.ts
@@ -70,24 +70,36 @@ export class UINodeExecutionDetails extends LitElement {
     return html`
       <div class="@container">
         <div class=${`${classes}`}>
-          <stencila-ui-node-execution-state
-            status=${this.status}
-            required=${this.required}
-            count=${this.count}
-          ></stencila-ui-node-execution-state>
-          ${this.count > 0
-            ? html`<stencila-ui-node-execution-count
-                  value=${this.count}
-                ></stencila-ui-node-execution-count>
-                <stencila-ui-node-execution-ended
-                  value=${this.ended}
-                ></stencila-ui-node-execution-ended>
-                <stencila-ui-node-execution-duration
-                  value=${this.duration}
-                ></stencila-ui-node-execution-duration>`
-            : ''}
+          ${this.type !== 'SuggestionBlock'
+            ? this.renderAllDetails()
+            : this.renderTimeAndDuration()}
         </div>
       </div>
+    `
+  }
+
+  protected renderAllDetails() {
+    return html`<stencila-ui-node-execution-state
+        status=${this.status}
+        required=${this.required}
+        count=${this.count}
+      ></stencila-ui-node-execution-state>
+      ${this.count > 0
+        ? html`<stencila-ui-node-execution-count
+              value=${this.count}
+            ></stencila-ui-node-execution-count>
+            ${this.renderTimeAndDuration()}`
+        : ''}`
+  }
+
+  protected renderTimeAndDuration() {
+    return html`
+      <stencila-ui-node-execution-ended
+        value=${this.ended}
+      ></stencila-ui-node-execution-ended>
+      <stencila-ui-node-execution-duration
+        value=${this.duration}
+      ></stencila-ui-node-execution-duration>
     `
   }
 }


### PR DESCRIPTION
**details**

- hides suggestions where status is not "Proposed" or `undefined`
- adds in the `duration` and `ended` execution details to the card
- adds command buttons to the card header
- add input for the revise

I have linked up the commands to the buttons, but only the 'reject' seems to be working... accept will return an error stating a missing `nodeId` and I'm not sure how to handle the revise yet

