### PR TITLE
fix(web): set correct node state for single node viewport

### DIFF
--- a/web/src/nodes/entity.ts
+++ b/web/src/nodes/entity.ts
@@ -93,7 +93,7 @@ export abstract class Entity extends LitElement {
     this.context.nodeId = this.id
 
     const mode = getModeParam(window)
-    if (mode && mode === 'test-expand-all') {
+    if ((mode && mode === 'test-expand-all') || this.depth === 0) {
       // start with card open in default
       this.context.cardOpen = true
     }


### PR DESCRIPTION
**details**

Have patched over the main issue raised in #2548 

This makes sure that nodes displayed in the vscode single node preview, have their entity context reflected

If the Entity is at depth === 0 (ie. is the root node) it will pass the correct value down to the for block interations or if block clauses.


closes: #2548 