### PR TITLE
refactor(web): phase out lit query decorator

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -280,3 +280,6 @@ make audit lint test
 
 > [!NOTE]
 > Themes are applied to the Shadow DOM of HTML-based document views using [Constructed Stylesheets](https://web.dev/articles/constructable-stylesheets). These do not allow the use of `@import`. Therefore the `postcss-import` plugin is used to inline these statements. This requires some oddities in the file paths used for font file in imported files. See the notes in the CSS file for existing fonts.
+
+> [!NOTE]
+> There have been issues using the lit [`@query`](https://lit.dev/docs/api/decorators/#query) decorator in the vscode webview environement. Due to the way the dom patching occurs between the editor and preview windows, the query properties are often turning `null` in the `connectedCallback`, `firstUpdated` and `render` methods of `Entity` elements.

--- a/web/src/nodes/code-chunk.ts
+++ b/web/src/nodes/code-chunk.ts
@@ -1,6 +1,6 @@
 import { LabelType } from '@stencila/types'
 import { html } from 'lit'
-import { customElement, property, query, state } from 'lit/decorators.js'
+import { customElement, property, state } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
 import { getTitleIcon } from '../ui/nodes/properties/programming-language'
@@ -37,14 +37,12 @@ export class CodeChunk extends CodeExecutable {
   })
   isInvisible?: boolean
 
-  @query('slot[name="outputs"]')
-  outputsSlot!: HTMLSlotElement
-
   @state()
   hasOutputs: boolean = false
 
-  protected handleOutputsChange() {
-    this.hasOutputs = !!this.outputsSlot.assignedElements()[0]
+  protected handleOutputsChange(e: Event) {
+    const slot = e.target as HTMLSlotElement
+    this.hasOutputs = !!slot.assignedElements()[0]
   }
 
   override render() {
@@ -149,7 +147,7 @@ export class CodeChunk extends CodeExecutable {
                 <slot name="caption"></slot>
               </caption>`
             : ''}
-          <slot name="outputs"></slot>
+          <slot name="outputs" @slotchange=${this.handleOutputsChange}></slot>
           ${this.labelType === 'FigureLabel'
             ? html`<figcaption><slot name="caption"></slot></figcaption>`
             : ''}

--- a/web/src/nodes/for-block.ts
+++ b/web/src/nodes/for-block.ts
@@ -23,17 +23,15 @@ import { CodeExecutable } from './code-executable'
 @customElement('stencila-for-block')
 @withTwind()
 export class ForBlock extends CodeExecutable {
-  @query('slot[name="iterations"]')
-  iterationSlot: HTMLSlotElement
-
   @property()
   variable: string
 
   @state()
   hasIterations: boolean = true
 
-  private handleIterationChange() {
-    this.hasIterations = !!this.iterationSlot.assignedElements()[0]
+  private handleIterationChange(e: Event) {
+    const slot = e.target as HTMLSlotElement
+    this.hasIterations = !!slot.assignedElements()[0]
   }
 
   override render() {

--- a/web/src/nodes/for-block.ts
+++ b/web/src/nodes/for-block.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit'
-import { customElement, property, query, state } from 'lit/decorators.js'
+import { customElement, property, state } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
 import { nodeUi } from '../ui/nodes/icons-and-colours'

--- a/web/src/nodes/if-block.ts
+++ b/web/src/nodes/if-block.ts
@@ -1,5 +1,5 @@
 import { html } from 'lit'
-import { customElement, query, state } from 'lit/decorators.js'
+import { customElement, state } from 'lit/decorators.js'
 
 import { withTwind } from '../twind'
 
@@ -21,14 +21,12 @@ import { Executable } from './executable'
 @customElement('stencila-if-block')
 @withTwind()
 export class IfBlock extends Executable {
-  @query('slot[name="clauses"]')
-  clausesSlot!: HTMLSlotElement
-
   @state()
   hasClauses: boolean = true
 
-  protected handleClauseChange() {
-    this.hasClauses = this.clausesSlot.assignedElements().length > 0
+  protected handleClauseChange(e: Event) {
+    const slot = e.target as HTMLSlotElement
+    this.hasClauses = slot.assignedElements().length > 0
   }
 
   override render() {

--- a/web/src/nodes/instruction-block.ts
+++ b/web/src/nodes/instruction-block.ts
@@ -24,9 +24,12 @@ import '../ui/nodes/properties/execution-messages'
 @customElement('stencila-instruction-block')
 @withTwind()
 export class InstructionBlock extends Instruction {
-  @query('slot[name="content"]')
-  contentSlot!: HTMLSlotElement
-
+  /**
+   * Slot element for the suggestion carousel
+   * - this slot will contain a `div` element with child `stencila-suggestion` nodes
+   * - query porperty decorator is used for this slot as it is used in multiple methods,
+   *   all triggered after rendering.
+   */
   @query('slot[name="suggestions"]')
   suggestionsSlot!: HTMLSlotElement
 
@@ -51,12 +54,9 @@ export class InstructionBlock extends Instruction {
     }
   }
 
-  private onContentSlotChange() {
-    const contentSlot = this.contentSlot?.assignedNodes()[0] as
-      | HTMLElement
-      | undefined
-
-    this.hasContent = contentSlot !== undefined
+  private onContentSlotChange(e: Event) {
+    const slot = e.target as HTMLSlotElement
+    this.hasContent = !!slot.assignedNodes()[0]
   }
 
   private onSuggestionsSlotChange() {
@@ -68,7 +68,7 @@ export class InstructionBlock extends Instruction {
    * are not visible.
    */
   private updateActiveSuggestion() {
-    const suggestionsSlot = this.suggestionsSlot?.assignedNodes()[0] as
+    const suggestionsSlot = this.suggestionsSlot.assignedNodes()[0] as
       | HTMLElement
       | undefined
 


### PR DESCRIPTION
Have refactored out the use of @query decorator in Entity sub class elements,

Have left one exception in the `InstructionBlock` element, where the suggestionSlot  query property is used thoughout the class methods when checking and updating visible suggestions. As it is not utilised ina lifecylce hook the

Have added a note to the web/README related to using the query decorator inside `Entity` classes.

