### PR TITLE
fix(code-inline): remove backtick, reduce font size

### DIFF
--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -12,8 +12,8 @@
 
   /* code */
   --code-font-family: 'IBM Plex Mono', monospace;
-  --code-bg-colour: #f2f2f2;
-  --code-font-size: 1rem;
+  --code-bg-colour: rgba(217, 217, 217, 1);
+  --code-font-size: 0.875rem;
 
   --mathml-font-family: 'STIX Two Math';
 
@@ -276,7 +276,13 @@ body {
       font-family: var(--code-font-family);
       font-size: var(--code-font-size);
       background-color: var(--code-bg-colour);
-      @apply rounded font-normal;
+      @apply rounded-sm font-normal px-0.5;
+
+      /* remove backticks inserted by the tw typography .prose */
+      &::before,
+      &::after {
+        content: '';
+      }
     }
   }
 


### PR DESCRIPTION
**details**

- reduced font size from 1rem to 0.875rem.
- added darker bg colour.
- reduced the border radius.
- removed the backticks (these were coming from the '@tailwind/typography' plugin).
- added some light horizontal padding to provide some breathing room at the start and end of the block.

![image](https://github.com/user-attachments/assets/be3da513-7b70-4228-af55-39b09ce10ffe)

closes #2413 