### PR TITLE
Odt codec

### DIFF
--- a/rust/codec-odt/Cargo.toml
+++ b/rust/codec-odt/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "codec-odt"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+codec = { path = "../codec" }
+codec-pandoc = { path = "../codec-pandoc" }

--- a/rust/codec-odt/Cargo.toml
+++ b/rust/codec-odt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codec-odt"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [dependencies]

--- a/rust/codec-odt/src/lib.rs
+++ b/rust/codec-odt/src/lib.rs
@@ -1,0 +1,92 @@
+use std::path::Path;
+
+use codec::{
+    common::{async_trait::async_trait, eyre::Result},
+    format::Format,
+    schema::Node,
+    status::Status,
+    Codec, CodecSupport, DecodeInfo, DecodeOptions, EncodeInfo, EncodeOptions, NodeType,
+};
+use codec_pandoc::{pandoc_from_format, pandoc_to_format, root_from_pandoc, root_to_pandoc};
+
+/// A codec for Open Document Format
+pub struct OdtCodec;
+
+const PANDOC_FORMAT: &str = "odt";
+
+#[async_trait]
+impl Codec for OdtCodec {
+    fn name(&self) -> &str {
+        "odt"
+    }
+
+    fn status(&self) -> Status {
+        Status::UnderDevelopment
+    }
+
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
+        match format {
+            Format::Odt => CodecSupport::LowLoss,
+            _ => CodecSupport::None,
+        }
+    }
+
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
+        match format {
+            Format::Odt => CodecSupport::LowLoss,
+            _ => CodecSupport::None,
+        }
+    }
+
+    fn supports_from_type(&self, _node_type: NodeType) -> CodecSupport {
+        CodecSupport::LowLoss
+    }
+
+    fn supports_to_type(&self, _node_type: NodeType) -> CodecSupport {
+        CodecSupport::LowLoss
+    }
+
+    fn supports_from_string(&self) -> bool {
+        false
+    }
+
+    fn supports_to_string(&self) -> bool {
+        false
+    }
+
+    async fn from_path(
+        &self,
+        path: &Path,
+        options: Option<DecodeOptions>,
+    ) -> Result<(Node, DecodeInfo)> {
+        let pandoc = pandoc_from_format(
+            "",
+            Some(path),
+            PANDOC_FORMAT,
+            options
+                .map(|options| options.passthrough_args)
+                .unwrap_or_default(),
+        )
+        .await?;
+        root_from_pandoc(pandoc)
+    }
+
+    async fn to_path(
+        &self,
+        node: &Node,
+        path: &Path,
+        options: Option<EncodeOptions>,
+    ) -> Result<EncodeInfo> {
+        let (pandoc, info) = root_to_pandoc(node)?;
+        pandoc_to_format(
+            &pandoc,
+            Some(path),
+            PANDOC_FORMAT,
+            options
+                .map(|options| options.passthrough_args)
+                .unwrap_or_default(),
+        )
+        .await?;
+        Ok(info)
+    }
+}

--- a/rust/codecs/Cargo.toml
+++ b/rust/codecs/Cargo.toml
@@ -24,12 +24,14 @@ codec-json5 = { path = "../codec-json5" }
 codec-jsonld = { path = "../codec-jsonld" }
 codec-latex = { path = "../codec-latex" }
 codec-markdown = { path = "../codec-markdown" }
+codec-odt = {path = "../codec-odt"}
 codec-pandoc = { path = "../codec-pandoc" }
 codec-pdf = { path = "../codec-pdf" }
 codec-swb = { path = "../codec-swb" }
 codec-text = { path = "../codec-text" }
 codec-yaml = { path = "../codec-yaml" }
 node-strip = { path = "../node-strip" }
+
 
 [dev-dependencies]
 common-dev = { path = "../common-dev" }

--- a/rust/codecs/Cargo.toml
+++ b/rust/codecs/Cargo.toml
@@ -32,7 +32,6 @@ codec-text = { path = "../codec-text" }
 codec-yaml = { path = "../codec-yaml" }
 node-strip = { path = "../node-strip" }
 
-
 [dev-dependencies]
 common-dev = { path = "../common-dev" }
 json_value_merge = "2.0.0"

--- a/rust/codecs/src/lib.rs
+++ b/rust/codecs/src/lib.rs
@@ -32,6 +32,7 @@ pub fn list() -> Vec<Box<dyn Codec>> {
         Box::new(codec_jsonld::JsonLdCodec),
         Box::new(codec_latex::LatexCodec),
         Box::new(codec_markdown::MarkdownCodec),
+        Box::new(codec_odt::OdtCodec),
         Box::new(codec_pandoc::PandocCodec),
         Box::new(codec_pdf::PdfCodec),
         Box::<codec_swb::SwbCodec>::default(),

--- a/rust/codecs/tests/snapshots/specs__specs.snap
+++ b/rust/codecs/tests/snapshots/specs__specs.snap
@@ -1,6 +1,7 @@
 ---
 source: rust/codecs/tests/specs.rs
 expression: specs
+snapshot_kind: text
 ---
 {
   "cbor": {
@@ -186,6 +187,21 @@ expression: specs
     },
     "supports_to_bytes": false,
     "supports_to_string": true,
+    "supports_to_path": true
+  },
+  "odt": {
+    "status": "under-development",
+    "supports_from_formats": {
+      "odt": "LowLoss"
+    },
+    "supports_from_bytes": false,
+    "supports_from_string": false,
+    "supports_from_path": true,
+    "supports_to_formats": {
+      "odt": "LowLoss"
+    },
+    "supports_to_bytes": false,
+    "supports_to_string": false,
     "supports_to_path": true
   },
   "pandoc": {

--- a/rust/format/src/lib.rs
+++ b/rust/format/src/lib.rs
@@ -44,6 +44,7 @@ pub enum Format {
     Text,
     // Word processor formats
     Docx,
+    Odt,
     // Math languages
     AsciiMath,
     Tex,
@@ -137,6 +138,7 @@ impl Format {
             Mp3 => "MPEG-3",
             Mp4 => "MPEG-4",
             Myst => "MyST Markdown",
+            Odt => "OpenDocument ODT",
             Ogg => "Ogg Vorbis",
             Ogv => "Ogg Vorbis Video",
             Pandoc => "Pandoc AST",
@@ -247,6 +249,7 @@ impl Format {
             "mkv" => Mkv,
             "mp3" => Mp3,
             "mp4" => Mp4,
+            "odt" => Odt,
             "ogg" => Ogg,
             "ogv" => Ogv,
             "pandoc" => Pandoc,
@@ -418,6 +421,7 @@ impl Display for Format {
             Mp3 => "mp3",
             Mp4 => "mp4",
             Myst => "myst",
+            Odt => "odt",
             Ogg => "ogg",
             Ogv => "ogv",
             Pandoc => "pandoc",


### PR DESCRIPTION
This allows for converting to and from Open Document format (`.odt`). There are still quite a few things that are lost on conversion like the `docx` codec