### PR TITLE
Ghost publishing: image handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,6 +4073,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "node-media"
+version = "0.0.0"
+dependencies = [
+ "common",
+ "images",
+ "schema",
+]
+
+[[package]]
 name = "node-patch-derive"
 version = "0.0.0"
 dependencies = [
@@ -5027,6 +5036,7 @@ dependencies = [
  "common",
  "document",
  "jsonwebtoken",
+ "node-media",
  "secrets",
  "url",
 ]

--- a/rust/codec-lexical/src/blocks.rs
+++ b/rust/codec-lexical/src/blocks.rs
@@ -175,7 +175,7 @@ fn paragraph_to_lexical(
     if let (1, Some(Inline::ImageObject(image))) =
         (paragraph.content.len(), paragraph.content.first())
     {
-        return image_to_lexical(&image, context);
+        return image_to_lexical(image, context);
     }
 
     let children = inlines_to_lexical(&paragraph.content, context);

--- a/rust/document/src/lib.rs
+++ b/rust/document/src/lib.rs
@@ -38,7 +38,7 @@ mod task_command;
 mod task_update;
 
 // Re-exports for convenience of consuming crates
-pub use codecs::{DecodeOptions, EncodeOptions, Format, LossesResponse};
+pub use codecs::{self, DecodeOptions, EncodeOptions, Format, LossesResponse};
 pub use schema;
 pub use sync_dom::DomPatch;
 
@@ -586,6 +586,14 @@ impl Document {
     /// Get the path of the document
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
+    }
+
+    /// Get the parent directory of the document
+    pub fn directory(&self) -> &Path {
+        self.path
+            .as_ref()
+            .and_then(|path| path.parent())
+            .unwrap_or_else(|| self.home.as_ref())
     }
 
     /// Get the file name of the document

--- a/rust/images/src/lib.rs
+++ b/rust/images/src/lib.rs
@@ -187,7 +187,7 @@ pub fn file_uri_to_file(
     }
 
     // Copy the file to the images directory
-    copy(&src_path, &images_dir.join(&image_name))?;
+    copy(&src_path, images_dir.join(&image_name))?;
 
     Ok(image_name)
 }

--- a/rust/node-media/Cargo.toml
+++ b/rust/node-media/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "node-media"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+common = { path = "../common" }
+images = { path = "../images" }
+schema = { path = "../schema" }
+
+[lints]
+workspace = true

--- a/rust/node-media/src/lib.rs
+++ b/rust/node-media/src/lib.rs
@@ -1,0 +1,95 @@
+use std::path::{Path, PathBuf};
+
+use common::tracing;
+use schema::{Block, ImageObject, Inline, VisitorMut, WalkControl, WalkNode};
+
+/// Walk over a node and extract/copy all media files into a folder and re-write URLs
+///
+/// # Arguments
+///
+/// `src_dir`: The directory of the node being walked, used to resolve any relative
+///            paths to media files in the node
+///
+/// `dest_dir`: The destination directory that collected media files should be placed in
+///
+/// `rewrite`: A function, usually a closure, to rewrite the URL of media nodes
+///            (i.e. images, audio, and video) within the root node. This function
+///            should have arguments (old_url: &str, media_file_name: &str) and return
+///            a new URL as a `String`.
+pub fn extract_media<T, F>(node: &mut T, src_dir: &Path, dest_dir: &Path, rewrite: F)
+where
+    T: WalkNode,
+    F: Fn(&str, &str) -> String,
+{
+    let mut walker = Walker {
+        src_dir: src_dir.to_path_buf(),
+        dest_dir: dest_dir.to_path_buf(),
+        rewrite,
+    };
+    walker.visit(node);
+}
+
+/// A visitor that collects node ids and addresses
+struct Walker<F>
+where
+    F: Fn(&str, &str) -> String,
+{
+    src_dir: PathBuf,
+    dest_dir: PathBuf,
+    rewrite: F,
+}
+
+impl<F> Walker<F>
+where
+    F: Fn(&str, &str) -> String,
+{
+    /// Visit an image to extract it and rewrite its URL
+    fn visit_image(&mut self, image: &mut ImageObject) -> WalkControl {
+        let image_path = if image.content_url.starts_with("data:") {
+            // Encode the data URI to a file
+            match images::data_uri_to_file(&image.content_url, &self.dest_dir) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::warn!("While encoding image data URI to file: {error}");
+                    None
+                }
+            }
+        } else {
+            match images::file_uri_to_file(&image.content_url, Some(&self.src_dir), &self.dest_dir)
+            {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    tracing::warn!("While encoding image to file: {error}");
+                    None
+                }
+            }
+        };
+
+        if let Some(image_path) = image_path {
+            image.content_url = (self.rewrite)(&image.content_url, &image_path);
+        }
+
+        WalkControl::Break
+    }
+}
+
+impl<F> VisitorMut for Walker<F>
+where
+    F: Fn(&str, &str) -> String,
+{
+    /// Visit a `Block` node type
+    fn visit_block(&mut self, block: &mut Block) -> WalkControl {
+        match block {
+            Block::ImageObject(image) => self.visit_image(image),
+            _ => WalkControl::Continue,
+        }
+    }
+
+    /// Visit an `Inline` node type
+    fn visit_inline(&mut self, inline: &mut Inline) -> WalkControl {
+        match inline {
+            Inline::ImageObject(image) => self.visit_image(image),
+            _ => WalkControl::Continue,
+        }
+    }
+}

