### PR TITLE
fix(vscode): show account email if available, when account logged in

### DIFF
--- a/vscode/src/authentication.ts
+++ b/vscode/src/authentication.ts
@@ -202,12 +202,19 @@ export class StencilaCloudProvider implements vscode.AuthenticationProvider {
     let userLabel;
     if (userResponse.status === 200) {
       // Check if the required properties exist in the response
-      const { username, firstName, lastName } = (await userResponse.json()) as {
-        username?: string;
-        firstName?: string;
-        lastName?: string;
-      };
-      userLabel = username ?? firstName ?? lastName ?? userId.slice(0, 12);
+      const { username, firstName, lastName, emailAddresses } =
+        (await userResponse.json()) as {
+          username?: string;
+          firstName?: string;
+          lastName?: string;
+          emailAddresses?: any[];
+        };
+      userLabel =
+        username ??
+        firstName ??
+        lastName ??
+        emailAddresses?.find((e) => e.email_address)?.email_address ??
+        userId.slice(0, 12);
     } else if (userResponse.status === 404) {
       // It is possible that we do not yet have an entry in the users table
       // yet so use the user id


### PR DESCRIPTION
https://github.com/stencila/stencila/issues/2336

Ideally we would show the users name when logged in, but usually they have not entered it and it falls back to userId. This PR will try to find an email address to fall back to before resorting to userId.

![image](https://github.com/user-attachments/assets/e69a429e-5018-4df9-a785-a6002e7d5e79)
