### PR TITLE
fix(code.ts): keep authroship attribute as string whilst being drilled

### DIFF
--- a/web/src/nodes/code-chunk.ts
+++ b/web/src/nodes/code-chunk.ts
@@ -100,7 +100,7 @@ export class CodeChunk extends CodeExecutable {
         <stencila-ui-node-code
           type="CodeChunk"
           code=${this.code}
-          .code-authorship=${this.codeAuthorship}
+          code-authorship=${this.codeAuthorship}
           language=${this.programmingLanguage}
           execution-required=${this.executionRequired}
           read-only

--- a/web/src/nodes/code-executable.ts
+++ b/web/src/nodes/code-executable.ts
@@ -11,6 +11,11 @@ export abstract class CodeExecutable extends Executable {
   @property()
   code: string
 
+  /**
+   * A 'stringified' JS array,
+   * Important should be kept as a `String`
+   * to avoid errors when passing down to children.
+   */
   @property({ attribute: 'code-authorship' })
   codeAuthorship?: string
 

--- a/web/src/ui/nodes/properties/code/code.ts
+++ b/web/src/ui/nodes/properties/code/code.ts
@@ -49,10 +49,12 @@ export class UINodeCode extends LitElement {
   code: string
 
   /**
-   * The runs of authorship of the code
+   * The runs of authorship of the code.
+   *
+   * **IMPORTANT** this will be a stringified array, and must be parsed before using
    */
-  @property({ attribute: 'code-authorship', type: Array })
-  codeAuthorship?: AuthorshipRun[]
+  @property({ attribute: 'code-authorship', type: String })
+  codeAuthorship?: string
 
   /**
    * The language of the code. Used to determine the syntax highlighting
@@ -255,15 +257,22 @@ export class UINodeCode extends LitElement {
    * @returns `CodeAuthorshipMarker[] | null`
    */
   private getAuthorshipMarkers = (): AuthorshipMarker[] | null => {
-    return this.codeAuthorship
-      ? this.codeAuthorship.map((run) => ({
+    if (this.codeAuthorship) {
+      try {
+        const authorshipRun = JSON.parse(this.codeAuthorship) as AuthorshipRun[]
+        return authorshipRun.map((run) => ({
           from: run[0],
           to: run[1],
           count: run[2],
           provenance: run[4],
           mi: run[5],
         }))
-      : null
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (e) {
+        return null
+      }
+    }
+    return null
   }
 
   /**


### PR DESCRIPTION
**details**

Removes regression of code snippet provenance highlights,

caused by prop drilling an array type that should have been a string.