### PR TITLE
Fix/nodemarkers going off screen

### DIFF
--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -6,7 +6,7 @@
 @import url('../fonts/stix-two-math/stix-two-math.css');
 
 :root {
-  padding: 3rem;
+  padding: 4rem;
   /* custom properties */
   --default-text-colour: #171817;
 

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -6,7 +6,7 @@
 @import url('../fonts/stix-two-math/stix-two-math.css');
 
 :root {
-  padding: 4rem;
+  padding: 3rem 4rem;
   /* custom properties */
   --default-text-colour: #171817;
 

--- a/web/src/ui/nodes/mixins/toggle-marker.ts
+++ b/web/src/ui/nodes/mixins/toggle-marker.ts
@@ -28,8 +28,12 @@ export type NodeColours = Pick<
   'borderColour' | 'colour' | 'textColour'
 >
 
+// Nested
 const HORIZ_INSET_PIXELS = 5
+// The base offset in pixels for the node marker
 const BASE_OFFSET = 60
+// The number in pixels to remove from the offset for smaller screens
+const SMALL_DEVICE_OFFSET_MODIFIER = 10
 
 /**
  * A Mixin that provides a "marker" with a vertical bar, to allow for a card to have its visibility
@@ -135,7 +139,7 @@ export const ToggleMarkerMixin = <T extends Constructor<UIBaseCard>>(
         'h-full',
         'transition-all duration-200 ease-in-out',
         'hover:cursor-pointer hover:z-50',
-        `-left-[${offset - 10}px] sm:-left-[${offset}px]`,
+        `-left-[${offset - SMALL_DEVICE_OFFSET_MODIFIER}px] sm:-left-[${offset}px]`,
         this.toggleMarkerPosition,
       ])
 

--- a/web/src/ui/nodes/mixins/toggle-marker.ts
+++ b/web/src/ui/nodes/mixins/toggle-marker.ts
@@ -98,6 +98,14 @@ export const ToggleMarkerMixin = <T extends Constructor<UIBaseCard>>(
       )
     }
 
+    override connectedCallback(): void {
+      super.connectedCallback()
+      const testMode = getModeParam(window)
+      if (testMode && testMode === 'test-expand-all') {
+        this.toggle = true
+      }
+    }
+
     protected renderMarker() {
       const nodeDisplay = InlineTypeList.includes(this.type)
         ? 'inline'
@@ -127,7 +135,7 @@ export const ToggleMarkerMixin = <T extends Constructor<UIBaseCard>>(
         'h-full',
         'transition-all duration-200 ease-in-out',
         'hover:cursor-pointer hover:z-50',
-        `-left-[${offset}px]`,
+        `-left-[${offset - 10}px] sm:-left-[${offset}px]`,
         this.toggleMarkerPosition,
       ])
 
@@ -175,14 +183,6 @@ export const ToggleMarkerMixin = <T extends Constructor<UIBaseCard>>(
           ></stencila-ui-icon-button>
         </div>
       `
-    }
-
-    override connectedCallback(): void {
-      super.connectedCallback()
-      const testMode = getModeParam(window)
-      if (testMode && testMode === 'test-expand-all') {
-        this.toggle = true
-      }
     }
   }
 


### PR DESCRIPTION
Some tweaks to keep the new node marker elements inside the window

- increase horizontal padding on the window
- decrease the offset by 10px on smaller screen widths

closes: #2452