### PR TITLE
fix(cli docs): add headering and examples to some help messages

### DIFF
--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -97,6 +97,7 @@ pub enum Command {
     New(new::Cli),
 
     Convert(convert::Cli),
+    #[command(hide=true)]
     Sync(sync::Cli),
 
     Compile(compile::Cli),

--- a/rust/cli/src/convert.rs
+++ b/rust/cli/src/convert.rs
@@ -10,6 +10,12 @@ use format::Format;
 use crate::options::{DecodeOptions, EncodeOptions, StripOptions};
 
 /// Convert a document to another format
+///
+/// Examples:
+///
+/// `stecila convert article.smd article.docx`
+///
+/// `stecila convert file.txt --from markdown --to json --pretty`
 #[derive(Debug, Parser)]
 pub struct Cli {
     /// The path of the input file

--- a/rust/cli/src/new.rs
+++ b/rust/cli/src/new.rs
@@ -9,9 +9,14 @@ use format::Format;
 use schema::NodeType;
 
 /// Create a new document with sidecar file
+///
+/// Supported exstentions can be seen with `stencila codecs list`
+/// 
+/// Example: `stencila new article.smd`
 #[derive(Debug, Parser)]
 pub struct Cli {
-    /// The path of the document to create
+    /// The path of the document to create with a supported extension 
+    #[arg(value_name="File")]
     path: PathBuf,
 
     /// Overwrite the document, and any sidecar file, if they already exist

--- a/rust/cli/src/options.rs
+++ b/rust/cli/src/options.rs
@@ -14,14 +14,17 @@ use node_strip::StripScope;
 pub struct StripOptions {
     /// Scopes defining which properties of nodes should be stripped
     #[arg(long)]
+    #[arg(help_heading("Strip Options"), display_order(3))]
     strip_scopes: Vec<StripScope>,
 
     /// A list of node types to strip
     #[arg(long)]
+    #[arg(help_heading("Strip Options"), display_order(3))]
     strip_types: Vec<String>,
 
     /// A list of node properties to strip
     #[arg(long)]
+    #[arg(help_heading("Strip Options"), display_order(3))]
     strip_props: Vec<String>,
 }
 
@@ -61,14 +64,17 @@ impl DecodeOptions {
 pub struct EncodeOptions {
     /// Encode as a standalone document
     #[arg(long, conflicts_with = "not_standalone")]
+    #[arg(help_heading("Encode Options"), display_order(2))]
     standalone: bool,
 
     /// Do not encode as a standalone document when writing to file
     #[arg(long, conflicts_with = "standalone")]
+    #[arg(help_heading("Encode Options"), display_order(2))]
     not_standalone: bool,
 
     /// For executable nodes, only encode outputs, not source properties
     #[arg(long, short)]
+    #[arg(help_heading("Encode Options"), display_order(2))]
     render: bool,
 
     /// Use compact form of encoding if possible
@@ -76,6 +82,7 @@ pub struct EncodeOptions {
     /// Use this flag to produce the compact forms of encoding (e.g. no indentation)
     /// which are supported by some formats (e.g. JSON, HTML).
     #[arg(long, short, conflicts_with = "pretty")]
+    #[arg(help_heading("Encode Options"), display_order(2))]
     compact: bool,
 
     /// Use a "pretty" form of encoding if possible
@@ -83,6 +90,7 @@ pub struct EncodeOptions {
     /// Use this flag to produce pretty forms of encoding (e.g. indentation)
     /// which are supported by some formats (e.g. JSON, HTML).
     #[arg(long, short, conflicts_with = "compact")]
+    #[arg(help_heading("Encode Options"), display_order(2))]
     pretty: bool,
 }
 

--- a/rust/node-execute/src/lib.rs
+++ b/rust/node-execute/src/lib.rs
@@ -269,6 +269,7 @@ impl HeadingInfo {
 pub struct ExecuteOptions {
     /// Re-execute all node types regardless of current state
     #[arg(long)]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub force_all: bool,
 
     /// Skip executing code
@@ -276,6 +277,7 @@ pub struct ExecuteOptions {
     /// By default, code-based nodes in the document (e.g. `CodeChunk`, `CodeExpression`, `ForBlock`)
     /// nodes will be executed if they are stale. Use this flag to skip executing all code-based nodes.
     #[arg(long)]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub skip_code: bool,
 
     /// Skip executing instructions
@@ -283,6 +285,7 @@ pub struct ExecuteOptions {
     /// By default, instructions with no suggestions, or with suggestions that have
     /// been rejected will be executed. Use this flag to skip executing all instructions.
     #[arg(long, alias = "skip-inst")]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub skip_instructions: bool,
 
     /// Retain existing suggestions for instructions
@@ -291,6 +294,7 @@ pub struct ExecuteOptions {
     /// are deleted. Use this flag to retain existing suggestions, for example, so that you can
     /// use a previous one if a revision is worse.
     #[arg(long)]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub retain_suggestions: bool,
 
     /// Re-execute instructions with suggestions that have not yet been reviewed
@@ -299,6 +303,7 @@ pub struct ExecuteOptions {
     /// (i.e. has a suggestion status that is empty) will not be re-executed. Use this
     /// flag to force these instructions to be re-executed.
     #[arg(long)]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub force_unreviewed: bool,
 
     /// Re-execute instructions with suggestions that have been accepted.
@@ -306,6 +311,7 @@ pub struct ExecuteOptions {
     /// By default, an instruction that has a suggestion that has been accepted, will
     /// not be re-executed. Use this flag to force these instructions to be re-executed.
     #[arg(long)]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub force_accepted: bool,
 
     /// Skip re-executing instructions with suggestions that have been rejected
@@ -313,6 +319,7 @@ pub struct ExecuteOptions {
     /// By default, instructions that have a suggestion that has been rejected, will be
     /// re-executed. Use this flag to skip re-execution of these instructions.
     #[arg(long)]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub skip_rejected: bool,
 
     /// Prepare, but do not actually perform, execution tasks
@@ -320,6 +327,7 @@ pub struct ExecuteOptions {
     /// Currently only supported by instructions where it is useful for debugging the
     /// rendering of prompts without making a potentially slow generative model API request.
     #[arg(long)]
+    #[arg(help_heading("Execute Options"), display_order(1))]
     pub dry_run: bool,
 }
 


### PR DESCRIPTION
This PR Is to edit cli help messages. Using headers, examples and adding more info where required to improve UX