### PR TITLE
fix(web): add bubbling event to card close click

### DIFF
--- a/rust/server/src/documents.rs
+++ b/rust/server/src/documents.rs
@@ -220,10 +220,10 @@ pub fn router() -> Router<ServerState> {
     Router::new()
         .without_v07_checks()
         .route("/open/*path", get(open_document))
-        .route("/:id/close", post(close_document))
-        .route("/:id/command", post(command_document))
-        .route("/:id/export", get(export_document))
-        .route("/:id/websocket", get(websocket_for_document))
+        .route("/{id}/close", post(close_document))
+        .route("/{id}/command", post(command_document))
+        .route("/{id}/export", get(export_document))
+        .route("/{id}/websocket", get(websocket_for_document))
 }
 
 /// Serve the root path

--- a/rust/server/src/server.rs
+++ b/rust/server/src/server.rs
@@ -164,7 +164,7 @@ pub async fn serve(
             documents::router().route_layer(middleware_fn(state.clone(), auth_middleware)),
         )
         .route(
-            "/*path",
+            "/{*path}",
             get(documents::serve_path).route_layer(middleware_fn(state.clone(), auth_middleware)),
         )
         .route(

--- a/rust/server/src/statics.rs
+++ b/rust/server/src/statics.rs
@@ -31,7 +31,7 @@ const STATIC_ENCODINGS: [(&str, &str); 2] = [("br", ".br"), ("", "")];
 pub fn router() -> Router<ServerState> {
     Router::new()
         .without_v07_checks()
-        .route("/*path", get(serve_static))
+        .route("/{*path}", get(serve_static))
 }
 
 /// Serve a static file (e.g. `index.js``)

--- a/web/src/ui/nodes/mixins/toggle-marker.ts
+++ b/web/src/ui/nodes/mixins/toggle-marker.ts
@@ -196,7 +196,7 @@ export const ToggleMarkerMixin = <T extends Constructor<UIBaseCard>>(
         <div class=${classes}>
           <stencila-ui-icon-button
             name="x"
-            @click=${() => (this.toggle = false)}
+            @click=${() => this.closeCard()}
           ></stencila-ui-icon-button>
         </div>
       `


### PR DESCRIPTION
fixes a regression caused by moving over to the new card layout in the togglemarker mixin

We now use the puiblic `this.closeCard()` method for a close button click event, this method fires the necessary event to let parent entities know there has been a change.

related issues: #2485 #2486 