### PR TITLE
List formats

### DIFF
--- a/rust/cli/src/compile.rs
+++ b/rust/cli/src/compile.rs
@@ -28,6 +28,7 @@ pub struct Cli {
     ///
     /// Defaults to inferring the format from the file name extension
     /// of the `output`. If no `output` is supplied, defaults to JSON.
+    /// See `stencila codecs list` for available formats.
     #[arg(long, short)]
     to: Option<String>,
 

--- a/rust/cli/src/convert.rs
+++ b/rust/cli/src/convert.rs
@@ -26,6 +26,8 @@ pub struct Cli {
     ///
     /// Defaults to inferring the format from the file name extension
     /// of the `input`.
+    ///
+    /// To view all supported file formats uses the codecs command.
     #[arg(long, short)]
     from: Option<String>,
 

--- a/rust/cli/src/convert.rs
+++ b/rust/cli/src/convert.rs
@@ -26,8 +26,7 @@ pub struct Cli {
     ///
     /// Defaults to inferring the format from the file name extension
     /// of the `input`.
-    ///
-    /// To view all supported file formats uses the codecs command.
+    /// See `stencila codecs list` for available formats.
     #[arg(long, short)]
     from: Option<String>,
 
@@ -35,6 +34,7 @@ pub struct Cli {
     ///
     /// Defaults to inferring the format from the file name extension
     /// of the `output`. If no `output` is supplied, defaults to JSON.
+    /// See `stencila codecs list` for available formats.
     #[arg(long, short)]
     to: Option<String>,
 

--- a/rust/cli/src/execute.rs
+++ b/rust/cli/src/execute.rs
@@ -30,6 +30,7 @@ pub struct Cli {
     ///
     /// Defaults to inferring the format from the file name extension
     /// of the `output`. If no `output` is supplied, defaults to JSON.
+    /// See `stencila codecs list` for available formats.
     #[arg(long, short)]
     to: Option<String>,
 

--- a/rust/cli/src/render.rs
+++ b/rust/cli/src/render.rs
@@ -31,6 +31,7 @@ pub struct Cli {
     ///
     /// Defaults to inferring the format from the file name extension
     /// of the `output`. If no `output` is supplied, defaults to Markdown.
+    /// See `stencila codecs list` for available formats.
     #[arg(long, short)]
     to: Option<String>,
 

--- a/rust/codecs/src/cli.rs
+++ b/rust/codecs/src/cli.rs
@@ -1,8 +1,9 @@
-use cli_utils::table::{self, Attribute, Cell};
+use cli_utils::table::{self, Attribute, Cell, Color};
 use codec::common::{
     clap::{self, Args, Parser, Subcommand},
     eyre::Result,
 };
+use codec::status::Status;
 
 /// Manage format conversion codecs
 #[derive(Debug, Parser)]
@@ -38,12 +39,30 @@ struct List;
 impl List {
     async fn run(self) -> Result<()> {
         let mut table = table::new();
-        table.set_header(["Name", "Status"]);
+        table.set_header(["Name", "Input formats", "Output formats", "Status"]);
 
         for codec in super::list() {
+            let supports_input = codec.supports_from_path();
+            let supports_output = codec.supports_to_path();
+            let status = codec.status();
             table.add_row([
                 Cell::new(codec.name()).add_attribute(Attribute::Bold),
-                Cell::new(codec.status()),
+                match supports_input {
+                    true => Cell::new("Yes").fg(Color::Green),
+                    false => Cell::new("No"),
+                },
+                match supports_output {
+                    true => Cell::new("Yes").fg(Color::Green),
+                    false => Cell::new("No"),
+                },
+                match status {
+                    Status::Planned => Cell::new(status).fg(Color::Red),
+                    Status::UnderDevelopment => Cell::new(status).fg(Color::Yellow),
+                    Status::Stable => Cell::new(status).fg(Color::Green),
+                    Status::Beta => Cell::new(status).fg(Color::DarkBlue),
+                    Status::Alpha => Cell::new(status).fg(Color::Magenta),
+                    Status::Experimental => Cell::new(status).fg(Color::DarkRed),
+                },
             ]);
         }
 

--- a/rust/codecs/tests/snapshots/specs__specs.snap
+++ b/rust/codecs/tests/snapshots/specs__specs.snap
@@ -169,7 +169,7 @@ expression: specs
   "markdown": {
     "status": "beta",
     "supports_from_formats": {
-      "markdown": "LowLoss",
+      "md": "LowLoss",
       "smd": "LowLoss",
       "qmd": "LowLoss",
       "myst": "LowLoss"
@@ -178,7 +178,7 @@ expression: specs
     "supports_from_string": true,
     "supports_from_path": true,
     "supports_to_formats": {
-      "markdown": "LowLoss",
+      "md": "LowLoss",
       "smd": "LowLoss",
       "qmd": "LowLoss",
       "myst": "LowLoss",

--- a/rust/format/src/lib.rs
+++ b/rust/format/src/lib.rs
@@ -412,7 +412,7 @@ impl Display for Format {
             JsonLd => "jsonld",
             Latex => "latex",
             Llmd => "llmd",
-            Markdown => "markdown",
+            Markdown => "md",
             Mermaid => "mermaid",
             Mkv => "mkv",
             Mp3 => "mp3",

--- a/rust/prompt/src/instruction/mod.rs
+++ b/rust/prompt/src/instruction/mod.rs
@@ -47,8 +47,10 @@ impl Instruction {
         };
 
         static TARGET: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(r"((below|next)|(above|prev(ious)?))?\s*((code)|(fig(ure)?)|(tab(le)?))?\s*(\d+)?")
-                .expect("invalid regex")
+            Regex::new(
+                r"((below|next)|(above|prev(ious)?))?\s*((code)|(fig(ure)?)|(tab(le)?))?\s*(\d+)?",
+            )
+            .expect("invalid regex")
         });
         let Some(captures) = TARGET.captures(message) else {
             // Unable to determine target from message, so just return the next block


### PR DESCRIPTION
added Input and Output format rows to the table created by the `codecs` command and colors to the status 
![Screenshot 2024-11-29 at 10 00 34](https://github.com/user-attachments/assets/670ed826-4584-4b12-89db-129b4084a7c6)

also added a quick message in the convert help page 
![Screenshot 2024-11-29 at 10 05 02](https://github.com/user-attachments/assets/4c9b3cd3-c9c0-46fe-8fc6-17b7e3e9e50a)

