### PR TITLE
feat(execution instance): allow for detecting different kernel

### DIFF
--- a/json/Article.jsonld
+++ b/json/Article.jsonld
@@ -699,6 +699,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/Article.schema.json
+++ b/json/Article.schema.json
@@ -789,6 +789,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/Button.jsonld
+++ b/json/Button.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/Button.schema.json
+++ b/json/Button.schema.json
@@ -214,6 +214,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/CallArgument.jsonld
+++ b/json/CallArgument.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/CallArgument.schema.json
+++ b/json/CallArgument.schema.json
@@ -215,6 +215,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/CallBlock.jsonld
+++ b/json/CallBlock.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/CallBlock.schema.json
+++ b/json/CallBlock.schema.json
@@ -215,6 +215,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/CodeChunk.jsonld
+++ b/json/CodeChunk.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/CodeChunk.schema.json
+++ b/json/CodeChunk.schema.json
@@ -228,6 +228,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/CodeExecutable.jsonld
+++ b/json/CodeExecutable.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/CodeExecutable.schema.json
+++ b/json/CodeExecutable.schema.json
@@ -210,6 +210,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/CodeExpression.jsonld
+++ b/json/CodeExpression.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/CodeExpression.schema.json
+++ b/json/CodeExpression.schema.json
@@ -221,6 +221,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/Executable.jsonld
+++ b/json/Executable.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/Executable.schema.json
+++ b/json/Executable.schema.json
@@ -205,6 +205,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/ForBlock.jsonld
+++ b/json/ForBlock.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/ForBlock.schema.json
+++ b/json/ForBlock.schema.json
@@ -218,6 +218,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/Form.jsonld
+++ b/json/Form.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/Form.schema.json
+++ b/json/Form.schema.json
@@ -207,6 +207,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/IfBlock.jsonld
+++ b/json/IfBlock.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/IfBlock.schema.json
+++ b/json/IfBlock.schema.json
@@ -210,6 +210,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/IfBlockClause.jsonld
+++ b/json/IfBlockClause.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/IfBlockClause.schema.json
+++ b/json/IfBlockClause.schema.json
@@ -216,6 +216,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/IncludeBlock.jsonld
+++ b/json/IncludeBlock.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/IncludeBlock.schema.json
+++ b/json/IncludeBlock.schema.json
@@ -213,6 +213,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/Instruction.jsonld
+++ b/json/Instruction.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/Instruction.schema.json
+++ b/json/Instruction.schema.json
@@ -211,6 +211,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/InstructionBlock.jsonld
+++ b/json/InstructionBlock.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/InstructionBlock.schema.json
+++ b/json/InstructionBlock.schema.json
@@ -220,6 +220,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/InstructionInline.jsonld
+++ b/json/InstructionInline.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/InstructionInline.schema.json
+++ b/json/InstructionInline.schema.json
@@ -220,6 +220,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/Parameter.jsonld
+++ b/json/Parameter.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/Parameter.schema.json
+++ b/json/Parameter.schema.json
@@ -217,6 +217,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/Prompt.jsonld
+++ b/json/Prompt.jsonld
@@ -699,6 +699,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/Prompt.schema.json
+++ b/json/Prompt.schema.json
@@ -768,6 +768,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/PromptBlock.jsonld
+++ b/json/PromptBlock.jsonld
@@ -165,6 +165,18 @@
       }
     },
     {
+      "@id": "stencila:executionInstance",
+      "@type": "rdfs:Property",
+      "rdfs:label": "executionInstance",
+      "rdfs:comment": "The id of the kernel instance that performed the last execution.",
+      "schema:domainIncludes": {
+        "@id": "stencila:Executable"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      }
+    },
+    {
       "@id": "stencila:executionKind",
       "@type": "rdfs:Property",
       "rdfs:label": "executionKind",

--- a/json/PromptBlock.schema.json
+++ b/json/PromptBlock.schema.json
@@ -212,6 +212,19 @@
       ],
       "$ref": "ExecutionStatus.schema.json"
     },
