### PR TITLE
feat(vscode): add preview, export and other basic functionality for Jupyter Notebooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,8 +292,7 @@ dependencies = [
 [[package]]
 name = "async-lsp"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115f2bf61b569172f1406f917503ef7d1366e40061d4551f58ff8d4f09caeb15"
+source = "git+https://github.com/nokome/async-lsp?rev=da490668242f41d0370c4dc443bd15309e6a9f5b#da490668242f41d0370c4dc443bd15309e6a9f5b"
 dependencies = [
  "futures",
  "lsp-types",
@@ -2150,6 +2149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,15 +3564,15 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.95.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
@@ -7019,7 +7027,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/rust/lsp/Cargo.toml
+++ b/rust/lsp/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-async-lsp = { version = "0.2.1", features = ["tokio"] }
+async-lsp = { git = "https://github.com/nokome/async-lsp", rev = "da490668242f41d0370c4dc443bd15309e6a9f5b", features = ["tokio"] }
 codec-markdown-trait = { path = "../codec-markdown-trait" }
 codec-text-trait = { path = "../codec-text-trait" }
 codecs = { path = "../codecs" }

--- a/rust/lsp/src/code_lens.rs
+++ b/rust/lsp/src/code_lens.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use async_lsp::{
-    lsp_types::{CodeLens, Command, Range, Url},
+    lsp_types::{CodeLens, Command, Range, Uri},
     ErrorCode, ResponseError,
 };
 use common::{inflector::Inflector, itertools::Itertools, serde_json::json, tokio::sync::RwLock};
@@ -41,7 +41,7 @@ pub(super) const WALKTHROUGH_EXPAND: &str = "stencila.walkthroughs.expand";
 /// code lenses without a `command` but with `data` which is used to "resolve"
 /// the command in the `resolve` handler below
 pub(crate) async fn request(
-    uri: Url,
+    uri: Uri,
     root: Arc<RwLock<TextNode>>,
 ) -> Result<Option<Vec<CodeLens>>, ResponseError> {
     let code_lenses = root

--- a/rust/lsp/src/commands.rs
+++ b/rust/lsp/src/commands.rs
@@ -13,7 +13,7 @@ use async_lsp::{
     lsp_types::{
         ApplyWorkspaceEditParams, DocumentChanges, ExecuteCommandParams, MessageType,
         NumberOrString, OneOf, OptionalVersionedTextDocumentIdentifier, Position, ProgressParams,
-        ProgressParamsValue, ShowMessageParams, TextDocumentEdit, Url, WorkDoneProgress,
+        ProgressParamsValue, ShowMessageParams, TextDocumentEdit, Uri, WorkDoneProgress,
         WorkDoneProgressBegin, WorkDoneProgressCancelParams, WorkDoneProgressCreateParams,
         WorkDoneProgressEnd, WorkDoneProgressReport, WorkspaceEdit,
     },
@@ -401,7 +401,7 @@ pub(super) async fn execute_command(
             client
                 .show_message(ShowMessageParams {
                     typ: MessageType::ERROR,
-                    message: format!("While sending command to {uri}: {error}"),
+                    message: format!("While sending command to {}: {error}", uri.as_str()),
                 })
                 .ok();
             return Ok(None);
@@ -469,7 +469,7 @@ pub(super) async fn execute_command(
                     client
                         .show_message(ShowMessageParams {
                             typ: MessageType::ERROR,
-                            message: format!("{error}\n\n{uri}"),
+                            message: format!("{error}\n\n{}", uri.as_str()),
                         })
                         .ok();
                 }
@@ -483,7 +483,7 @@ pub(super) async fn execute_command(
 }
 
 /// Extract a document URI from a command arg
-pub(super) fn uri_arg(arg: Option<Value>) -> Result<Url, ResponseError> {
+pub(super) fn uri_arg(arg: Option<Value>) -> Result<Uri, ResponseError> {
     arg.and_then(|value| serde_json::from_value(value).ok())
         .ok_or_else(|| {
             ResponseError::new(

--- a/rust/lsp/src/content.rs
+++ b/rust/lsp/src/content.rs
@@ -4,13 +4,12 @@
 use std::sync::Arc;
 
 use async_lsp::{
-    lsp_types::{notification::Notification, request::Request},
+    lsp_types::{notification::Notification, request::Request, Uri},
     ClientSocket, ErrorCode, ResponseError,
 };
 
 use codecs::{EncodeOptions, Format};
 use common::{
-    reqwest::Url,
     serde::{Deserialize, Serialize},
     tokio,
     tokio::sync::RwLock,
@@ -30,7 +29,7 @@ impl Request for SubscribeContent {
 #[serde(crate = "common::serde")]
 pub struct SubscribeContentParams {
     // The URI of the document for which the content is desired
-    pub uri: Url,
+    pub uri: Uri,
 
     // The format that the content is desired in
     pub format: Format,
@@ -42,7 +41,7 @@ struct PublishContent;
 #[serde(crate = "common::serde")]
 pub struct PublishContentParams {
     // The URI of the document for which the content is for
-    pub uri: Url,
+    pub uri: Uri,
 
     // The format that the content is in
     pub format: Format,

--- a/rust/lsp/src/diagnostics.rs
+++ b/rust/lsp/src/diagnostics.rs
@@ -5,7 +5,7 @@
 use async_lsp::{
     lsp_types::{
         notification::Notification, Diagnostic, DiagnosticSeverity, Position,
-        PublishDiagnosticsParams, Range, Url,
+        PublishDiagnosticsParams, Range, Uri,
     },
     ClientSocket, LanguageClient,
 };
@@ -40,7 +40,7 @@ struct PublishStatus;
 #[derive(Serialize, Deserialize)]
 #[serde(crate = "common::serde")]
 struct PublishStatusParams {
-    uri: Url,
+    uri: Uri,
     statuses: Vec<Status>,
 }
 
@@ -50,7 +50,7 @@ impl Notification for PublishStatus {
 }
 
 /// Publish diagnostics
-pub(super) fn publish(uri: &Url, text_node: &TextNode, client: &mut ClientSocket) {
+pub(super) fn publish(uri: &Uri, text_node: &TextNode, client: &mut ClientSocket) {
     // Publish status notifications. As for diagnostics intentionally publishes an
     // empty set so as to clear existing decorations.
     let statuses = statuses(text_node);

--- a/rust/lsp/src/dom.rs
+++ b/rust/lsp/src/dom.rs
@@ -4,13 +4,12 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_lsp::{
-    lsp_types::{notification::Notification, request::Request},
+    lsp_types::{notification::Notification, request::Request, Uri},
     ClientSocket, ErrorCode, ResponseError,
 };
 
 use common::{
     once_cell::sync::Lazy,
-    reqwest::Url,
     serde::{Deserialize, Serialize},
     tokio::{
         self,
@@ -37,7 +36,7 @@ impl Request for SubscribeDom {
 #[serde(crate = "common::serde")]
 pub struct SubscribeDomParams {
     // The URI of the document for which the DOM is desired
-    pub uri: Url,
+    pub uri: Uri,
 }
 
 pub struct ResetDom;

--- a/rust/lsp/src/hover.rs
+++ b/rust/lsp/src/hover.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use async_lsp::{
-    lsp_types::{Hover, HoverContents, HoverParams, MarkupContent, MarkupKind, Url},
+    lsp_types::{Hover, HoverContents, HoverParams, MarkupContent, MarkupKind, Uri},
     ResponseError,
 };
 
@@ -21,7 +21,7 @@ use crate::text_document::TextNode;
 /// Handle a request for a hover display over a position of the document
 pub(super) async fn request(
     params: HoverParams,
-    uri: Url,
+    uri: Uri,
     doc: Arc<RwLock<Document>>,
     root: Arc<RwLock<TextNode>>,
 ) -> Result<Option<Hover>, ResponseError> {
@@ -72,7 +72,7 @@ pub(super) async fn request(
 }
 
 /// Render the outputs of a code chunk as Markdown
-fn code_chunk(node: CodeChunk, uri: &Url, node_id: &NodeId) -> Option<String> {
+fn code_chunk(node: CodeChunk, uri: &Uri, node_id: &NodeId) -> Option<String> {
     let outputs = node.outputs?;
 
     if outputs.is_empty() {
@@ -108,7 +108,7 @@ fn code_chunk(node: CodeChunk, uri: &Url, node_id: &NodeId) -> Option<String> {
                 if not_image || too_big {
                     // Do not show image but indicate that there is an image to view and provide a link
                     let args = percent_encoding::utf8_percent_encode(
-                        &format!(r#"["{uri}","CodeChunk","{node_id}"]"#),
+                        &format!(r#"["{}","CodeChunk","{node_id}"]"#, uri.as_str()),
                         percent_encoding::NON_ALPHANUMERIC,
                     )
                     .to_string();

--- a/rust/lsp/src/lib.rs
+++ b/rust/lsp/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, env};
 
-use async_lsp::{lsp_types::Url, ClientSocket};
+use async_lsp::{lsp_types::Uri, ClientSocket};
 
 use common::{eyre::Result, serde::Deserialize, serde_json, tracing};
 
@@ -40,7 +40,7 @@ pub(crate) struct ServerState {
     options: ServerOptions,
 
     /// The documents opened by the client that are handled by this server
-    documents: HashMap<Url, TextDocument>,
+    documents: HashMap<Uri, TextDocument>,
 
     /// The status of the server
     status: ServerStatus,

--- a/rust/lsp/src/lib.rs
+++ b/rust/lsp/src/lib.rs
@@ -19,15 +19,18 @@ mod logging;
 mod models_;
 mod node_ids;
 mod node_info;
+mod notebook_document;
 mod prompts_;
 mod run;
 mod symbols;
 mod text_document;
 mod utils;
 
-pub use run::run;
+use notebook_document::NotebookDocument;
 use schema::{Organization, Person};
 use text_document::TextDocument;
+
+pub use run::run;
 
 /// The state of the language server
 pub(crate) struct ServerState {
@@ -39,8 +42,11 @@ pub(crate) struct ServerState {
     /// The configuration options defined by the client or using environment variables
     options: ServerOptions,
 
-    /// The documents opened by the client that are handled by this server
-    documents: HashMap<Uri, TextDocument>,
+    /// The text documents opened by the client that are handled by this server
+    text_documents: HashMap<Uri, TextDocument>,
+
+    /// The notebook documents opened by the client that are handled by this server
+    notebook_documents: HashMap<Uri, NotebookDocument>,
 
     /// The status of the server
     status: ServerStatus,

--- a/rust/lsp/src/lifecycle.rs
+++ b/rust/lsp/src/lifecycle.rs
@@ -7,9 +7,10 @@ use std::{ops::ControlFlow, process};
 use async_lsp::{
     lsp_types::{
         CodeLensOptions, CompletionOptions, DocumentSymbolOptions, ExecuteCommandOptions,
-        HoverProviderCapability, InitializeResult, InitializedParams, MessageType, OneOf,
-        ServerCapabilities, ServerInfo, ShowMessageParams, TextDocumentSyncCapability,
-        TextDocumentSyncKind, WorkDoneProgressOptions,
+        HoverProviderCapability, InitializeResult, InitializedParams, MessageType, Notebook,
+        NotebookCellSelector, NotebookDocumentFilter, NotebookDocumentSyncOptions,
+        NotebookSelector, OneOf, ServerCapabilities, ServerInfo, ShowMessageParams,
+        TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
     },
     Error, LanguageClient, ResponseError,
 };
@@ -42,6 +43,17 @@ pub(super) async fn initialize() -> Result<InitializeResult, ResponseError> {
         }),
         capabilities: ServerCapabilities {
             text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+            notebook_document_sync: Some(OneOf::Left(NotebookDocumentSyncOptions {
+                notebook_selector: vec![NotebookSelector::ByNotebook {
+                    notebook: Notebook::NotebookDocumentFilter(NotebookDocumentFilter::ByType {
+                        notebook_type: "jupyter-notebook".to_string(),
+                        scheme: None,
+                        pattern: None,
+                    }),
+                    cells: None,
+                }],
+                save: Some(true),
+            })),
             document_symbol_provider: Some(OneOf::Right(DocumentSymbolOptions {
                 label: Some("Nodes".to_string()),
                 work_done_progress_options: WorkDoneProgressOptions {

--- a/rust/lsp/src/node_ids.rs
+++ b/rust/lsp/src/node_ids.rs
@@ -4,13 +4,12 @@
 use std::{str::FromStr, sync::Arc};
 
 use async_lsp::{
-    lsp_types::{request::Request, Position},
+    lsp_types::{request::Request, Position, Uri},
     ResponseError,
 };
 
 use common::{
     itertools::Itertools,
-    reqwest::Url,
     serde::{Deserialize, Serialize},
     tokio::sync::RwLock,
 };
@@ -30,7 +29,7 @@ impl Request for NodeIdsForLines {
 #[serde(crate = "common::serde")]
 pub struct NodeIdsForLinesParams {
     /// The URI of the document for which the node ids are desired
-    pub uri: Url,
+    pub uri: Uri,
 
     /// The lines for which corresponding node ids are desired
     pub lines: Vec<u32>,
@@ -66,7 +65,7 @@ impl Request for LinesForNodeIds {
 #[serde(crate = "common::serde")]
 pub struct LinesForNodeIdsParams {
     /// The URI of the document for which the line numbers are desired
-    pub uri: Url,
+    pub uri: Uri,
 
     /// The node ids for which the line numbers are desired
     pub ids: Vec<String>,

--- a/rust/lsp/src/node_info.rs
+++ b/rust/lsp/src/node_info.rs
@@ -3,7 +3,7 @@
 //! See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics
 
 use async_lsp::{
-    lsp_types::{notification::Notification, Range, Url},
+    lsp_types::{notification::Notification, Range, Uri},
     ClientSocket,
 };
 
@@ -34,7 +34,7 @@ struct PublishNodeInfo;
 #[derive(Serialize, Deserialize)]
 #[serde(crate = "common::serde")]
 struct PublishNodeInfoParams {
-    uri: Url,
+    uri: Uri,
     nodes: Vec<NodeInfo>,
 }
 
@@ -44,7 +44,7 @@ impl Notification for PublishNodeInfo {
 }
 
 /// Publish node information
-pub(super) fn publish(uri: &Url, text_node: &TextNode, client: &mut ClientSocket) {
+pub(super) fn publish(uri: &Uri, text_node: &TextNode, client: &mut ClientSocket) {
     let mut nodes = Vec::new();
     node_infos(text_node, &mut nodes);
 

--- a/rust/lsp/src/notebook_document.rs
+++ b/rust/lsp/src/notebook_document.rs
@@ -1,0 +1,198 @@
+//! Handling of notebook document synchronization related messages
+//!
+//! See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#notebookDocument_synchronization
+
+use std::{ops::ControlFlow, path::PathBuf, sync::Arc};
+
+use async_lsp::{
+    lsp_types::{
+        DidChangeNotebookDocumentParams, DidCloseNotebookDocumentParams,
+        DidOpenNotebookDocumentParams, DidSaveNotebookDocumentParams, NotebookCell,
+        NotebookCellKind, NotebookDocumentChangeEvent, TextDocumentItem, Uri,
+    },
+    Error, ErrorCode, ResponseError,
+};
+
+use codecs::Format;
+use common::{
+    eyre::{bail, Report},
+    tokio::{
+        self,
+        sync::{mpsc, RwLock},
+    },
+    tracing,
+};
+use document::Document;
+use schema::{Article, Author, AuthorRole, AuthorRoleName, Node, Person};
+
+use crate::ServerState;
+
+/// A notebook document that has been opened by the language server
+pub(super) struct NotebookDocument {
+    /// The cells of the notebook
+    pub cells: Arc<RwLock<Vec<NotebookCell>>>,
+
+    /// The text documents associated with each cell
+    pub texts: Arc<RwLock<Vec<TextDocumentItem>>>,
+
+    /// The Stencila document for the notebook document
+    pub doc: Arc<RwLock<Document>>,
+
+    /// A sender to the `update_task`
+    ///
+    /// Sends change events to the `update_task`. This is an `UnboundedSender`
+    /// so that updates can be sent from sync functions
+    update_sender: mpsc::UnboundedSender<NotebookDocumentChangeEvent>,
+}
+
+impl NotebookDocument {
+    /// Create a new text document with an initial set of cells
+    fn new(
+        uri: Uri,
+        cells: Vec<NotebookCell>,
+        texts: Vec<TextDocumentItem>,
+        user: Option<Person>,
+    ) -> Result<Self, Report> {
+        // Get path without percent encodings (e.g. for spaces)
+        let path = percent_encoding::percent_decode_str(uri.path().as_str()).decode_utf8_lossy();
+
+        let path = PathBuf::from(path.as_ref());
+        let format = Format::from_path(&path);
+        let Some(home) = path.parent() else {
+            bail!("File does not have a parent dir")
+        };
+
+        let person = user.unwrap_or_else(|| Person {
+            given_names: Some(vec!["Anonymous".to_string()]),
+            ..Default::default()
+        });
+        let author_role = AuthorRole {
+            author: schema::AuthorRoleAuthor::Person(person),
+            role_name: AuthorRoleName::Writer,
+            format: Some(format.name().to_string()),
+            ..Default::default()
+        };
+
+        let doc = Document::init(home.into(), Some(path))?;
+        let article = Self::decode_article(&cells, &texts);
+
+        let cells = Arc::new(RwLock::new(cells));
+        let texts = Arc::new(RwLock::new(texts));
+        let doc = Arc::new(RwLock::new(doc));
+
+        let (update_sender, update_receiver) = mpsc::unbounded_channel();
+        {
+            let cells = cells.clone();
+            let texts = texts.clone();
+            let doc = doc.clone();
+            tokio::spawn(async {
+                Self::update_task(update_receiver, cells, texts, doc, author_role).await;
+            });
+        }
+
+        Ok(NotebookDocument {
+            cells,
+            texts,
+            doc,
+            update_sender,
+        })
+    }
+
+    /// An async background task which updates the source and
+    /// the Stencila document when there change in the editor
+    async fn update_task(
+        mut receiver: mpsc::UnboundedReceiver<NotebookDocumentChangeEvent>,
+        cells: Arc<RwLock<Vec<NotebookCell>>>,
+        docs: Arc<RwLock<Vec<TextDocumentItem>>>,
+        doc: Arc<RwLock<Document>>,
+        author_role: AuthorRole,
+    ) {
+        while let Some(change_event) = receiver.recv().await {
+            tracing::debug!("Received notebook change event");
+
+            // TODO: update cells, translate to Stencila document and update it
+        }
+    }
+
+    fn decode_article(cells: &[NotebookCell], docs: &[TextDocumentItem]) -> Node {
+        Node::Article(Article::default())
+    }
+}
+
+/// Handle a notification from the client that a text document was opened
+pub(super) fn did_open(
+    state: &mut ServerState,
+    params: DidOpenNotebookDocumentParams,
+) -> ControlFlow<Result<(), Error>> {
+    let uri = params.notebook_document.uri;
+    let cells = params.notebook_document.cells;
+    let cell_docs = params.cell_text_documents;
+
+    tracing::debug!(
+        "Opening notebook {} with {} cells",
+        uri.to_string(),
+        cells.len()
+    );
+
+    let user = state
+        .options
+        .user
+        .as_ref()
+        .and_then(|user| user.object.clone());
+
+    let doc = match NotebookDocument::new(uri.clone(), cells, cell_docs, user) {
+        Ok(doc) => doc,
+        Err(error) => {
+            return ControlFlow::Break(Err(Error::Response(ResponseError::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("While creating new document: {error}"),
+            ))))
+        }
+    };
+
+    state.notebook_documents.insert(uri, doc);
+
+    ControlFlow::Continue(())
+}
+
+/// Handle a notification from the client that a notebook document was changed
+pub(super) fn did_change(
+    state: &mut ServerState,
+    params: DidChangeNotebookDocumentParams,
+) -> ControlFlow<Result<(), Error>> {
+    let uri = params.notebook_document.uri;
+    if let Some(doc) = state.notebook_documents.get_mut(&uri) {
+        let change = params.change;
+        if let Err(error) = doc.update_sender.send(change) {
+            tracing::error!("While sending updated source: {error}");
+        }
+    } else {
+        tracing::warn!("Unknown document `{}`", uri.to_string())
+    }
+
+    ControlFlow::Continue(())
+}
+
+/// Handle a notification from the client that a notebook document was saved
+pub(super) fn did_save(
+    _state: &mut ServerState,
+    params: DidSaveNotebookDocumentParams,
+) -> ControlFlow<Result<(), Error>> {
+    let uri = params.notebook_document.uri;
+    tracing::debug!("Saving notebook {}", uri.to_string());
+
+    ControlFlow::Continue(())
+}
+
+/// Handle a notification from the client that a notebook document was closed
+pub(super) fn did_close(
+    state: &mut ServerState,
+    params: DidCloseNotebookDocumentParams,
+) -> ControlFlow<Result<(), Error>> {
+    let uri = params.notebook_document.uri;
+    tracing::debug!("Closing notebook {}", uri.to_string());
+
+    state.notebook_documents.remove(&uri);
+
+    ControlFlow::Continue(())
+}


### PR DESCRIPTION
Adds handling of Jupyter Notebooks to the Stencila Language Server to enable basic functionality such as live preview, and export to other formats. Adding AI commands is likely to be done in a separate PR.