### PR TITLE
feature(devcontainer) - a `.devcontainer` profile for demoing the vscode extension

### DIFF
--- a/.devcontainer/demo/Dockerfile
+++ b/.devcontainer/demo/Dockerfile
@@ -1,0 +1,6 @@
+FROM --platform=linux/amd64 ubuntu:24.04 
+
+ENV DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
+
+RUN apt-get update && apt-get install -y --allow-change-held-packages --no-install-recommends build-essential git r-base r-cran-tidyverse python3 python3-pip python3-numpy python3-matplotlib python3-requests python3-pandas python3-setuptools python3-dev 
+

--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -9,7 +9,14 @@
     "extensions": [
       "stencila.stencila"
     ]
+  },
+  "secrets": {
+  "STENCILA_API_TOKEN": {
+    "description": "Add your stencila API token from stencila.cloud",
+    "documentationUrl": "https:\\stencila.cloud"
   }
+}
+
 }
 
 

--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+
+
+	"build": { "dockerfile": "Dockerfile" },
+	"customizations": {
+  "vscode": {
+    "extensions": [
+      "stencila.stencila"
+    ]
+  }
+}
+
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/demo/devcontainer.json
+++ b/.devcontainer/demo/devcontainer.json
@@ -2,45 +2,18 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
 
-
 	"build": { "dockerfile": "Dockerfile" },
 	"customizations": {
-  "vscode": {
-    "extensions": [
-      "stencila.stencila"
-    ]
-  },
-  "secrets": {
-  "STENCILA_API_TOKEN": {
-    "description": "Add your stencila API token from stencila.cloud",
-    "documentationUrl": "https:\\stencila.cloud"
-  }
-}
-
-}
-
-
-	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
-	// "mounts": [
-	// 	{
-	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
-	// 		"target": "/usr/local/cargo",
-	// 		"type": "volume"
-	// 	}
-	// ]
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+		"vscode": {
+			"extensions": [
+			"stencila.stencila"
+			]
+		},
+		"secrets": {
+		"STENCILA_API_TOKEN": {
+			"description": "Add your stencila API token from stencila.cloud",
+			"documentationUrl": "https:\\stencila.cloud"
+			}
+		}
+	}
 }


### PR DESCRIPTION
Here is the demo container for inclusion in the main stencila repo.

You will need to enable this in codespaces on this repository manually in the repo's Codespaces Settings:
https://docs.github.com/en/codespaces/developing-in-a-codespace/creating-a-codespace-for-a-repository

It will prompt for a STENCILA_API_TOKEN when started up, you can add this environment variable to your account globally at: https://github.com/settings/codespaces