### PR TITLE
ghost nested lists encoding

### DIFF
--- a/rust/codec-lexical/src/blocks.rs
+++ b/rust/codec-lexical/src/blocks.rs
@@ -282,20 +282,71 @@ fn list_from_lexical(list: lexical::ListNode, context: &mut LexicalDecodeContext
 }
 
 fn list_to_lexical(list: &List, context: &mut LexicalEncodeContext) -> lexical::BlockNode {
-    let markdown = match codec_markdown::encode(&art([Block::List(list.clone())]), None) {
-        Ok((md, ..)) => md,
-        Err(error) => {
-            // If encoding fails (should very, rarely if at all)
-            // record loss and return empty string
-            context.losses.add(format!("Markdown: {error}"));
-            String::new()
-        }
-    };
+    if list
+        .items
+        .iter()
+        .flat_map(|item| &item.content)
+        .any(|block| {
+            if let Block::List(List{..}) = block{
+                return true;
+            } else{
+                return false;
+            }
+        })
+    {
+        let markdown = match codec_markdown::encode(&art([Block::List(list.clone())]), None) {
+            Ok((md, ..)) => md,
+            Err(error) => {
+                // If encoding fails (should very, rarely if at all)
+                // record loss and return empty string
+                context.losses.add(format!("Markdown: {error}"));
+                String::new()
+            }
+        };
 
-    lexical::BlockNode::Markdown(lexical::MarkdownNode {
-        markdown,
+        lexical::BlockNode::Markdown(lexical::MarkdownNode {
+            markdown,
+            ..Default::default()
+        })
+    } else {
+        let children = list
+            .items
+            .iter()
+            .map(|item| list_item_to_lexical(item, context))
+            .collect();
+
+        let list_type = match list.order {
+            ListOrder::Ascending | ListOrder::Descending => lexical::ListType::Number,
+            ListOrder::Unordered => lexical::ListType::Bullet,
+        };
+
+        lexical::BlockNode::List(lexical::ListNode {
+            list_type,
+            children,
+            ..Default::default()
+        })
+    }
+}
+
+fn list_item_to_lexical(
+    list_item: &ListItem,
+    context: &mut LexicalEncodeContext,
+) -> lexical::ListItemNode {
+    let mut children = Vec::new();
+
+    for (i, block) in list_item.content.clone().into_iter().enumerate() {
+        if i != 0 {
+            children.push(lexical::BlockNode::LineBreak(lexical::LineBreakNode {
+                ..Default::default()
+            }));
+        }
+        children.push(block_to_lexical(&block, context));
+    }
+
+    lexical::ListItemNode {
+        children,
         ..Default::default()
-    })
+    }
 }
 
 fn quote_to_lexical(quote: &QuoteBlock, context: &mut LexicalEncodeContext) -> lexical::BlockNode {

--- a/rust/codec-lexical/src/blocks.rs
+++ b/rust/codec-lexical/src/blocks.rs
@@ -287,10 +287,10 @@ fn list_to_lexical(list: &List, context: &mut LexicalEncodeContext) -> lexical::
         .iter()
         .flat_map(|item| &item.content)
         .any(|block| {
-            if let Block::List(List{..}) = block{
-                return true;
-            } else{
-                return false;
+            if let Block::List(List { .. }) = block {
+                true
+            } else {
+                false
             }
         })
     {

--- a/rust/codec-lexical/tests/snapshots/examples__ghost.koenig.snap
+++ b/rust/codec-lexical/tests/snapshots/examples__ghost.koenig.snap
@@ -192,8 +192,41 @@ snapshot_kind: text
         "markdown": "- List item 1\n\n    This is a paragraph under the bullet\n\n- - List item 1\n\n      This is a paragraph under the bullet\n\n  - List item 2\n"
       },
       {
-        "type": "markdown",
-        "markdown": "1. Numbered list item 1\n2. Numbered list item 2\n"
+        "type": "list",
+        "listType": "number",
+        "start": 1,
+        "children": [
+          {
+            "type": "listitem",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "extended-text",
+                    "format": 0,
+                    "text": "Numbered list item 1"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "listitem",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "extended-text",
+                    "format": 0,
+                    "text": "Numbered list item 2"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
         "type": "horizontalrule"

--- a/rust/codec-lexical/tests/snapshots/examples__playground.lexical.snap
+++ b/rust/codec-lexical/tests/snapshots/examples__playground.lexical.snap
@@ -99,8 +99,203 @@ snapshot_kind: text
         ]
       },
       {
-        "type": "markdown",
-        "markdown": "- Visit the \n\n  [Lexical website](https://lexical.dev/)\n\n   for documentation and more information.\n\n- Check out the code on our \n\n  [GitHub repository](https://github.com/facebook/lexical)\n\n  .\n\n- Playground code can be found \n\n  [here](https://github.com/facebook/lexical/tree/main/packages/lexical-playground)\n\n  .\n\n- Join our \n\n  [Discord Server](https://discord.com/invite/KmG4wQnnD9)\n\n   and chat with the team.\n"
+        "type": "list",
+        "listType": "bullet",
+        "start": 1,
+        "children": [
+          {
+            "type": "listitem",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": "Visit the "
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "link",
+                    "children": [
+                      {
+                        "type": "text",
+                        "format": 0,
+                        "text": "Lexical website"
+                      }
+                    ],
+                    "format": "",
+                    "url": "https://lexical.dev/"
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": " for documentation and more information."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "listitem",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": "Check out the code on our "
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "link",
+                    "children": [
+                      {
+                        "type": "text",
+                        "format": 0,
+                        "text": "GitHub repository"
+                      }
+                    ],
+                    "format": "",
+                    "url": "https://github.com/facebook/lexical"
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": "."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "listitem",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": "Playground code can be found "
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "link",
+                    "children": [
+                      {
+                        "type": "text",
+                        "format": 0,
+                        "text": "here"
+                      }
+                    ],
+                    "format": "",
+                    "url": "https://github.com/facebook/lexical/tree/main/packages/lexical-playground"
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": "."
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "listitem",
+            "children": [
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": "Join our "
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "link",
+                    "children": [
+                      {
+                        "type": "text",
+                        "format": 0,
+                        "text": "Discord Server"
+                      }
+                    ],
+                    "format": "",
+                    "url": "https://discord.com/invite/KmG4wQnnD9"
+                  }
+                ]
+              },
+              {
+                "type": "linebreak"
+              },
+              {
+                "type": "paragraph",
+                "children": [
+                  {
+                    "type": "text",
+                    "format": 0,
+                    "text": " and chat with the team."
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
         "type": "paragraph",


### PR DESCRIPTION
encode flat lists to lexical lists for easy of editing on ghost and encode nested lists to markdown because lexical does not support them.