--- a/rust/publish-ghost/Cargo.toml
+++ b/rust/publish-ghost/Cargo.toml
@@ -8,6 +8,7 @@ codec-text = { "path" = "../codec-text" }
 common = { "path" = "../common" }
 document = { path = "../document" }
 jsonwebtoken = { version = "9.3.0", default-features = false }
+node-media = { "path" = "../node-media" }
 secrets = { "path" = "../secrets" }
 url = "2.5.4"
 

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -149,10 +149,10 @@ impl Cli {
     /// Create a post or page by POSTing it to the Ghost API
     #[tracing::instrument(skip(doc))]
     async fn create(&self, doc: Document) -> Result<()> {
-        // Require a host
         let Some(host) = &self.ghost else {
             bail!("File does not have an identifier for Ghost so the ---ghost option must be provided");
         };
+        let host = host.to_string();
         let base_url = format!("https://{host}/ghost/api/admin/");
 
         tracing::trace!("Publishing document to {base_url}");
@@ -167,11 +167,54 @@ impl Cli {
             bail!("Please use either the --post or --page flag");
         };
 
-        // Generate JWT for request
+        // Generate JWT for request(s)
         let token = generate_jwt(&self.key).context("generating JWT")?;
 
+        let mut root = doc.root().await;
+
+        //let temp_dir = tempfile::tempdir()?;
+        //let media_dir = temp_dir.path();
+        // TODO: Use temp dir; this local media dir just for testing
+        let media_dir = PathBuf::from("media");
+        if media_dir.exists() {
+            remove_dir_all(&media_dir).await?;
+        }
+
+        node_media::extract_media(
+            &mut root,
+            doc.directory(),
+            &media_dir,
+            |old_url, file_name| {
+                tracing::info!(old = ?old_url, file_name = ?file_name, "rewriting URL");
+                if old_url.contains(&host) {
+                    return old_url.to_string();
+                }
+                
+                if self.dry_run {
+                    return file_name.to_string();
+                }
+
+                // need to do some gymnastics to get back into async land from a closure
+                let new_url = tokio::task::block_in_place(move || {
+                    let rt = tokio::runtime::Handle::current();
+                    
+                    // upload files one at a time to prevent overloading the server
+                    rt.block_on(async move {
+                        tracing::info!("Uploading image {file_name}");
+                        if let Ok(Resource {url: Some(url), ..}) = self.post_image(file_name).await {
+                            url
+                        } else {
+                            file_name.to_string()
+                        }
+                    })
+                });
+
+                new_url
+            },
+        );
+
         // Construct the POST payload
-        let payload = Payload::from_doc(resource_type, &doc, None).await?;
+        let payload: Payload = Payload::from_doc(resource_type, &doc, None).await?;
 
         // Return early if this is just a dry run
         if self.dry_run {
@@ -223,6 +266,46 @@ impl Cli {
         );
 
         Ok(())
+    }
+
+    #[tracing::instrument]
+    async fn post_image(&self, image_path: &str) -> Result<Resource> {
+        let Some(ref host) = self.ghost else {
+            bail!("Provide the hostname of the Ghost instance with --ghost");
+        };
+        let url: String = format!("https://{host}/ghost/api/admin/images/upload");
+        tracing::trace!("Uploading image {image_path}");
+        let token = generate_jwt(&self.key).context("generating JWT")?;
+
+        // ensure that only the file name is provided to Ghost
+        let image_path = std::path::Path::new(image_path);
+        let Some(file_name) = image_path.file_name() else {
+            bail!("image_path must be to a file");
+        };
+        let file_name = file_name.to_string_lossy().into_owned();
+
+        let form = reqwest::multipart::Form::new()
+            .file("file", &image_path).await.context("reading {image_url}")?
+            .text("ref", file_name);
+
+        if self.dry_run {
+            return Ok(Resource { url: Some("#".to_string()), ..Default::default()});
+        }
+
+        let response = Client::new()
+            .post(url)
+            .header("Authorization", format!("Ghost {token}"))
+            .multipart(form)
+            .send()
+            .await?;
+        tracing::debug!(resp = ?response, "Image upload response");
+
+        if let StatusCode::CREATED = response.status() {
+            let mut payload: Payload = response.json().await?;
+            Ok(payload.resource()?)
+        } else {
+            error_for_response::<Resource>(response).await
+        }
     }
 
     /// Update a Ghost post or page from local file
@@ -456,7 +539,7 @@ fn generate_jwt(key: &Option<String>) -> Result<String> {
 ///
 /// Attempts to extract error message from JSON response, and if
 /// that fails, displays the body text.
-async fn error_for_response(response: Response) -> Result<()> {
+async fn error_for_response<T>(response: Response) -> Result<T> {
     let code = response.status().as_u16();
     if let Ok(body) = response.text().await {
         if let Ok(err) = serde_json::from_str::<serde_json::Value>(&body) {
@@ -490,6 +573,20 @@ struct Resource {
     lexical: Option<String>,
     status: Option<Status>,
     updated_at: Option<String>, // Required for updating
+
+    // fields for images & media
+
+    /// URL field
+    /// 
+    /// Used by Ghost to refer User-Agents to the correct place to GET the content.
+    url: Option<String>, // Required for images & media
+    /// Reference field
+    /// 
+    /// Used by Stencila to point to the original file. Used to determine whether the file
+    /// needs to be stored on disk and/or uploaded. `None` indicates that an image was uploaded
+    /// directly into Ghost.
+    #[serde(rename = "ref")]
+    reference: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -505,6 +602,8 @@ enum Status {
 enum ResourceType {
     Post,
     Page,
+    #[allow(unused)]
+    Image,
 }
 
 /// A payload from the Ghost Admin API
@@ -513,6 +612,7 @@ enum ResourceType {
 enum Payload {
     Posts(Vec<Resource>),
     Pages(Vec<Resource>),
+    Images(Vec<Resource>),
 }
 
 impl Payload {
@@ -541,28 +641,28 @@ impl Payload {
 
         // Get the root node of the document, extract images (and other media in the future)
         // and rewrite their URLs to be their URLs on the Ghost server
-        let mut root = doc.root().await;
+        let root = doc.root().await;
 
-        //let temp_dir = tempfile::tempdir()?;
-        //let media_dir = temp_dir.path();
-        // TODO: Use temp dir; this local media dir just for testing
-        let media_dir = PathBuf::from("media");
-        if media_dir.exists() {
-            remove_dir_all(&media_dir).await?;
-        }
-        node_media::extract_media(
-            &mut root,
-            doc.directory(),
-            &media_dir,
-            |_old_url, file_name| {
-                // Construct a new URL for the media file
-                // TODO: make this what it should be
-                format!("images/{file_name}")
-            },
-        );
+        // //let temp_dir = tempfile::tempdir()?;
+        // //let media_dir = temp_dir.path();
+        // // TODO: Use temp dir; this local media dir just for testing
+        // let media_dir = PathBuf::from("media");
+        // if media_dir.exists() {
+        //     remove_dir_all(&media_dir).await?;
+        // }
+        // node_media::extract_media(
+        //     &mut root,
+        //     doc.directory(),
+        //     &media_dir,
+        //     |_old_url, file_name| {
+        //         // Construct a new URL for the media file
+        //         // TODO: make this what it should be
+        //         format!("images/{file_name}")
+        //     },
+        // );
 
-        // TODO: Upload images to Ghost. This should check that files don't already
-        // exist on the server
+        // // TODO: Upload images to Ghost. This should check that files don't already
+        // // exist on the server
 
         // Dump root node to a Lexical (Ghost's Dialect) string
         let lexical = codecs::to_string(
@@ -583,20 +683,24 @@ impl Payload {
             ..Default::default()
         };
 
-        Ok(match resource_type {
+        let payload =  match resource_type {
             ResourceType::Post => Payload::Posts(vec![resource]),
             ResourceType::Page => Payload::Pages(vec![resource]),
-        })
+            ResourceType::Image => Payload::Images(vec![resource]),
+        };
+
+        Ok(payload)
     }
 
     /// Get the first resource from a payload
     ///
-    /// Used when GETing from the API to extract the page or post.
+    /// Used when GETing from the API to extract the content from within the nested JSON
     fn resource(&mut self) -> Result<Resource> {
         match self {
             Payload::Posts(posts) => posts.pop(),
             Payload::Pages(pages) => pages.pop(),
+            Payload::Images(images) => images.pop(),
         }
-        .ok_or_eyre("Payload does not have any page or post")
+        .ok_or_eyre("Payload does not have any content, such as page or post")
     }
 }

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -195,7 +195,7 @@ impl Cli {
                 }
 
                 // need to do some gymnastics to get back into async land from a closure
-                let new_url = tokio::task::block_in_place(move || {
+                tokio::task::block_in_place(move || {
                     let rt = tokio::runtime::Handle::current();
                     
                     // upload files one at a time to prevent overloading the server
@@ -207,9 +207,7 @@ impl Cli {
                             file_name.to_string()
                         }
                     })
-                });
-
-                new_url
+                })
             },
         );
 

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -641,27 +641,6 @@ impl Payload {
         // and rewrite their URLs to be their URLs on the Ghost server
         let root = doc.root().await;
 
-        // //let temp_dir = tempfile::tempdir()?;
-        // //let media_dir = temp_dir.path();
-        // // TODO: Use temp dir; this local media dir just for testing
-        // let media_dir = PathBuf::from("media");
-        // if media_dir.exists() {
-        //     remove_dir_all(&media_dir).await?;
-        // }
-        // node_media::extract_media(
-        //     &mut root,
-        //     doc.directory(),
-        //     &media_dir,
-        //     |_old_url, file_name| {
-        //         // Construct a new URL for the media file
-        //         // TODO: make this what it should be
-        //         format!("images/{file_name}")
-        //     },
-        // );
-
-        // // TODO: Upload images to Ghost. This should check that files don't already
-        // // exist on the server
-
         // Dump root node to a Lexical (Ghost's Dialect) string
         let lexical = codecs::to_string(
             &root,

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -212,7 +212,7 @@ impl Cli {
         );
 
         // Construct the POST payload
-        let payload: Payload = Payload::from_doc(resource_type, &doc, None).await?;
+        let payload = Payload::from_doc(resource_type, &doc, None).await?;
 
         // Return early if this is just a dry run
         if self.dry_run {

--- a/rust/publish-ghost/src/lib.rs
+++ b/rust/publish-ghost/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -9,14 +9,12 @@ use url::Host;
 use common::{
     clap::{self, Parser},
     eyre::{bail, eyre, Context, OptionExt, Result},
-    reqwest::{Client, Response, StatusCode},
+    reqwest::{multipart::Form, Client, Response, StatusCode},
     serde::{Deserialize, Serialize},
     serde_json,
     serde_with::skip_serializing_none,
     strum::Display,
-    tempfile,
-    tokio::fs::remove_dir_all,
-    tracing,
+    tempfile, tokio, tracing,
 };
 use document::{
     codecs,
@@ -147,7 +145,7 @@ impl Cli {
     }
 
     /// Create a post or page by POSTing it to the Ghost API
-    #[tracing::instrument(skip(doc))]
+    #[tracing::instrument(skip(self, doc))]
     async fn create(&self, doc: Document) -> Result<()> {
         let Some(host) = &self.ghost else {
             bail!("File does not have an identifier for Ghost so the ---ghost option must be provided");
@@ -167,52 +165,11 @@ impl Cli {
             bail!("Please use either the --post or --page flag");
         };
 
-        // Generate JWT for request(s)
+        // Generate JWT for request
         let token = generate_jwt(&self.key).context("generating JWT")?;
 
-        let mut root = doc.root().await;
-
-        //let temp_dir = tempfile::tempdir()?;
-        //let media_dir = temp_dir.path();
-        // TODO: Use temp dir; this local media dir just for testing
-        let media_dir = PathBuf::from("media");
-        if media_dir.exists() {
-            remove_dir_all(&media_dir).await?;
-        }
-
-        node_media::extract_media(
-            &mut root,
-            doc.directory(),
-            &media_dir,
-            |old_url, file_name| {
-                tracing::info!(old = ?old_url, file_name = ?file_name, "rewriting URL");
-                if old_url.contains(&host) {
-                    return old_url.to_string();
-                }
-                
-                if self.dry_run {
-                    return file_name.to_string();
-                }
-
-                // need to do some gymnastics to get back into async land from a closure
-                tokio::task::block_in_place(move || {
-                    let rt = tokio::runtime::Handle::current();
-                    
-                    // upload files one at a time to prevent overloading the server
-                    rt.block_on(async move {
-                        tracing::info!("Uploading image {file_name}");
-                        if let Ok(Resource {url: Some(url), ..}) = self.post_image(file_name).await {
-                            url
-                        } else {
-                            file_name.to_string()
-                        }
-                    })
-                })
-            },
-        );
-
         // Construct the POST payload
-        let payload = Payload::from_doc(resource_type, &doc, None).await?;
+        let payload = self.payload(resource_type, &doc, None).await?;
 
         // Return early if this is just a dry run
         if self.dry_run {
@@ -266,46 +223,6 @@ impl Cli {
         Ok(())
     }
 
-    #[tracing::instrument]
-    async fn post_image(&self, image_path: &str) -> Result<Resource> {
-        let Some(ref host) = self.ghost else {
-            bail!("Provide the hostname of the Ghost instance with --ghost");
-        };
-        let url: String = format!("https://{host}/ghost/api/admin/images/upload");
-        tracing::trace!("Uploading image {image_path}");
-        let token = generate_jwt(&self.key).context("generating JWT")?;
-
-        // ensure that only the file name is provided to Ghost
-        let image_path = std::path::Path::new(image_path);
-        let Some(file_name) = image_path.file_name() else {
-            bail!("image_path must be to a file");
-        };
-        let file_name = file_name.to_string_lossy().into_owned();
-
-        let form = reqwest::multipart::Form::new()
-            .file("file", &image_path).await.context("reading {image_url}")?
-            .text("ref", file_name);
-
-        if self.dry_run {
-            return Ok(Resource { url: Some("#".to_string()), ..Default::default()});
-        }
-
-        let response = Client::new()
-            .post(url)
-            .header("Authorization", format!("Ghost {token}"))
-            .multipart(form)
-            .send()
-            .await?;
-        tracing::debug!(resp = ?response, "Image upload response");
-
-        if let StatusCode::CREATED = response.status() {
-            let mut payload: Payload = response.json().await?;
-            Ok(payload.resource()?)
-        } else {
-            error_for_response::<Resource>(response).await
-        }
-    }
-
     /// Update a Ghost post or page from local file
     #[tracing::instrument(skip(doc))]
     async fn put(&self, doc: Document, doc_url: String) -> Result<()> {
@@ -345,7 +262,7 @@ impl Cli {
         let Resource { updated_at, .. } = payload.resource()?;
 
         // Construct the PUT payload with the latest `updated_at`
-        let payload = Payload::from_doc(resource_type, &doc, updated_at).await?;
+        let payload = self.payload(resource_type, &doc, updated_at).await?;
 
         // Send the request
         let response = Client::new()
@@ -364,6 +281,55 @@ impl Cli {
             Ok(())
         } else {
             error_for_response(response).await
+        }
+    }
+
+    /// Post an image and return the image `Resource`
+    ///
+    /// This is used when creating and updating posts or pages.
+    #[tracing::instrument]
+    async fn post_image(&self, image_path: &Path) -> Result<Resource> {
+        let Some(ref host) = self.ghost else {
+            bail!("Provide the hostname of the Ghost instance with --ghost");
+        };
+
+        // Ensure that only the file name is provided to Ghost as a ref
+        let Some(file_name) = image_path.file_name() else {
+            bail!("image_path must be to a file");
+        };
+        let file_name = file_name.to_string_lossy().into_owned();
+
+        tracing::info!("Uploading image `{file_name}` to Ghost",);
+
+        let form = Form::new()
+            .file("file", image_path)
+            .await
+            .context(format!("reading {}", image_path.display()))?
+            .text("ref", file_name);
+
+        if self.dry_run {
+            return Ok(Resource {
+                url: Some("#".to_string()),
+                ..Default::default()
+            });
+        }
+
+        // TODO: Generating token for each image (and then for payload) seems wasteful. Can we cache?
+        let token = generate_jwt(&self.key).context("generating JWT")?;
+
+        let response = Client::new()
+            .post(format!("https://{host}/ghost/api/admin/images/upload"))
+            .header("Authorization", format!("Ghost {token}"))
+            .multipart(form)
+            .send()
+            .await?;
+        tracing::debug!(resp = ?response, "Image upload response");
+
+        if let StatusCode::CREATED = response.status() {
+            let mut payload: Payload = response.json().await?;
+            Ok(payload.resource()?)
+        } else {
+            error_for_response::<Resource>(response).await
         }
     }
 
@@ -429,6 +395,105 @@ impl Cli {
         );
 
         Ok(())
+    }
+
+    /// Create a payload for a [`ResourceType`] from a document
+    async fn payload(
+        &self,
+        resource_type: ResourceType,
+        doc: &Document,
+        updated_at: Option<String>,
+    ) -> Result<Payload> {
+        // Get document title and other metadata
+        // TODO: other metadata such as authors, excerpt (from abstract?)
+        // could be obtained in a similar way and returned from this function
+        let (title,) = doc
+            .inspect(|root: &Node| {
+                let mut title = None;
+
+                if let Node::Article(article) = root {
+                    if let Some(inlines) = &article.title {
+                        title = Some(codec_text::to_text(inlines));
+                    }
+                }
+
+                (title,)
+            })
+            .await;
+
+        // Get the root node of the document
+        let mut root = doc.root().await;
+
+        // Temporary directory to extract media files into before uploading
+        let temp_dir = tempfile::tempdir()?;
+        let media_dir = temp_dir.path();
+
+        // Extract images (and other media in the future) and upload to Ghost
+        // and rewrite their URLs to be their URLs on the Ghost server
+        node_media::extract_media(
+            &mut root,
+            doc.directory(),
+            &media_dir,
+            |old_url, file_name| {
+                tracing::debug!(old = ?old_url, file_name = ?file_name, "rewriting URL");
+
+                // If  dry run or if it looks like this is already a Ghost URL, do not do
+                // change the URL
+                if self.dry_run && old_url.contains("/ghost/api/admin/") {
+                    return old_url.to_string();
+                }
+
+                let image_path = media_dir.join(file_name);
+
+                // need to do some gymnastics to get back into async land from a closure
+                tokio::task::block_in_place(move || {
+                    let rt = tokio::runtime::Handle::current();
+
+                    // upload files one at a time to prevent overloading the server
+                    rt.block_on(async move {
+                        match self.post_image(&image_path).await {
+                            Ok(Resource { url: Some(url), .. }) => url,
+                            Ok(_) => {
+                                tracing::error!("Did not get URL for image");
+                                file_name.into()
+                            }
+                            Err(error) => {
+                                tracing::error!("While uploading {file_name}: {error}");
+                                file_name.into()
+                            }
+                        }
+                    })
+                })
+            },
+        );
+
+        // Dump root node to a Lexical (Ghost's Dialect) string.
+        // Important: this version of the root node has rewritten URLs
+        let lexical = codecs::to_string(
+            &root,
+            Some(EncodeOptions {
+                format: Some(Format::Koenig),
+                // TODO: The option for "just one big HTML card" so go here
+                standalone: Some(false),
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+        let resource = Resource {
+            title: title.or_else(|| Some("Untitled".into())),
+            lexical: Some(lexical),
+            updated_at,
+            ..Default::default()
+        };
+
+        let payload = match resource_type {
+            ResourceType::Post => Payload::Posts(vec![resource]),
+            ResourceType::Page => Payload::Pages(vec![resource]),
+            ResourceType::Image => Payload::Images(vec![resource]),
+        };
+
+        Ok(payload)
     }
 }
 
@@ -573,13 +638,13 @@ struct Resource {
     updated_at: Option<String>, // Required for updating
 
     // fields for images & media
-
     /// URL field
-    /// 
+    ///
     /// Used by Ghost to refer User-Agents to the correct place to GET the content.
     url: Option<String>, // Required for images & media
+
     /// Reference field
-    /// 
+    ///
     /// Used by Stencila to point to the original file. Used to determine whether the file
     /// needs to be stored on disk and/or uploaded. `None` indicates that an image was uploaded
     /// directly into Ghost.
@@ -614,61 +679,6 @@ enum Payload {
 }
 
 impl Payload {
-    /// Create a payload from a document
-    async fn from_doc(
-        resource_type: ResourceType,
-        doc: &Document,
-        updated_at: Option<String>,
-    ) -> Result<Self> {
-        // Get document title and other metadata
-        // TODO: other metadata such as authors, excerpt (from abstract?)
-        // could be obtained in a similar way and returned from this function
-        let (title,) = doc
-            .inspect(|root: &Node| {
-                let mut title = None;
-
-                if let Node::Article(article) = root {
-                    if let Some(inlines) = &article.title {
-                        title = Some(codec_text::to_text(inlines));
-                    }
-                }
-
-                (title,)
-            })
-            .await;
-
-        // Get the root node of the document, extract images (and other media in the future)
-        // and rewrite their URLs to be their URLs on the Ghost server
-        let root = doc.root().await;
-
-        // Dump root node to a Lexical (Ghost's Dialect) string
-        let lexical = codecs::to_string(
-            &root,
-            Some(EncodeOptions {
-                format: Some(Format::Koenig),
-                // TODO: The option for "just one big HTML card" so go here
-                standalone: Some(false),
-                ..Default::default()
-            }),
-        )
-        .await?;
-
-        let resource = Resource {
-            title: title.or_else(|| Some("Untitled".into())),
-            lexical: Some(lexical),
-            updated_at,
-            ..Default::default()
-        };
-
-        let payload =  match resource_type {
-            ResourceType::Post => Payload::Posts(vec![resource]),
-            ResourceType::Page => Payload::Pages(vec![resource]),
-            ResourceType::Image => Payload::Images(vec![resource]),
-        };
-
-        Ok(payload)
-    }
-
     /// Get the first resource from a payload
     ///
     /// Used when GETing from the API to extract the content from within the nested JSON

--- a/rust/schema/src/implem/media_objects.rs
+++ b/rust/schema/src/implem/media_objects.rs
@@ -159,18 +159,18 @@ impl DomCodec for ImageObject {
         }
 
         if img {
-            // If the document is being encoded standalone, and the image URL is data URI
+            // If the document is being encoded standalone, and the image URL is a data URI
             // or file system path (possibly with a relative URL) the ensure that we have
-            // create an on disk copy
+            // created an on disk copy
             if context.standalone
                 && !(self.content_url.starts_with("http://")
                     || self.content_url.starts_with("https://"))
             {
                 let images_dir = context.images_dir();
 
-                let image_path = if self.content_url.starts_with("data:") {
+                let image_name = if self.content_url.starts_with("data:") {
                     // Encode the data URI to a file
-                    match images::data_uri_to_path(&self.content_url, &images_dir) {
+                    match images::data_uri_to_file(&self.content_url, &images_dir) {
                         Ok(path) => Some(path),
                         Err(error) => {
                             tracing::warn!("While encoding image data URI to file: {error}");
@@ -178,10 +178,9 @@ impl DomCodec for ImageObject {
                         }
                     }
                 } else {
-                    match images::file_uri_to_path(
+                    match images::file_uri_to_file(
                         &self.content_url,
                         context.from_path.as_deref(),
-                        context.to_path.as_deref(),
                         &images_dir,
                     ) {
                         Ok(path) => Some(path),
@@ -193,8 +192,8 @@ impl DomCodec for ImageObject {
                 };
 
                 // Fallback to encoding the original URL
-                let src = match image_path {
-                    Some(image_path) => image_path.to_string_lossy().to_string(),
+                let src = match image_name {
+                    Some(image_name) => images_dir.join(image_name).to_string_lossy().to_string(),
                     None => self.content_url.to_string(),
                 };
 


### PR DESCRIPTION
This adds a new crate `node-media` which factors out some functionality we had elsewhere for marshaling images in a document into an image directory with hash filenames.

It uses this crate to extract images from documents, upload them to Ghost, and rewrite the URLs of nodes in the document as needed.

@timClicks: I'll pass this over to you to finish off.

I've done some preliminary testing with this Markdown file

```md
A Base64 encoded image:

![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNk+8/wn4EIwDiqkL4KAZCkFDN4mQTvAAAAAElFTkSuQmCC)

A file relative to this doc:

![](./image.png)
```
