### PR TITLE
Fix/vscode ui bugs

### DIFF
--- a/web/src/clients/webview.ts
+++ b/web/src/clients/webview.ts
@@ -365,8 +365,7 @@ export class WebViewClient {
   /**
    * Handle a received `ScrollSyncMessage` message
    */
-  private handleScrollSyncMessage(data: ScrollSyncMessage) {
-    const { startId, cursorId } = data
+  private handleScrollSyncMessage({ startId, cursorId }: ScrollSyncMessage) {
     // Prioritize cursor position if it exists
     if (cursorId) {
       const cursorElement = document.getElementById(cursorId)
@@ -389,7 +388,12 @@ export class WebViewClient {
     if (startId) {
       const startElement = document.getElementById(startId)
 
-      if (startElement && startElement.depth === 1) {
+      /*
+        To avoid jumpy screens, only track an element
+        if it is the top level of the document.
+      */
+      // @ts-expect-error `depth` property will not expected on `Element`
+      if (startElement && startElement?.depth === 1) {
         const viewportHeight = window.innerHeight
         const rect = startElement.getBoundingClientRect()
 

--- a/web/src/clients/webview.ts
+++ b/web/src/clients/webview.ts
@@ -365,7 +365,8 @@ export class WebViewClient {
   /**
    * Handle a received `ScrollSyncMessage` message
    */
-  private handleScrollSyncMessage({ startId, cursorId }: ScrollSyncMessage) {
+  private handleScrollSyncMessage(data: ScrollSyncMessage) {
+    const { startId, cursorId } = data
     // Prioritize cursor position if it exists
     if (cursorId) {
       const cursorElement = document.getElementById(cursorId)
@@ -387,13 +388,16 @@ export class WebViewClient {
     // If no cursor, try to maintain viewport position using start/end elements
     if (startId) {
       const startElement = document.getElementById(startId)
-      if (startElement) {
+
+      if (startElement && startElement.depth === 1) {
         const viewportHeight = window.innerHeight
         const rect = startElement.getBoundingClientRect()
 
+        const top = rect.top + window.scrollY - viewportHeight * 0.1
+
         // Scroll to position the start element near the top with some padding
         window.scrollTo({
-          top: rect.top + window.scrollY - viewportHeight * 0.1,
+          top,
           behavior: 'smooth',
         })
       }

--- a/web/src/nodes/instruction-block.ts
+++ b/web/src/nodes/instruction-block.ts
@@ -308,6 +308,7 @@ export class InstructionBlock extends Instruction {
             : ''}"
         >
           <div
+            class="pointer-events-none"
             style="transition: transform 0.3s ease-in-out; transform: translateX(-${this
               .activeSuggestion * 100}%)"
           >

--- a/web/src/nodes/instruction-block.ts
+++ b/web/src/nodes/instruction-block.ts
@@ -302,8 +302,8 @@ export class InstructionBlock extends Instruction {
           <slot name="content" @slotchange=${this.onContentSlotChange}></slot>
         </div>
         <div
-          class="suggestions-container ${this.activeSuggestion === null ||
-          this.activeSuggestion === undefined
+          class="suggestions-container overflow-x-hidden ${this
+            .activeSuggestion === null || this.activeSuggestion === undefined
             ? 'hidden'
             : ''}"
         >


### PR DESCRIPTION
**details**

Suggestions
- set overflow hidden on the parent of transforming carousel div to stop overflowed suggestions creating x scrolling space
- disable pointer events on carousel div to stop the left overflow blocking click events on the create node marker

Scroll link behaviour
- disabled the preveiw scroll linking on nested elements, this at least stops the jumpyness, but if the parent node is long then it will not track the scrolling within that element.


closes #2463 

related #2453 