+    "executionInstance": {
+      "@id": "stencila:executionInstance",
+      "description": "The id of the kernel instance that performed the last execution.",
+      "$comment": "Used to help identify whether execution is required due to the last execution\nbeing in a difference instance (e.g. after a kernel restart).\n",
+      "aliases": [
+        "execution-instance",
+        "execution_instance"
+      ],
+      "strip": [
+        "execution"
+      ],
+      "type": "string"
+    },
     "executionKind": {
       "@id": "stencila:executionKind",
       "description": "The kind (e.g. main kernel vs kernel fork) of the last execution.",

--- a/json/context.jsonld
+++ b/json/context.jsonld
@@ -275,6 +275,7 @@
     "executionDigest": "stencila:executionDigest",
     "executionDuration": "stencila:executionDuration",
     "executionEnded": "stencila:executionEnded",
+    "executionInstance": "stencila:executionInstance",
     "executionKind": "stencila:executionKind",
     "executionMessages": "stencila:executionMessages",
     "executionMode": "stencila:executionMode",

--- a/python/stencila_types/src/stencila_types/types.py
+++ b/python/stencila_types/src/stencila_types/types.py
@@ -616,6 +616,9 @@ class Executable(Entity):
     execution_status: ExecutionStatus | None = None
     """Status of the most recent, including any current, execution."""
 
+    execution_instance: str | None = None
+    """The id of the kernel instance that performed the last execution."""
+
     execution_kind: ExecutionKind | None = None
     """The kind (e.g. main kernel vs kernel fork) of the last execution."""
 

--- a/rust/kernel-bash/src/lib.rs
+++ b/rust/kernel-bash/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use kernel_micro::{
     common::eyre::Result, format::Format, Kernel, KernelAvailability, KernelForks, KernelInstance,
     KernelInterrupt, KernelKill, KernelTerminate, Microkernel,
@@ -7,14 +5,13 @@ use kernel_micro::{
 
 /// A kernel for executing Bash code locally
 #[derive(Default)]
-pub struct BashKernel {
-    /// A counter of instances of this microkernel
-    instances: AtomicU64,
-}
+pub struct BashKernel;
+
+const NAME: &str = "bash";
 
 impl Kernel for BashKernel {
     fn name(&self) -> String {
-        "bash".to_string()
+        NAME.to_string()
     }
 
     fn availability(&self) -> KernelAvailability {
@@ -44,7 +41,7 @@ impl Kernel for BashKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
-        self.microkernel_create_instance(self.instances.fetch_add(1, Ordering::SeqCst))
+        self.microkernel_create_instance(NAME)
     }
 }
 

--- a/rust/kernel-graphviz/src/lib.rs
+++ b/rust/kernel-graphviz/src/lib.rs
@@ -8,6 +8,7 @@ use kernel::{
         async_trait::async_trait, eyre::Result, once_cell::sync::Lazy, regex::Regex, tracing,
     },
     format::Format,
+    generate_id,
     schema::{
         ExecutionMessage, ImageObject, MessageLevel, Node, SoftwareApplication,
         SoftwareApplicationOptions,
@@ -35,16 +36,34 @@ impl Kernel for GraphvizKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
-        Ok(Box::new(GraphvizKernelInstance))
+        Ok(Box::new(GraphvizKernelInstance::new()))
     }
 }
 
-pub struct GraphvizKernelInstance;
+pub struct GraphvizKernelInstance {
+    /// The unique id of the kernel instance
+    id: String,
+}
+
+impl Default for GraphvizKernelInstance {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GraphvizKernelInstance {
+    /// Create a new instance
+    pub fn new() -> Self {
+        Self {
+            id: generate_id(NAME),
+        }
+    }
+}
 
 #[async_trait]
 impl KernelInstance for GraphvizKernelInstance {
-    fn name(&self) -> String {
-        NAME.to_string()
+    fn id(&self) -> &str {
+        &self.id
     }
 
     async fn execute(&mut self, code: &str) -> Result<(Vec<Node>, Vec<ExecutionMessage>)> {
@@ -114,7 +133,7 @@ impl KernelInstance for GraphvizKernelInstance {
     }
 
     async fn fork(&mut self) -> Result<Box<dyn KernelInstance>> {
-        Ok(Box::new(Self))
+        Ok(Box::new(Self::new()))
     }
 }
 
@@ -127,7 +146,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty() -> Result<()> {
-        let mut kernel = GraphvizKernelInstance {};
+        let mut kernel = GraphvizKernelInstance::new();
 
         let (outputs, messages) = kernel.execute("").await?;
         assert_eq!(messages[0].message, "Expected (graph|digraph)");
@@ -146,7 +165,7 @@ mod tests {
 
     #[tokio::test]
     async fn syntax_errors() -> Result<()> {
-        let mut kernel = GraphvizKernelInstance {};
+        let mut kernel = GraphvizKernelInstance::new();
 
         let (outputs, messages) = kernel.execute("digraph { A -> B").await?;
         assert_eq!(messages[0].message, "Unknown token");

--- a/rust/kernel-jinja/src/lib.rs
+++ b/rust/kernel-jinja/src/lib.rs
@@ -16,6 +16,7 @@ use kernel::{
         serde_json, tokio, tracing,
     },
     format::Format,
+    generate_id,
     schema::{
         ExecutionMessage, MessageLevel, Node, Null, SoftwareApplication, SoftwareApplicationOptions,
     },
@@ -47,14 +48,14 @@ impl Kernel for JinjaKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
-        Ok(Box::new(JinjaKernelInstance::new(NAME)))
+        Ok(Box::new(JinjaKernelInstance::new()))
     }
 }
 
 #[derive(Default)]
 pub struct JinjaKernelInstance {
-    /// The name of the kernel instance
-    name: String,
+    /// The unique id of the kernel instance
+    id: String,
 
     /// The Jinja template context
     ///
@@ -64,9 +65,22 @@ pub struct JinjaKernelInstance {
 }
 
 impl JinjaKernelInstance {
-    pub fn new(name: &str) -> Self {
+    /// Create a new instance
+    pub fn new() -> Self {
         Self {
-            name: name.into(),
+            id: generate_id(NAME),
+            context: None,
+        }
+    }
+
+    /// Create a new instance with a specific id
+    ///
+    /// This constructor is needed when we have a Jinja kernel instance
+    /// that is a child of another kernel instance and we need the
+    /// child and parent to have the same is (for variable resolution)
+    pub fn with_id(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
             context: None,
         }
     }
@@ -91,8 +105,8 @@ impl JinjaKernelInstance {
 
 #[async_trait]
 impl KernelInstance for JinjaKernelInstance {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn id(&self) -> &str {
+        &self.id
     }
 
     async fn execute(&mut self, code: &str) -> Result<(Vec<Node>, Vec<ExecutionMessage>)> {
@@ -184,20 +198,20 @@ impl KernelInstance for JinjaKernelInstance {
         responder: KernelVariableResponder,
     ) {
         self.context = Some(Arc::new(JinjaKernelContext {
-            instance: self.name(),
+            instance: self.id().to_string(),
             variable_channel: Mutex::new((requester, responder)),
         }));
     }
 
     async fn fork(&mut self) -> Result<Box<dyn KernelInstance>> {
-        Ok(Box::new(Self::new(&self.name)))
+        Ok(Box::new(Self::new()))
     }
 }
 
 /// A Jinja template context used to make requests for variable to other kernels
 #[derive(Debug)]
 pub struct JinjaKernelContext {
-    /// The name of the kernel instance
+    /// The id of the kernel instance
     ///
     /// Required to make requests for variables from other contexts
     instance: String,

--- a/rust/kernel-mermaid/src/lib.rs
+++ b/rust/kernel-mermaid/src/lib.rs
@@ -1,6 +1,7 @@
 use kernel::{
     common::{async_trait::async_trait, eyre::Result, tracing},
     format::Format,
+    generate_id,
     schema::{
         ExecutionMessage, ImageObject, Node, SoftwareApplication, SoftwareApplicationOptions,
     },
@@ -32,24 +33,38 @@ impl Kernel for MermaidKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
-        Ok(Box::new(MermaidKernelInstance {
-            // It is important to give the Jinja kernel the same name since
-            // it acting as a proxy to this kernel and a different name can
-            // cause deadlocks for variable requests
-            jinja: JinjaKernelInstance::new(NAME),
-        }))
+        Ok(Box::new(MermaidKernelInstance::new()))
     }
 }
 
 #[derive(Default)]
 pub struct MermaidKernelInstance {
+    /// The unique id of the kernel instance
+    id: String,
+
+    /// The Jinja kernel instance used to render any Jinja templating
     jinja: JinjaKernelInstance,
+}
+
+impl MermaidKernelInstance {
+    /// Create a new instance
+    pub fn new() -> Self {
+        let id = generate_id(NAME);
+        Self {
+            // It is important to give the Jinja kernel the same id since
+            // it acting as a proxy to this kernel and a different id can
+            // cause deadlocks for variable requests
+            jinja: JinjaKernelInstance::with_id(&id),
+
+            id,
+        }
+    }
 }
 
 #[async_trait]
 impl KernelInstance for MermaidKernelInstance {
-    fn name(&self) -> String {
-        NAME.to_string()
+    fn id(&self) -> &str {
+        &self.id
     }
 
     async fn execute(&mut self, code: &str) -> Result<(Vec<Node>, Vec<ExecutionMessage>)> {

--- a/rust/kernel-nodejs/src/lib.rs
+++ b/rust/kernel-nodejs/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use kernel_micro::{
     common::eyre::Result, format::Format, Kernel, KernelAvailability, KernelForks, KernelInstance,
     KernelInterrupt, KernelKill, KernelTerminate, Microkernel,
@@ -7,14 +5,13 @@ use kernel_micro::{
 
 /// A kernel for executing JavaScript code in Node.js
 #[derive(Default)]
-pub struct NodeJsKernel {
-    /// A counter of instances of this microkernel
-    instances: AtomicU64,
-}
+pub struct NodeJsKernel;
+
+const NAME: &str = "nodejs";
 
 impl Kernel for NodeJsKernel {
     fn name(&self) -> String {
-        "nodejs".to_string()
+        NAME.to_string()
     }
 
     fn availability(&self) -> KernelAvailability {
@@ -44,7 +41,7 @@ impl Kernel for NodeJsKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
-        self.microkernel_create_instance(self.instances.fetch_add(1, Ordering::SeqCst))
+        self.microkernel_create_instance(NAME)
     }
 }
 

--- a/rust/kernel-python/src/lib.rs
+++ b/rust/kernel-python/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use kernel_micro::{
     common::eyre::Result, format::Format, Kernel, KernelAvailability, KernelForks, KernelInstance,
     KernelInterrupt, KernelKill, KernelTerminate, Microkernel,
@@ -7,14 +5,13 @@ use kernel_micro::{
 
 /// A kernel for executing Python code
 #[derive(Default)]
-pub struct PythonKernel {
-    /// A counter of instances of this microkernel
-    instances: AtomicU64,
-}
+pub struct PythonKernel;
+
+const NAME: &str = "python";
 
 impl Kernel for PythonKernel {
     fn name(&self) -> String {
-        "python".to_string()
+        NAME.to_string()
     }
 
     fn availability(&self) -> KernelAvailability {
@@ -43,7 +40,7 @@ impl Kernel for PythonKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
-        self.microkernel_create_instance(self.instances.fetch_add(1, Ordering::SeqCst))
+        self.microkernel_create_instance(NAME)
     }
 }
 

--- a/rust/kernel-r/src/lib.rs
+++ b/rust/kernel-r/src/lib.rs
@@ -1,5 +1,3 @@
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use kernel_micro::{
     common::eyre::Result, format::Format, schema::MessageLevel, Kernel, KernelAvailability,
     KernelForks, KernelInstance, KernelInterrupt, KernelKill, KernelTerminate, Microkernel,
@@ -7,14 +5,13 @@ use kernel_micro::{
 
 /// A kernel for executing R code
 #[derive(Default)]
-pub struct RKernel {
-    /// A counter of instances of this microkernel
-    instances: AtomicU64,
-}
+pub struct RKernel;
+
+const NAME: &str = "r";
 
 impl Kernel for RKernel {
     fn name(&self) -> String {
-        "r".to_string()
+        NAME.to_string()
     }
 
     fn availability(&self) -> KernelAvailability {
@@ -42,7 +39,7 @@ impl Kernel for RKernel {
     }
 
     fn create_instance(&self) -> Result<Box<dyn KernelInstance>> {
-        self.microkernel_create_instance(self.instances.fetch_add(1, Ordering::SeqCst))
+        self.microkernel_create_instance(NAME)
     }
 }
 

--- a/rust/kernel/src/lib.rs
+++ b/rust/kernel/src/lib.rs
@@ -2,10 +2,12 @@ use std::path::Path;
 
 use common::{
     async_trait::async_trait,
+    bs58,
     eyre::{bail, Result},
     serde::{Deserialize, Serialize},
     strum::Display,
     tokio::sync::{broadcast, mpsc, watch},
+    uuid::Uuid,
 };
 use format::Format;
 
@@ -194,11 +196,23 @@ pub type KernelVariableResponder = broadcast::Receiver<KernelVariableResponse>;
 #[allow(unused)]
 #[async_trait]
 pub trait KernelInstance: Sync + Send {
-    /// Get the name of the kernel instance
+    /// Get the id of the kernel instance
     ///
-    /// This name should be unique amongst all kernel instances,
-    /// including those for other `Kernel`s.
-    fn name(&self) -> String;
+    /// This id is used to determine if the `execution_required` property
+    /// needs to set to `KernelRestarted` because, although the node may have
+    /// been executed at some time, it was not executed in the current kernel
+    /// instance.
+    ///
+    /// As such, for most kernel instance this id should be unique across all
+    /// kernel instances across processes and time (e.g. include a timestamp).
+    /// This is not strictly necessary for kernels that do not hold state
+    /// (e.g. AsciiMath) but, for consistency, we maintain this convention for
+    /// those too.
+    ///
+    /// For kernels that are not builtin (e.g. Python, R) it
+    /// is useful to incorporate the version and or path of the executable to
+    /// help the user understand which external binary the kernel is running.
+    fn id(&self) -> &str;
 
     /// Get the status of the kernel instance
     async fn status(&self) -> Result<KernelStatus> {
@@ -248,33 +262,33 @@ pub trait KernelInstance: Sync + Send {
     }
 
     /// Get a variable from the kernel instance
-    async fn get(&mut self, name: &str) -> Result<Option<Node>> {
+    async fn get(&mut self, id: &str) -> Result<Option<Node>> {
         Ok(None)
     }
 
     /// Set a variable in the kernel instance
-    async fn set(&mut self, name: &str, value: &Node) -> Result<()> {
+    async fn set(&mut self, id: &str, value: &Node) -> Result<()> {
         Ok(())
     }
 
     /// Remove a variable from the kernel instance
-    async fn remove(&mut self, name: &str) -> Result<()> {
+    async fn remove(&mut self, id: &str) -> Result<()> {
         Ok(())
     }
 
     /// Create a fork of the kernel instance
     async fn fork(&mut self) -> Result<Box<dyn KernelInstance>> {
-        bail!("Kernel `{}` does not support forks", self.name())
+        bail!("Kernel `{}` does not support forks", self.id())
     }
 
     /// Get a watcher of the status of the kernel instance
     fn status_watcher(&self) -> Result<watch::Receiver<KernelStatus>> {
-        bail!("Kernel `{}` does not support watching", self.name())
+        bail!("Kernel `{}` does not support watching", self.id())
     }
 
     /// Get a signaller to interrupt or kill the kernel instance
     fn signal_sender(&self) -> Result<mpsc::Sender<KernelSignal>> {
-        bail!("Kernel `{}` does not support signals", self.name())
+        bail!("Kernel `{}` does not support signals", self.id())
     }
 
     /// Set the channel for requesting variables from other kernels
@@ -284,6 +298,15 @@ pub trait KernelInstance: Sync + Send {
         responder: KernelVariableResponder,
     ) {
     }
+}
+
+/// Generate an id for a kernel instance
+///
+/// Uses the same algorithm as for node ids but with a prefix which
+/// is determined by the `KernelInstance` implementation
+pub fn generate_id(prefix: &str) -> String {
+    let uuid = bs58::encode(&Uuid::new_v4()).into_string();
+    format!("{prefix}_{uuid}")
 }
 
 /// The status of a kernel instance

--- a/rust/kernels/src/lib.rs
+++ b/rust/kernels/src/lib.rs
@@ -80,9 +80,9 @@ struct KernelInstanceEntry {
     /// The kernel that the instance is an instance of
     kernel: Arc<Box<dyn Kernel>>,
 
-    /// The name of the instance. Used to avoid needing to take
-    /// a lock on the instance just to get its name (which is constant)
-    name: String,
+    /// The id of the kernel instance. Used to avoid needing to take
+    /// a lock on the instance just to get its id (which is constant)
+    id: String,
 
     /// The instance itself
     instance: Arc<Mutex<Box<dyn KernelInstance>>>,
@@ -177,14 +177,14 @@ impl Kernels {
                 // If the candidate instance is the same as the request instance then
                 // skip - because unnecessary because likely to cause deadlock in
                 // next step.
-                if entry.name == request.instance {
+                if entry.id == request.instance {
                     continue;
                 }
 
                 let mut instance = entry.instance.lock().await;
                 if let Ok(Some(value)) = instance.get(&response.variable).await {
                     response.value = Some(value);
-                    response.instance = Some(entry.name.clone());
+                    response.instance = Some(entry.id.clone());
                     break;
                 }
             }
@@ -230,7 +230,7 @@ impl Kernels {
         };
 
         let mut instance = kernel.create_instance()?;
-        let name = instance.name();
+        let id = instance.id().to_string();
         if kernel.supports_variable_requests() {
             instance.variable_channel(
                 self.variable_request_sender.clone(),
@@ -243,7 +243,7 @@ impl Kernels {
         let mut instances = self.instances.write().await;
         instances.push(KernelInstanceEntry {
             kernel: Arc::new(kernel),
-            name,
+            id,
             instance: instance.clone(),
         });
 
@@ -267,13 +267,13 @@ impl Kernels {
             );
         }
 
-        let name = instance.name();
+        let id = instance.id().to_string();
         let instance = Arc::new(Mutex::new(instance));
 
         let mut instances = self.instances.write().await;
         instances.push(KernelInstanceEntry {
             kernel,
-            name,
+            id,
             instance,
         });
 
@@ -298,7 +298,7 @@ impl Kernels {
                 return Ok(Some(entry.instance.clone()));
             };
 
-            if entry.name == language {
+            if entry.id == language {
                 return Ok(Some(entry.instance.clone()));
             }
 
@@ -310,6 +310,15 @@ impl Kernels {
         }
 
         Ok(None)
+    }
+
+    /// Determine if the kernels set has an instance with the given id
+    pub async fn has_instance(&mut self, id: &str) -> bool {
+        self.instances
+            .read()
+            .await
+            .iter()
+            .any(|entry| entry.id == id)
     }
 
     /// Get a reference to each of the kernel instances
@@ -327,14 +336,17 @@ impl Kernels {
         &mut self,
         code: &str,
         language: Option<&str>,
-    ) -> Result<(Vec<Node>, Vec<ExecutionMessage>)> {
+    ) -> Result<(Vec<Node>, Vec<ExecutionMessage>, String)> {
         let instance = match self.get_instance(language).await? {
             Some(instance) => instance,
             None => self.create_instance(language).await?,
         };
 
         let mut instance = instance.lock().await;
-        instance.execute(code).await
+        let (nodes, messages) = instance.execute(code).await?;
+        let id = instance.id().to_string();
+
+        Ok((nodes, messages, id))
     }
 
     /// Evaluate a code expression in a kernel instance
@@ -342,14 +354,17 @@ impl Kernels {
         &mut self,
         code: &str,
         language: Option<&str>,
-    ) -> Result<(Node, Vec<ExecutionMessage>)> {
+    ) -> Result<(Node, Vec<ExecutionMessage>, String)> {
         let instance = match self.get_instance(language).await? {
             Some(instance) => instance,
             None => self.create_instance(language).await?,
         };
 
         let mut instance = instance.lock().await;
-        instance.evaluate(code).await
+        let (node, messages) = instance.evaluate(code).await?;
+        let id = instance.id().to_string();
+
+        Ok((node, messages, id))
     }
 
     /// Get a variable from the kernels
@@ -429,18 +444,18 @@ mod tests {
     async fn variables_to_jinja() -> Result<()> {
         let mut kernels = Kernels::new_here();
 
-        let (.., messages) = kernels.execute("let a = 123", Some("rhai")).await?;
+        let (_, messages, ..) = kernels.execute("let a = 123", Some("rhai")).await?;
         assert_eq!(messages, vec![]);
 
-        let (node, messages) = kernels.evaluate("a * 2", Some("jinja")).await?;
+        let (node, messages, ..) = kernels.evaluate("a * 2", Some("jinja")).await?;
         assert_eq!(messages, vec![]);
         assert_eq!(node, Node::Integer(246));
 
-        let (node, messages) = kernels.execute("{{a * 3}}", Some("jinja")).await?;
+        let (node, messages, ..) = kernels.execute("{{a * 3}}", Some("jinja")).await?;
         assert_eq!(messages, vec![]);
         assert_eq!(node, vec![Node::String("369".to_string())]);
 
-        let (node, messages) = kernels.execute("{{foo + 4}}", Some("jinja")).await?;
+        let (node, messages, ..) = kernels.execute("{{foo + 4}}", Some("jinja")).await?;
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].level, MessageLevel::Exception);
         assert_eq!(messages[0].message, "invalid operation: tried to use + operator on unsupported types undefined and number (in <string>:1)");
@@ -466,7 +481,7 @@ mod tests {
 
         // In original kernels post forking
 
-        let (node, messages) = kernels.evaluate("a", Some("js")).await?;
+        let (node, messages, ..) = kernels.evaluate("a", Some("js")).await?;
         assert_eq!(messages, vec![]);
         assert_eq!(node, Node::Integer(1));
 
@@ -476,17 +491,17 @@ mod tests {
         let node = kernels.get("c").await?;
         assert_eq!(node, None);
 
-        let (node, messages) = kernels.evaluate("a + b", Some("jinja")).await?;
+        let (node, messages, ..) = kernels.evaluate("a + b", Some("jinja")).await?;
         assert_eq!(messages, vec![]);
         assert_eq!(node, Node::Integer(3));
 
-        let (nodes, messages) = kernels.execute("{{ c }}", Some("jinja")).await?;
+        let (nodes, messages, ..) = kernels.execute("{{ c }}", Some("jinja")).await?;
         assert_eq!(messages, vec![]);
         assert_eq!(nodes[0], Node::String(String::new()));
 
         // In fork
 
-        let (node, messages) = fork.evaluate("a", Some("js")).await?;
+        let (node, messages, ..) = fork.evaluate("a", Some("js")).await?;
         assert_eq!(messages, vec![]);
         assert_eq!(node, Node::Integer(11));
 
@@ -496,7 +511,7 @@ mod tests {
         let node = fork.get("c").await?;
         assert_eq!(node, Some(Node::Integer(33)));
 
-        let (node, messages) = fork.evaluate("a + b + c", Some("jinja")).await?;
+        let (node, messages, ..) = fork.evaluate("a + b + c", Some("jinja")).await?;
         assert_eq!(messages, vec![]);
         assert_eq!(node, Node::Integer(66));
 

--- a/rust/lsp/src/diagnostics.rs
+++ b/rust/lsp/src/diagnostics.rs
@@ -114,6 +114,7 @@ fn execution_status(node: &TextNode, execution: &TextNodeExecution) -> Option<St
             (status.clone(), status)
         } else if let Some(
             reason @ (ExecutionRequired::NeverExecuted
+            | ExecutionRequired::KernelRestarted
             | ExecutionRequired::StateChanged
             | ExecutionRequired::SemanticsChanged
             | ExecutionRequired::DependenciesChanged
@@ -130,6 +131,9 @@ fn execution_status(node: &TextNode, execution: &TextNodeExecution) -> Option<St
             };
             let message = match reason {
                 NeverExecuted => "Not executed".to_string(),
+                KernelRestarted => {
+                    "Stale: not yet executed in the current kernel instance".to_string()
+                }
                 StateChanged => "Stale: changes since last executed".to_string(),
                 SemanticsChanged => "Stale: semantic changes since last executed".to_string(),
                 DependenciesChanged => "Stale: one or more dependencies have changed".to_string(),

--- a/rust/node-execute/src/code_expression.rs
+++ b/rust/node-execute/src/code_expression.rs
@@ -74,7 +74,7 @@ impl Executable for CodeExpression {
         if !self.code.trim().is_empty() {
             let started = Timestamp::now();
 
-            let (output, messages) = executor
+            let (output, messages, ..) = executor
                 .kernels
                 .write()
                 .await
@@ -87,6 +87,7 @@ impl Executable for CodeExpression {
                             "While evaluating expression",
                             error,
                         )],
+                        String::new(),
                     )
                 });
 

--- a/rust/node-execute/src/for_block.rs
+++ b/rust/node-execute/src/for_block.rs
@@ -102,7 +102,7 @@ impl Executable for ForBlock {
             is_empty = false;
 
             // Evaluate code in kernels to get the iterable
-            let (output, mut code_messages) = executor
+            let (output, mut code_messages, _instance) = executor
                 .kernels
                 .write()
                 .await
@@ -115,6 +115,7 @@ impl Executable for ForBlock {
                             "While evaluating expression",
                             error,
                         )],
+                        String::new(),
                     )
                 });
             messages.append(&mut code_messages);

--- a/rust/node-execute/src/if_block.rs
+++ b/rust/node-execute/src/if_block.rs
@@ -226,7 +226,7 @@ impl Executable for IfBlockClause {
         let is_empty = self.code.trim().is_empty();
         let (is_active, mut status) = if !is_empty {
             // Evaluate code in kernels
-            let (output, mut code_messages) = executor
+            let (output, mut code_messages, ..) = executor
                 .kernels
                 .write()
                 .await
@@ -236,6 +236,7 @@ impl Executable for IfBlockClause {
                     (
                         Node::Null(Null),
                         vec![error_to_execution_message("While evaluating clause", error)],
+                        String::new(),
                     )
                 });
             messages.append(&mut code_messages);

--- a/rust/node-execute/src/math_block.rs
+++ b/rust/node-execute/src/math_block.rs
@@ -46,7 +46,7 @@ impl Executable for MathBlock {
                     .await
                     .map_or_else(
                         |error| (None, vec![error_to_compilation_message(error)]),
-                        |(mut outputs, messages)| {
+                        |(mut outputs, messages, ..)| {
                             let output = (!outputs.is_empty()).then(|| outputs.swap_remove(0));
                             let mathml = match output {
                                 Some(Node::String(mathml)) => Some(mathml),

--- a/rust/node-execute/src/math_inline.rs
+++ b/rust/node-execute/src/math_inline.rs
@@ -37,7 +37,7 @@ impl Executable for MathInline {
                     .await
                     .map_or_else(
                         |error| (None, vec![error_to_compilation_message(error)]),
-                        |(node, messages)| {
+                        |(node, messages, ..)| {
                             let mathml = match node {
                                 Node::String(mathml) => Some(mathml),
                                 _ => None,

--- a/rust/node-execute/src/raw_block.rs
+++ b/rust/node-execute/src/raw_block.rs
@@ -32,7 +32,7 @@ impl Executable for RawBlock {
                 .await
                 .map_or_else(
                     |error| (None, vec![error_to_compilation_message(error)]),
-                    |(outputs, messages)| {
+                    |(outputs, messages, ..)| {
                         let messages = messages.into_iter().map(CompilationMessage::from).collect();
                         (Some(outputs), messages)
                     },

--- a/rust/node-execute/src/styled_block.rs
+++ b/rust/node-execute/src/styled_block.rs
@@ -24,14 +24,14 @@ impl Executable for StyledBlock {
         if !self.code.trim().is_empty() {
             let lang = self.style_language.as_deref().or(Some("style"));
 
-            let (result, messages) = executor
+            let (result, messages, ..) = executor
                 .kernels()
                 .await
                 .execute(self.code.trim(), lang)
                 .await
                 .map_or_else(
                     |error| (None, vec![error_to_compilation_message(error)]),
-                    |(outputs, messages)| {
+                    |(outputs, messages, ..)| {
                         let messages = messages.into_iter().map(CompilationMessage::from).collect();
 
                         (Some(outputs), messages)

--- a/rust/node-execute/src/styled_inline.rs
+++ b/rust/node-execute/src/styled_inline.rs
@@ -31,7 +31,7 @@ impl Executable for StyledInline {
                 .await
                 .map_or_else(
                     |error| (None, vec![error_to_compilation_message(error)]),
-                    |(outputs, messages)| {
+                    |(outputs, messages, ..)| {
                         let messages = messages.into_iter().map(CompilationMessage::from).collect();
 
                         (Some(outputs), messages)

--- a/rust/node-type/src/node_property.rs
+++ b/rust/node-type/src/node_property.rs
@@ -91,6 +91,7 @@ pub enum NodeProperty {
     ExecutionDigest,
     ExecutionDuration,
     ExecutionEnded,
+    ExecutionInstance,
     ExecutionKind,
     ExecutionMessages,
     ExecutionMode,

--- a/rust/plugins/src/kernels.rs
+++ b/rust/plugins/src/kernels.rs
@@ -134,7 +134,7 @@ pub struct PluginKernelInstance {
     /// The plugin instance started when this kernel is started
     plugin_instance: Option<PluginInstance>,
 
-    /// The name of the kernel instance on the plugin instance
+    /// The id of the kernel instance on the plugin instance
     kernel_instance: Option<String>,
 }
 
@@ -159,13 +159,14 @@ impl PluginKernelInstance {
 
 #[async_trait]
 impl KernelInstance for PluginKernelInstance {
-    fn name(&self) -> String {
+    fn id(&self) -> &str {
         // This should only be called once the kernel has stated and
-        // has a name. But in case it has not, and because this method
-        // is infallible, default to "unnamed".
-        self.kernel_instance
-            .clone()
-            .unwrap_or_else(|| String::from("unnamed"))
+        // has a id. But in case it has not, and because this method
+        // is infallible, default to "noid".
+        match &self.kernel_instance {
+            Some(id) => id.as_str(),
+            None => "noid",
+        }
     }
 
     async fn start(&mut self, _directory: &Path) -> Result<()> {

--- a/rust/prompt/src/lib.rs
+++ b/rust/prompt/src/lib.rs
@@ -33,7 +33,7 @@ pub struct PromptContext {
 impl PromptContext {
     /// Create a QuickJS kernel instance for the context
     pub async fn into_kernel(self) -> Result<Box<dyn KernelInstance>> {
-        let mut instance = QuickJsKernelInstance::new("prompt".to_string());
+        let mut instance = QuickJsKernelInstance::new();
         instance.start_here().await?;
         instance
             .runtime_context()?

--- a/rust/schema/src/types/article.rs
+++ b/rust/schema/src/types/article.rs
@@ -390,6 +390,12 @@ pub struct ArticleOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/button.rs
+++ b/rust/schema/src/types/button.rs
@@ -149,6 +149,11 @@ pub struct ButtonOptions {
     #[strip(execution)]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/call_argument.rs
+++ b/rust/schema/src/types/call_argument.rs
@@ -158,6 +158,12 @@ pub struct CallArgumentOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/call_block.rs
+++ b/rust/schema/src/types/call_block.rs
@@ -170,6 +170,12 @@ pub struct CallBlockOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/code_chunk.rs
+++ b/rust/schema/src/types/code_chunk.rs
@@ -208,6 +208,12 @@ pub struct CodeChunkOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/code_expression.rs
+++ b/rust/schema/src/types/code_expression.rs
@@ -172,6 +172,12 @@ pub struct CodeExpressionOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/for_block.rs
+++ b/rust/schema/src/types/for_block.rs
@@ -208,6 +208,12 @@ pub struct ForBlockOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/form.rs
+++ b/rust/schema/src/types/form.rs
@@ -121,6 +121,11 @@ pub struct FormOptions {
     #[strip(execution)]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/if_block.rs
+++ b/rust/schema/src/types/if_block.rs
@@ -140,6 +140,12 @@ pub struct IfBlockOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/if_block_clause.rs
+++ b/rust/schema/src/types/if_block_clause.rs
@@ -185,6 +185,12 @@ pub struct IfBlockClauseOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/include_block.rs
+++ b/rust/schema/src/types/include_block.rs
@@ -157,6 +157,12 @@ pub struct IncludeBlockOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/instruction_block.rs
+++ b/rust/schema/src/types/instruction_block.rs
@@ -188,6 +188,12 @@ pub struct InstructionBlockOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/instruction_inline.rs
+++ b/rust/schema/src/types/instruction_inline.rs
@@ -188,6 +188,12 @@ pub struct InstructionInlineOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/parameter.rs
+++ b/rust/schema/src/types/parameter.rs
@@ -142,6 +142,12 @@ pub struct ParameterOptions {
     #[cfg_attr(feature = "proptest", proptest(value = "None"))]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    #[cfg_attr(feature = "proptest", proptest(value = "None"))]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/prompt.rs
+++ b/rust/schema/src/types/prompt.rs
@@ -339,6 +339,11 @@ pub struct PromptOptions {
     #[strip(execution)]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/rust/schema/src/types/prompt_block.rs
+++ b/rust/schema/src/types/prompt_block.rs
@@ -124,6 +124,11 @@ pub struct PromptBlockOptions {
     #[strip(execution)]
     pub execution_status: Option<ExecutionStatus>,
 
+    /// The id of the kernel instance that performed the last execution.
+    #[serde(alias = "execution-instance", alias = "execution_instance")]
+    #[strip(execution)]
+    pub execution_instance: Option<String>,
+
     /// The kind (e.g. main kernel vs kernel fork) of the last execution.
     #[serde(alias = "execution-kind", alias = "execution_kind")]
     #[strip(execution)]

--- a/schema/Executable.yaml
+++ b/schema/Executable.yaml
@@ -84,6 +84,14 @@ properties:
     description: Status of the most recent, including any current, execution.
     strip: [execution]
     $ref: ExecutionStatus
+  executionInstance:
+    '@id': stencila:executionInstance
+    description: The id of the kernel instance that performed the last execution.
+    $comment: |
+      Used to help identify whether execution is required due to the last execution
+      being in a difference instance (e.g. after a kernel restart).
+    strip: [execution]
+    type: string
   executionKind:
     '@id': stencila:executionKind
     description: The kind (e.g. main kernel vs kernel fork) of the last execution.

--- a/ts/src/types/Executable.ts
+++ b/ts/src/types/Executable.ts
@@ -73,6 +73,11 @@ export class Executable extends Entity {
   executionStatus?: ExecutionStatus;
 
   /**
+   * The id of the kernel instance that performed the last execution.
+   */
+  executionInstance?: string;
+
+  /**
    * The kind (e.g. main kernel vs kernel fork) of the last execution.
    */
   executionKind?: ExecutionKind;


### PR DESCRIPTION
The adds an `executionInstance` property to `Executable` nodes which allows for detecting whether or not a `CodeChunk` has been executed in the current kernel instance for a language.

Currently only used to determine `executionRequired` for `CodeChunk` but that may be extended to other node types in the future.