### PR TITLE
Publish to Ghost

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,6 +13,8 @@ This document contains the help content for the `stencila` command-line program.
 * [`stencila render`↴](#stencila-render)
 * [`stencila preview`↴](#stencila-preview)
 * [`stencila publish`↴](#stencila-publish)
+* [`stencila publish ghost`↴](#stencila-publish-ghost)
+* [`stencila publish stencila`↴](#stencila-publish-stencila)
 * [`stencila serve`↴](#stencila-serve)
 * [`stencila lsp`↴](#stencila-lsp)
 * [`stencila prompts`↴](#stencila-prompts)
@@ -64,7 +66,7 @@ CLI subcommands and global options
 * `execute` — Execute a document
 * `render` — Render a document
 * `preview` — Preview a document or site
-* `publish` — Publish a document or site
+* `publish` — Publish one or more documents
 * `serve` — Run the HTTP/Websocket server
 * `lsp` — Run the Language Server Protocol server
 * `prompts` — Manage prompts
@@ -527,17 +529,26 @@ Opens a preview of a document or site in the browser. When `--sync=in` (the defa
 
 ## `stencila publish`
 
-Publish a document or site
+Publish one or more documents
 
-Currently only supports publishing a single document to the web via Stencila Cloud.
+**Usage:** `stencila publish <COMMAND>`
 
-In the future, it is likely that other publication platforms will be supported.
+###### **Subcommands:**
 
-**Usage:** `stencila publish [OPTIONS] [PATH]`
+* `ghost` — Publish to Ghost
+* `stencila` — Publish to Stencila Cloud
+
+
+
+## `stencila publish ghost`
+
+Publish to Ghost
+
+**Usage:** `stencila publish ghost [OPTIONS] [PATH]`
 
 ###### **Arguments:**
 
-* `<PATH>` — The path to the document file or site directory to publish
+* `<PATH>` — Path to the file or directory to publish
 
    Defaults to the current directory.
 
@@ -545,8 +556,31 @@ In the future, it is likely that other publication platforms will be supported.
 
 ###### **Options:**
 
-* `-k`, `--key <KEY>` — Key or identifier required by the platform being published to
-* `--dry-run` — Perform a dry run
+* `--domain` — The Ghost domain
+* `--key` — The Ghost Admin API key
+* `--post` — Create a post
+* `--page` — Create a page
+
+
+
+## `stencila publish stencila`
+
+Publish to Stencila Cloud
+
+**Usage:** `stencila publish stencila [OPTIONS] [PATH]`
+
+###### **Arguments:**
+
+* `<PATH>` — Path to the file or directory to publish
+
+   Defaults to the current directory.
+
+  Default value: `.`
+
+###### **Options:**
+
+* `-k`, `--key <KEY>` — The key for the site
+* `--dry-run` — Perform a dry run only
 * `--no-html` — Do not publish a HTML file
 * `--no-jsonld` — Do not publish a JSON-LD file
 * `--no-llmd` — Do not publish a LLM-Markdown file

--- a/rust/publish-ghost/Cargo.toml
+++ b/rust/publish-ghost/Cargo.toml
@@ -4,4 +4,13 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+codec = { "path" = "../codec" }
+# codec-html = { "path" = "../codec-html" }
+codec-text = { "path" = "../codec-text" }
 common = { "path" = "../common" }
+document = { path = "../document" }
+jsonwebtoken = {version = "9", default-features = false }
+schema = { "path" = "../schema" }
+secrets = { "path" = "../secrets" }
+url = "2.5"
+

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -130,7 +130,7 @@ pub struct Cli {
     /// The Ghost domain
     /// 
     /// This is the domain name of your Ghost instance, with an optional port. 
-    #[arg(long, env = "STENCILA_GHOST_DOMAIN", value_parser = parse_host)]
+    #[arg(long, env = "STENCILA_GHOST_DOMAIN", value_parser = parse_host, default_value = "ghost.io")]
     ghost: Host,
 
     /// The Ghost Admin API key

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -183,16 +183,19 @@ impl Cli {
         // Send content to Ghost
         let token = generate_jwt(&self.key).context("generating JWT")?;
 
-        let url = if self.post {
-            format!("https://{}/ghost/api/admin/posts/", self.ghost)
+        // "root key" is the terminology use by Ghost/Lexical
+        let root_key = if self.post {
+            "posts"
         } else if self.page {
-            format!("https://{}/ghost/api/admin/pages/", self.ghost)
+            "pages"
         } else {
             unreachable!();
         };
 
+        let url = format!("https://{}/ghost/api/admin/{}/", self.ghost, root_key);
+
         let payload = serde_json::json!({
-            "posts" : [
+            root_key : [
                 json!({
                     "title": "WIP: Stencila",
                     "html": content,

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -1,9 +1,123 @@
 use std::path::PathBuf;
 
+use codec::{Codec, EncodeOptions};
+// use codec_html::HtmlCodec;
+use codec_text::TextCodec;
 use common::{
     clap::{self, Parser},
-    eyre::Result,
+    eyre::{bail, eyre, Context, Result}, 
+    reqwest::Client,
+    serde::{Deserialize, Serialize},
+    serde_json::{self, json},
+    tracing,
 };
+use document::{CommandWait, Document};
+
+use url;
+use jsonwebtoken as jwt;
+
+const SECRET_NAME: &str = "GHOST_ADMIN_API_KEY";
+
+// use eyre::{eyre, Result};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(crate = "common::serde")]
+struct Claims {
+    // "Audience", e.g. a URL in the Ghost instance
+    aud: String,
+    iat: u64,
+    exp: u64,
+}
+
+fn generate_jwt(key: &str) -> Result<String> {
+    let Some((id, secret)) =  key.split_once(':') else {
+        return Err(eyre!("invalid Ghost Admin API key")); // should never happen
+    };
+
+    let iat = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| eyre!("error accessing system clock: {}", e))?
+        .as_secs();
+
+    let exp = iat + 5 * 60; // 5 minutes
+    let aud = "/admin/".to_string();
+
+    let mut header = jwt::Header::new(jwt::Algorithm::HS256);
+    header.typ = Some("JWT".to_string());
+    header.kid = Some(id.to_string());
+    
+    let payload = Claims {
+        aud,
+        iat,
+        exp,
+    };
+
+    let secret: Result<Vec<u8>> = secret
+        .as_bytes()
+        .chunks(2)
+        .map(|chunk| {
+            // SAFETY: will always succeed as we start with a str
+            let hex_pair = std::str::from_utf8(chunk).unwrap();
+
+            u8::from_str_radix(hex_pair, 16)
+                .map_err(|e| eyre!("invalid input in secret: {}", e))
+        })
+        .collect();
+    let secret = secret?;
+
+    let secret = jwt::EncodingKey::from_secret(&secret);
+    let token = jwt::encode(&header, &payload, &secret)?;
+
+    Ok(token)
+}
+
+fn only_hex(s: &str) -> bool {
+    s.chars().all(|c| c.is_ascii_lowercase() && c.is_ascii_hexdigit())
+}
+
+// Validate that key looks like a Ghost Admin API key
+fn validate_key(key: &str) -> Result<String> {
+    // Split into id:secret
+    let Some((id, secret)) = key.split_once(':') else {
+        bail!("Ghost Admin API key must be in format `id:secret`, i.e. an id and secret separated by a colon.");
+    };
+
+    if id.is_empty() {
+        bail!("The id field of `key` must not be empty");
+    }
+    if secret.is_empty() {
+        bail!("The secret field of `key` must not be empty");
+    }
+
+    if !only_hex(id) || !only_hex(secret) {
+        tracing::warn!("Ghost Admin API key may be invalid; should only contain lowercase hexadecimal characters");
+    }
+
+    Ok(key.to_string())
+}
+
+/// Parse an input from the command line as a Ghost Admin API key
+fn parse_key(arg: &str) -> Result<String> {
+    // Use the key provided on the command-line
+    if !arg.is_empty() {
+        return validate_key(arg);
+    }
+
+    // If not, check if it's provided as an environment variable
+    if let Ok(env_key) = std::env::var("STENCILA_GHOST_KEY") {
+        return validate_key(&env_key);
+    }
+
+    // Lastly, check the keyring.
+    secrets::get(SECRET_NAME)
+}
+
+fn parse_host(arg: &str) -> Result<url::Host> {
+    // Question mark converts between error types
+    Ok(url::Host::parse(arg)?)
+}
 
 /// Publish to Ghost
 #[derive(Debug, Parser)]
@@ -15,12 +129,18 @@ pub struct Cli {
     path: PathBuf,
 
     /// The Ghost domain
-    #[arg(long, env = "STENCILA_GHOST_DOMAIN")]
-    domain: bool,
+    /// 
+    /// This is the domain name of your Ghost instance, with an optional port. 
+    #[arg(long, env = "STENCILA_GHOST_DOMAIN", value_parser = parse_host)]
+    ghost: url::Host,
 
     /// The Ghost Admin API key
-    #[arg(long, env = "STENCILA_GHOST_KEY")]
-    key: bool,
+    /// 
+    /// To create one, create a new Custom Integration under
+    /// the Integrations screen in Ghost Admin. Use the Admin API Key,
+    /// rather than the Content API Key.
+    #[arg(long, env = "STENCILA_GHOST_KEY", value_parser = parse_key)]
+    key: String,
 
     /// Create a post
     #[arg(long, conflicts_with = "page")]
@@ -33,6 +153,73 @@ pub struct Cli {
 
 impl Cli {
     pub async fn run(self) -> Result<()> {
-        Ok(())
+        if !self.path.exists() {
+            bail!("Path does not exist: {}", self.path.display())
+        }
+
+        if !self.path.is_file() {
+            bail!("Only publishing files is currently supported")
+        }
+
+        // Compile document
+        let doc = Document::open(&self.path).await?;
+        doc.compile(CommandWait::Yes).await?;
+
+        let theme = doc.config().await?.theme;
+        let node = &*doc.root_read().await;
+
+        // Convert it to Lexical
+        // TODO: use codec-lexical 
+
+        let options = EncodeOptions {
+            theme,
+            standalone: Some(false),
+            ..Default::default()
+        };
+
+        let codec = TextCodec;
+        // codec.to_string()
+        
+        // let codec = HtmlCodec;
+        let (content, _encode_info) = codec.to_string(node, Some(options)).await?;
+        // let content = format!("<!--kg-card-begin: html-->\r\n{content}\r\n<!--kg-card-end: html-->");
+        let content = format!("<!--kg-card-begin: html-->\r\n<pre>{content}</pre>\r\n<!--kg-card-end: html-->");
+
+        // Send content to Ghost
+        let token = generate_jwt(&self.key).context("generating JWT")?;
+
+        let url = if self.post {
+            format!("https://{}/ghost/api/admin/posts/", self.ghost)
+        } else if self.page {
+            format!("https://{}/ghost/api/admin/pages/", self.ghost)
+        } else {
+            unreachable!();
+        };
+
+        let payload = serde_json::json!({
+            "posts" : [
+                json!({
+                    "title": "WIP: Stencila",
+                    "html": content,
+                    "status": "published",
+                })
+            ]
+        });
+
+        let response = Client::new()
+            .post(url)
+            .header("Authorization", format!("Ghost {token}"))
+            .query(&[("source", "html")])
+            .json(&payload)
+            .send()
+            .await?;
+    
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let code= response.status().as_u16();
+            let err: serde_json::Value = response.json().await?;
+            bail!("HTTP {code}: {msg}:\n{err}", msg = err["errors"][0]["message"])
+        }
     }
 }

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -58,8 +58,7 @@ fn generate_jwt(key: &str) -> Result<String> {
         .as_bytes()
         .chunks(2)
         .map(|chunk| {
-            // SAFETY: will always succeed as we start with a str
-            let hex_pair = std::str::from_utf8(chunk).unwrap();
+            let hex_pair = std::str::from_utf8(chunk)?; // will always succeed as we start with a str
 
             u8::from_str_radix(hex_pair, 16)
                 .map_err(|e| eyre!("invalid input in secret: {}", e))

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -13,7 +13,7 @@ use common::{
 };
 use document::{CommandWait, Document};
 
-use url;
+use url::Host;
 use jsonwebtoken as jwt;
 
 const SECRET_NAME: &str = "GHOST_ADMIN_API_KEY";
@@ -113,9 +113,9 @@ fn parse_key(arg: &str) -> Result<String> {
     secrets::get(SECRET_NAME)
 }
 
-fn parse_host(arg: &str) -> Result<url::Host> {
+fn parse_host(arg: &str) -> Result<Host> {
     // Question mark converts between error types
-    Ok(url::Host::parse(arg)?)
+    Ok(Host::parse(arg)?)
 }
 
 /// Publish to Ghost
@@ -131,7 +131,7 @@ pub struct Cli {
     /// 
     /// This is the domain name of your Ghost instance, with an optional port. 
     #[arg(long, env = "STENCILA_GHOST_DOMAIN", value_parser = parse_host)]
-    ghost: url::Host,
+    ghost: Host,
 
     /// The Ghost Admin API key
     /// 
@@ -176,12 +176,8 @@ impl Cli {
             ..Default::default()
         };
 
-        let codec = TextCodec;
-        // codec.to_string()
-        
-        // let codec = HtmlCodec;
+        let codec = TextCodec;        
         let (content, _encode_info) = codec.to_string(node, Some(options)).await?;
-        // let content = format!("<!--kg-card-begin: html-->\r\n{content}\r\n<!--kg-card-end: html-->");
         let content = format!("<!--kg-card-begin: html-->\r\n<pre>{content}</pre>\r\n<!--kg-card-end: html-->");
 
         // Send content to Ghost

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -167,6 +167,14 @@ impl Cli {
         let theme = doc.config().await?.theme;
         let node = &*doc.root_read().await;
 
+        let mut title = String::from("Untitled");
+        if let schema::Node::Article(article) = node {
+             if let Some(title_parts) = &article.title {
+                title = title_parts.iter().map(|x| x.to_string()).collect();
+                println!("{title}");
+             }
+        }
+
         // Convert it to Lexical
         // TODO: use codec-lexical 
 
@@ -197,7 +205,7 @@ impl Cli {
         let payload = serde_json::json!({
             root_key : [
                 json!({
-                    "title": "WIP: Stencila",
+                    "title": title,
                     "html": content,
                     "status": "published",
                 })

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -127,6 +127,18 @@ pub struct Cli {
     #[arg(default_value = ".")]
     path: PathBuf,
 
+    /// Dry run test
+    /// 
+    /// When set, stencila will perform the document conversion but skip the publication to Ghost.
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
+
+    /// Dry run test
+    /// 
+    /// When set, stencila will perform the document conversion but skip the publication to Ghost.
+    #[arg(long, default_value_t = false)]
+    dry_run: bool,
+
     /// The Ghost domain
     /// 
     /// This is the domain name of your Ghost instance, with an optional port. 
@@ -211,6 +223,10 @@ impl Cli {
                 })
             ]
         });
+
+        if self.dry_run {
+            return Ok(());
+        }
 
         let response = Client::new()
             .post(url)

--- a/rust/secrets/src/lib.rs
+++ b/rust/secrets/src/lib.rs
@@ -20,7 +20,12 @@ pub mod cli;
 #[derive(Clone, Serialize)]
 #[serde(crate = "common::serde")]
 enum SecretCategory {
+    /// Used to access external services for creating content, esp. LLMs.
     AiApiKey,
+    
+    /// Used to publish Stencila documents to an external service, 
+    /// and/or to update a document based on externally-hosted content.
+    ReadWriteApiKey,
 }
 
 #[skip_serializing_none]
@@ -111,6 +116,12 @@ static SECRETS: Lazy<Vec<Secret>> = Lazy::new(|| {
             "MISTRAL_API_KEY",
             "Mistral API Key",
             "Used to access the Mistral API",
+        ),
+        Secret::new(
+            SecretCategory::ReadWriteApiKey,
+            "GHOST_ADMIN_API_KEY",
+            "Ghost Admin API Key",
+            "Used to read from and publish to Ghost",
         ),
     ]
 });


### PR DESCRIPTION
This PR enables users to publish Stencila docs to Ghost.

Features:

- Stores secrets within the OS keyring via Stencila's secrets,

Limitations: 

- Uses the text codec to create a rough version of the doc in Ghost. Intended to be updated with `codec-lexical` when it's available.
- Lack of testing (am unfamiliar with some of the mechanics)
- Only files are supported currently, rather than directories