### PR TITLE
refactor: apply new styles to article author provenance

### DIFF
--- a/web/src/nodes/article.ts
+++ b/web/src/nodes/article.ts
@@ -1,5 +1,5 @@
 import { provide } from '@lit/context'
-import { LitElement, html } from 'lit'
+import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators'
 
 import { withTwind } from '../twind'
@@ -63,15 +63,34 @@ export class StencilaArticle extends LitElement {
     )
   }
 
+  /**
+   * Provide some formatting rules for the authors and provenance elements
+   */
+  static override styles = css`
+    [slot='authors'] > slot::slotted(*) {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem; // gap-3
+    }
+
+    [slot='provenance'] > slot::slotted(*) {
+      display: flex;
+      flex-direction: row;
+      gap: 0.75rem; // gap-3
+    }
+  `
+
   override render() {
     return html`
       <aside class="min-w-80 max-w-prose mx-auto">
         <stencila-ui-authors-provenance>
           <div class="flex flex-col gap-y-4">
             <div slot="authors">
+              <label class="block text-sm mb-4">Contributers</label>
               <slot name="authors"></slot>
             </div>
             <div slot="provenance">
+              <label class="block text-sm mb-4">Provenance</label>
               <slot name="provenance"></slot>
             </div>
           </div>

--- a/web/src/nodes/provenance-count.ts
+++ b/web/src/nodes/provenance-count.ts
@@ -38,7 +38,6 @@ export class ProvenanceCount extends Entity {
 
   override render() {
     const nodeType = this.ancestors.split('.').reverse()[0] as NodeType
-
     const { colour, borderColour, textColour } = nodeUi(nodeType)
 
     const styles = apply([

--- a/web/src/ui/nodes/icons-and-colours.ts
+++ b/web/src/ui/nodes/icons-and-colours.ts
@@ -31,6 +31,10 @@ const nodeColours = (name: string) => ({
 
 // prettier-ignore
 const nodeTypeUIMap: Partial<Record<NodeType, NodeTypeUI>> = {
+  // Article level
+  Article:          {                        ...nodeColours('gray')},
+
+
   // Primitive data types
   Boolean:          { icon: 'toggleOff',     ...nodeColours('slate')},
   Integer:          { icon: 'hash',          ...nodeColours('slate')},

--- a/web/src/ui/nodes/properties/authors-provenance.ts
+++ b/web/src/ui/nodes/properties/authors-provenance.ts
@@ -2,10 +2,10 @@ import { consume } from '@lit/context'
 import { apply } from '@twind/core'
 import { LitElement, html } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
-// import { Ref, createRef, ref } from 'lit/directives/ref'
 
 import { withTwind } from '../../../twind'
 import { DocumentContext, documentContext } from '../../document/context'
+import { nodeUi } from '../icons-and-colours'
 
 import '../../animation/collapsible'
 
@@ -31,10 +31,13 @@ export class UIAuthorsProvenance extends LitElement {
   // private buttonRef: Ref<HTMLDivElement> = createRef()
 
   protected override render() {
+    const { textColour, colour, borderColour } = nodeUi('Article')
+
     const contentStyles = apply([
       'p-4 text-sans',
-      'bg-gray-100',
-      'border border-black/20 rounded',
+      `bg-[${colour}]`,
+      `text-[${textColour}]`,
+      `border border-[${borderColour}] rounded`,
       'transition-all ease-in duration-200',
     ])
 

--- a/web/src/ui/nodes/properties/authors-provenance.ts
+++ b/web/src/ui/nodes/properties/authors-provenance.ts
@@ -2,7 +2,7 @@ import { consume } from '@lit/context'
 import { apply } from '@twind/core'
 import { LitElement, html } from 'lit'
 import { customElement, state } from 'lit/decorators.js'
-import { Ref, createRef, ref } from 'lit/directives/ref'
+// import { Ref, createRef, ref } from 'lit/directives/ref'
 
 import { withTwind } from '../../../twind'
 import { DocumentContext, documentContext } from '../../document/context'
@@ -28,9 +28,16 @@ export class UIAuthorsProvenance extends LitElement {
   /**
    * ref used to manage mouse events.
    */
-  private buttonRef: Ref<HTMLDivElement> = createRef()
+  // private buttonRef: Ref<HTMLDivElement> = createRef()
 
   protected override render() {
+    const contentStyles = apply([
+      'p-4 text-sans',
+      'bg-gray-100',
+      'border border-black/20 rounded',
+      'transition-all ease-in duration-200',
+    ])
+
     return html`
       <div
         class=${`${this.context.showAuthorProvenance ? 'mb-8' : 'mb-0'} transition-all ease-in duration-200 group pointer-events-none`}
@@ -38,84 +45,11 @@ export class UIAuthorsProvenance extends LitElement {
         <stencila-ui-collapsible-animation
           class=${`pointer-events-auto ${this.context.showAuthorProvenance ? 'opened' : ''}`}
         >
-          ${this.renderBody()}
+          <div class=${contentStyles}>
+            <slot></slot>
+          </div>
         </stencila-ui-collapsible-animation>
       </div>
     `
-  }
-
-  /**
-   * Output the header element which acts as a event handler for click events.
-   */
-  // @ts-expect-error TODO determine if this unused function is still needed
-  private renderHeader() {
-    const collapsedClasses = !this.context.showAuthorProvenance
-      ? [
-          'text-black/50',
-          'border-t-black/20 border-l-black/0 border-r-black/0 rounded-t-none',
-        ]
-      : [
-          'text-black/20',
-          'border-l-black/0 border-t-black/0 border-r-black/0 rounded-t',
-          'hover:bg-[rgba(0,0,0,0.025)] hover:contrast-[105%]',
-          'group-hover:border-l-black group-hover:border-r-black',
-        ]
-    const containerClasses = apply([
-      ...collapsedClasses,
-      [
-        'relative z-[1]',
-        'flex gap-x-2 items-center',
-        'border border-b-white group-hover:border-t-black',
-        'group-hover:text-black',
-        'p-2 -mb-px',
-        'max-w-fit',
-        'transform-gpu',
-        'transition-all duration-200',
-        'cursor-pointer pointer-events-auto',
-        'after:content-[""] after:block',
-        'after:w-[calc(100%-2px)] after:h-px',
-        'after:bg-white',
-        'after:absolute after:bottom-0 after:left-[1px]',
-      ],
-    ])
-
-    return html`<div class=${containerClasses} ${ref(this.buttonRef)}>
-      <stencila-ui-icon name="feather" class="text-xs"></stencila-ui-icon
-      ><span class="font-sans text-2xs leading-none block"
-        >Authors and Provenance</span
-      >
-      ${this.renderCollapse()}
-    </div>`
-  }
-
-  private renderBody() {
-    const classes = apply([
-      'p-4 text-sans',
-      'border border-black/0 rounded-tl-none rounded-b rounded-tr',
-      // 'group-hover:border-black',
-      'transition-all ease-in duration-200',
-    ])
-
-    return html`<div class=${classes}>
-      <slot></slot>
-    </div>`
-  }
-
-  /**
-   * Render the collapse card under the header.
-   *
-   * Note: this code is inspired by @linkcode `stencila-ui-base-card` and could
-   * be abstracted further.
-   */
-  private renderCollapse() {
-    const classes = apply(['flex items-center', `brightness-75`])
-
-    return html`<div class=${classes}>
-      <stencila-ui-chevron-button
-        default-pos=${this.context.showAuthorProvenance ? 'up' : 'down'}
-        .disableEvents=${true}
-        class="inline-flex text-xs"
-      ></stencila-ui-chevron-button>
-    </div>`
   }
 }


### PR DESCRIPTION
**details**

Have applied some simple formatting style rules and labeling to the article level authors provenance slotted elements.

These should be similar to the node card displays of the same elements.

Also removed deprecated code from the `UIAuthorsProvenance` class

![image](https://github.com/user-attachments/assets/db2d369c-5a6e-45ce-98b7-51f1938b9d01)


related issues: closes #2339 