### PR TITLE
refactor(markdown syntax): revise syntax for self-closing and next-block commands

### DIFF
--- a/docs/walkthroughs/command-syntax.smd
+++ b/docs/walkthroughs/command-syntax.smd
@@ -41,10 +41,10 @@ Rather than having to write three new lines for a `create` command e.g.
 :::
 ```
 
-Stencila allows you to write a "self closing" opening fence by adding `<<` to the end of the line e.g.
+Stencila allows you to write a "self closing" opening fence by adding `:::` to the end of the line e.g.
 
 ```markdown
-::: create plot of height versus width <<
+::: create plot of height versus width :::
 ```
 
 ...
@@ -63,10 +63,10 @@ The cat sat on
 :::
 ```
 
-Stencila uses a "next block only" shorthand, by adding `>>` to the end of the opening fence when there is only one block in the target content or active suggestion of a command e.g.
+Stencila uses a "next block only" shorthand, by adding `>>>` to the end of the opening fence when there is only one block in the target content or active suggestion of a command e.g.
 
 ```markdown
-::: edit expand to 20-30 words >>
+::: edit expand to 20-30 words >>>
 
 The cat sat on
 ```
@@ -74,7 +74,7 @@ The cat sat on
 Here is an example of a `create` block, which has already been run and has a single suggestion:
 
 ````markdown
-::: create code to print hello world >>
+::: create code to print hello world >>>
 
 ```python exec
 print("Hello world")


### PR DESCRIPTION
Stencila Markdown uses two shorthands for semicolon fences: "self closing" (no child blocks in content or active suggestion) and "next-block" (there is only one child block in content or active suggestion). The `docs/walkthroughs/command-syntax.smd` (see the files changed in the PR for quick access) file explains the rationale for having these shorthands.

User tests indicate that the existing syntax is confusing:

- inconsistency of having three colons at the start of the line and two angle brackets at the end e.g. `::: edit expand to 2 paragraphs >>`

- difficulty in remembering which direction angle brackets should be pointing for self-closing shorthand (`<<`) versus next-block-only shorthand (`>>`)

This PR proposes to change the syntax to:

- for self-closing fences using three colons at the end of the line e.g. `::: create code to plot data :::`

- for next-block fences using three right pointing angle brackets e.g. `::: edit expand to 40-50 words >>>`

See the changes to `docs/walkthroughs/command-syntax.smd` for more example of how this would look.

If the majority of reviewers think this is an improvement then I will extend this PR with the further changes needed to the Markdown codec, syntax highlighter, snippets, tests etc.
