### PR TITLE
fix(image-objects): reset all styles on svg el to avoid prose inherit

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stencila",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stencila",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "9.0.1"

--- a/web/src/nodes/image-object.ts
+++ b/web/src/nodes/image-object.ts
@@ -177,7 +177,19 @@ export class ImageObject extends Entity {
   }
 
   private renderSvg() {
-    return html`<div slot="content">${unsafeSVG(this.svg)}</div>`
+    /* 
+     Reset styles on svg to stop any inner text elements
+     inheriting the tailwind prose styles
+    */
+    const svgStyles = css`
+      & svg {
+        all: initial;
+      }
+    `
+
+    return html`
+      <div slot="content" class=${svgStyles}>${unsafeSVG(this.svg)}</div>
+    `
   }
 
   private renderImg() {


### PR DESCRIPTION
**details**

The prose typograhpy from the default theme was leaking into svg elements inside the image-object nodes, specifically mermaid.

I have set the rule `all: initial` on the svg element to override this, thus reseting the line height.

![image](https://github.com/user-attachments/assets/554079c2-a7dd-4b9e-b4bb-bce4bb2fdaf5)

