### PR TITLE
fix(timestamp): replace relative time with consistant value for test 2448

### DIFF
--- a/web/src/ui/nodes/properties/generic/timestamp.ts
+++ b/web/src/ui/nodes/properties/generic/timestamp.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from 'lit/decorators.js'
 import moment from 'moment'
 
 import { withTwind } from '../../../../twind'
+import { getModeParam } from '../../../../utilities/getModeParam'
 
 /**
  * UI Node Timestamp Property
@@ -33,6 +34,14 @@ export class UINodeTimestampProperty extends LitElement {
    * Set the `relativeTime` property and request the element update
    */
   private updateRelativeTime = () => {
+    const windowMode = getModeParam(window)
+
+    // if in test mode, set an arbitrary value for consistency across the screenshots
+    if (windowMode && windowMode === 'test-expand-all') {
+      this.relativeTime = 'some time ago'
+      return
+    }
+
     this.relativeTime =
       this.value === undefined || this.value === 0
         ? '-'

--- a/web/src/utilities/getModeParam.ts
+++ b/web/src/utilities/getModeParam.ts
@@ -1,6 +1,6 @@
 /**
- * A function that takes the window instance and checks for the `?mode=` param
- * Will retunr the value is it is there, otherwise `null`
+ * A function that takes the window instance and checks for the `?mode=` param.
+ * If param exists, will return the value, otherwise returns `null`.
  */
 export const getModeParam = (window: Window) => {
   const params = new URLSearchParams(window.location.search)


### PR DESCRIPTION
**details**

when the window is in 'test-expand-all' mode, the timestamp components will replace the dynamic values with 'some-time-ago' to avoid flagging in the regression screenshot tests.


closes: #2448 