### PR TITLE
feat(models): expose quality, cost, and speed scores

### DIFF
--- a/rust/model/src/lib.rs
+++ b/rust/model/src/lib.rs
@@ -83,6 +83,9 @@ pub struct ModelSpecification {
     version: String,
     r#type: ModelType,
     availability: ModelAvailability,
+    quality_score: Option<u32>,
+    cost_score: Option<u32>,
+    speed_score: Option<u32>,
 }
 
 impl From<&dyn Model> for ModelSpecification {
@@ -94,6 +97,9 @@ impl From<&dyn Model> for ModelSpecification {
             version: model.version(),
             r#type: model.r#type(),
             availability: model.availability(),
+            quality_score: model.quality_score(),
+            cost_score: model.cost_score(),
+            speed_score: model.speed_score(),
         }
     }
 }
@@ -245,6 +251,32 @@ pub trait Model: Sync + Send {
     /// Get a list of output types this model supports
     fn supported_outputs(&self) -> &[ModelIO] {
         &[]
+    }
+
+    /// Get the overall quality score for the model
+    ///
+    /// This should be a score in the range 0-100 representing the overall quality
+    /// of responses from the model. It should not be specific to any prompt or task.
+    /// The model with the highest overall score should have a score of 100.
+    fn quality_score(&self) -> Option<u32> {
+        None
+    }
+
+    /// Get the cost score for the model
+    ///
+    /// This should be a score in the range 0-100 representing the cost of the
+    /// model usage (per token, input and output tokens combined). The cheapest
+    /// model should have a score of 100.
+    fn cost_score(&self) -> Option<u32> {
+        None
+    }
+
+    /// Get the speed score for the model
+    ///
+    /// This should be a score in the range 0-100 representing the speed of
+    /// model responses. The fastest model should have a score of 100.
+    fn speed_score(&self) -> Option<u32> {
+        None
     }
 
     /// Perform a generation task

--- a/vscode/src/models.ts
+++ b/vscode/src/models.ts
@@ -84,6 +84,9 @@ interface Model {
     | "RequiresKey"
     | "Installable"
     | "Unavailable";
+  qualityScore?: number;
+  costScore?: number;
+  speedScore?: number;
 }
 
 class ModelPickerItem implements vscode.QuickPickItem {

--- a/web/src/nodes/model-parameters.ts
+++ b/web/src/nodes/model-parameters.ts
@@ -91,31 +91,81 @@ export class ModelParameters extends Entity {
 
     const { textColour } = this.parentNodeUI
 
-    // Render options
+    // Repeat an icon between 1 and 5 times based on score from 0-100
+    // If `reverse = true` then use the reversed score e.g. 100 = 1 icon
+    const scoreIcons = (
+      icon: string | TemplateResult,
+      score?: number,
+      reverse = false
+    ): string | TemplateResult[] => {
+      if (score === undefined || score === null) {
+        return ''
+      }
+      const clampedScore = Math.max(0, Math.min(100, score))
+      const repeatCount = reverse
+        ? 5 - Math.ceil((clampedScore / 100) * 5) + 1
+        : Math.ceil((clampedScore / 100) * 5)
+      return Array(repeatCount).fill(icon)
+    }
+
+    // Render model options nested under a divider for each provider
     this.modelOptions = Object.entries(providers).map(
       ([provider, models], index) => {
         return html`
           ${index !== 0 ? html`<sl-divider class="my-1"></sl-divider>` : ''}
           <div
-            class="flex flex-row items-center gap-2 px-2 py-1 text-[${textColour}]"
+            class="flex flex-row items-center gap-2 pl-6 py-1 text-[${textColour}]"
           >
             <stencila-ui-icon
               slot="prefix"
               class="text-base"
               name=${iconMaybe(provider.toLowerCase()) ?? 'building'}
             ></stencila-ui-icon>
-            ${provider}
+            <span class="font-semi-bold">${provider}</span>
           </div>
-          ${models.map(
-            (model) => html`
+          ${models.map((model) => {
+            const iconGroupStyle = apply('w-[50px] flex flex-row')
+
+            return html`
               <sl-option
                 value=${model.id}
                 style="--sl-spacing-x-small: 0.25rem;"
               >
-                <span class="text-sm text-[${textColour}]">${model.id}</span>
+                <div
+                  class="flex flex-row flex-wrap justify-between items-center text-[${textColour}]"
+                >
+                  <div class="text-sm">${model.name} ${model.version}</div>
+                  <div class="flex flex-row items-center gap-2 text-[10px]">
+                    <div class=${iconGroupStyle}>
+                      ${scoreIcons(
+                        html`<stencila-ui-icon
+                          name="starFill"
+                        ></stencila-ui-icon>`,
+                        model.qualityScore
+                      )}
+                    </div>
+                    <div class=${iconGroupStyle}>
+                      ${scoreIcons(
+                        html`<stencila-ui-icon
+                          name="currencyDollar"
+                        ></stencila-ui-icon>`,
+                        model.costScore,
+                        true
+                      )}
+                    </div>
+                    <div class=${iconGroupStyle}>
+                      ${scoreIcons(
+                        html`<stencila-ui-icon
+                          name="lightningChargeFill"
+                        ></stencila-ui-icon>`,
+                        model.speedScore
+                      )}
+                    </div>
+                  </div>
+                </div>
               </sl-option>
             `
-          )}
+          })}
         `
       }
     )

--- a/web/src/nodes/model-parameters.ts
+++ b/web/src/nodes/model-parameters.ts
@@ -136,31 +136,39 @@ export class ModelParameters extends Entity {
                 >
                   <div class="text-sm">${model.name} ${model.version}</div>
                   <div class="flex flex-row items-center gap-2 text-[10px]">
-                    <div class=${iconGroupStyle}>
-                      ${scoreIcons(
-                        html`<stencila-ui-icon
-                          name="starFill"
-                        ></stencila-ui-icon>`,
-                        model.qualityScore
-                      )}
-                    </div>
-                    <div class=${iconGroupStyle}>
-                      ${scoreIcons(
-                        html`<stencila-ui-icon
-                          name="currencyDollar"
-                        ></stencila-ui-icon>`,
-                        model.costScore,
-                        true
-                      )}
-                    </div>
-                    <div class=${iconGroupStyle}>
-                      ${scoreIcons(
-                        html`<stencila-ui-icon
-                          name="lightningChargeFill"
-                        ></stencila-ui-icon>`,
-                        model.speedScore
-                      )}
-                    </div>
+                    <sl-tooltip
+                      content="Overall quality score: ${model.qualityScore}/100"
+                    >
+                      <div class=${iconGroupStyle}>
+                        ${scoreIcons(
+                          html`<stencila-ui-icon
+                            name="starFill"
+                          ></stencila-ui-icon>`,
+                          model.qualityScore
+                        )}
+                      </div>
+                    </sl-tooltip>
+                    <sl-tooltip content="Cost score: ${model.costScore}/100">
+                      <div class=${iconGroupStyle}>
+                        ${scoreIcons(
+                          html`<stencila-ui-icon
+                            name="currencyDollar"
+                          ></stencila-ui-icon>`,
+                          model.costScore,
+                          true
+                        )}
+                      </div>
+                    </sl-tooltip>
+                    <sl-tooltip content="Speed score: ${model.speedScore}/100">
+                      <div class=${iconGroupStyle}>
+                        ${scoreIcons(
+                          html`<stencila-ui-icon
+                            name="lightningChargeFill"
+                          ></stencila-ui-icon>`,
+                          model.speedScore
+                        )}
+                      </div>
+                    </sl-tooltip>
                   </div>
                 </div>
               </sl-option>

--- a/web/src/system.ts
+++ b/web/src/system.ts
@@ -94,17 +94,7 @@ class Data extends EventTarget {
   }
 
   get models(): Model[] {
-    return this._models.map((model) => ({
-      ...model,
-      // TODO: Remove these temporary, random scores, used for mocks
-      ...(model.id === 'stencila/router'
-        ? {}
-        : {
-            qualityScore: Math.floor(Math.random() * 101),
-            costScore: Math.floor(Math.random() * 101),
-            speedScore: Math.floor(Math.random() * 101),
-          }),
-    }))
+    return this._models
   }
 
   set models(models: Model[]) {

--- a/web/src/system.ts
+++ b/web/src/system.ts
@@ -42,6 +42,9 @@ export interface Model {
     | 'Installable'
     | 'Unavailable'
     | 'Disabled'
+  qualityScore?: number
+  costScore?: number
+  speedScore?: number
 }
 
 /**
@@ -91,7 +94,17 @@ class Data extends EventTarget {
   }
 
   get models(): Model[] {
-    return this._models
+    return this._models.map((model) => ({
+      ...model,
+      // TODO: Remove these temporary, random scores, used for mocks
+      ...(model.id === 'stencila/router'
+        ? {}
+        : {
+            qualityScore: Math.floor(Math.random() * 101),
+            costScore: Math.floor(Math.random() * 101),
+            speedScore: Math.floor(Math.random() * 101),
+          }),
+    }))
   }
 
   set models(models: Model[]) {

--- a/web/src/ui/icons/icon.ts
+++ b/web/src/ui/icons/icon.ts
@@ -102,6 +102,7 @@ import javascript from './javascript.svg'
 import json from './json.svg'
 import latex from './latex.svg'
 import lightbulb from './lightbulb.svg'
+import lightningChargeFill from './lightning-charge-fill.svg'
 import lightning from './lightning.svg'
 import list from './list.svg'
 import lock from './lock.svg'
@@ -234,6 +235,7 @@ const icons = {
   json,
   latex,
   lightbulb,
+  lightningChargeFill,
   lightning,
   list,
   lock,

--- a/web/src/ui/icons/icons-shoelace.sh
+++ b/web/src/ui/icons/icons-shoelace.sh
@@ -64,6 +64,7 @@ icons=(
     info-circle
     lightbulb
     lightning
+    lightning-charge-fill
     lock
     paperclip
     person

--- a/web/src/ui/icons/lightning-charge-fill.svg
+++ b/web/src/ui/icons/lightning-charge-fill.svg
@@ -1,0 +1,3 @@
+<svg  fill="currentColor" class="bi bi-lightning-charge-fill" viewBox="0 0 16 16">
+  <path d="M11.251.068a.5.5 0 0 1 .227.58L9.677 6.5H13a.5.5 0 0 1 .364.843l-8 8.5a.5.5 0 0 1-.842-.49L6.323 9.5H3a.5.5 0 0 1-.364-.843l8-8.5a.5.5 0 0 1 .615-.09z"/>
+</svg>


### PR DESCRIPTION
@jduckles had the excellent idea of exposing model scores for overall quality (not specific to a particular prompt), cost, and speed in the select menu for models.

This implements that (currently with random scores pending adding those to `GET htpps://api.stencila.cloud/v1/models`) and more:

- the list of models is now sorted, across providers, in Rust, according to (a) routers always first, (b) quality score if any, (c) provider+model name

- the scores are displayed in the `stencila models list` command as colour coded numbers (and also in JSON or YAML when using the `--as` option)

![Screenshot from 2025-01-23 08-04-34](https://github.com/user-attachments/assets/7428843a-68c2-4250-bcaa-b6638a76bfae)

- improved how models names & versions are displayed in the model selection menu which makes it consistent with the models sidebar menu

- the scores are displayed in the model selection menu using star, dollar and zap icons, examples below for wide and narrow displays

![Screenshot from 2025-01-23 08-17-11](https://github.com/user-attachments/assets/5faba5e5-b825-4c84-b698-0d28dcc4df07)

![Screenshot from 2025-01-23 08-18-34](https://github.com/user-attachments/assets/d0c983aa-801b-43c1-9a4b-82ad55e9da75)

- tool tips in the menu like "Overall model score: 82/100" 

The information density is high (i.e. its pretty busy!) but I think this is a really good way to bring our evals/benchmarking right into the application and make it useful to users. Because there are correlations between quality and cost and speed - I think it will look less busy with real scores.