### PR TITLE
Fix/codemirror keybindings

### DIFF
--- a/rust/lsp/src/commands.rs
+++ b/rust/lsp/src/commands.rs
@@ -90,6 +90,7 @@ pub(super) const EXPORT_DOC: &str = "stencila.export-doc";
 pub(super) fn commands() -> Vec<String> {
     [
         PATCH_VALUE,
+        PATCH_VALUE_EXECUTE,
         PATCH_CLONE,
         PATCH_CHAT_FOCUS,
         PATCH_NODE_FORMAT,

--- a/web/src/nodes/include-block.ts
+++ b/web/src/nodes/include-block.ts
@@ -39,6 +39,11 @@ export class IncludeBlock extends Executable {
   @state()
   private hasContent = false
 
+  /**
+   * Whether the include block is read-only.
+   *
+   * Currently always false, but in the future, this may depend on the context.
+   */
   private readonly = false
 
   /**
@@ -47,6 +52,9 @@ export class IncludeBlock extends Executable {
    */
   private contentObserver: MutationObserver
 
+  /**
+   * A timer on the <input> used to debounce changes
+   */
   private inputTimer: NodeJS.Timeout
 
   /**
@@ -61,8 +69,9 @@ export class IncludeBlock extends Executable {
       this.dispatchEvent(patchValue('IncludeBlock', this.id, 'source', value))
     }, 300)
   }
+
   /**
-   * Key press event handler to run include upon 'Ctrl+Enter'
+   * Key press event handler to execute upon 'Ctrl+Enter'
    */
   private onKeydown(e: KeyboardEvent) {
     if (e.ctrlKey && e.key === 'Enter') {

--- a/web/src/nodes/include-block.ts
+++ b/web/src/nodes/include-block.ts
@@ -53,7 +53,6 @@ export class IncludeBlock extends Executable {
    * Send the patch event upon input change
    */
   private onInputChange(e: InputEvent) {
-    console.log('timer')
     const value = (e.target as HTMLInputElement).value
     if (this.inputTimer) {
       clearTimeout(this.inputTimer)
@@ -185,7 +184,7 @@ export class IncludeBlock extends Executable {
           <input
             class="flex-grow rounded-sm border border-[${borderColour}] px-2 font-mono h-[2em] outline-black"
             value=${this.source}
-            @input=${(e) => this.onInputChange(e)}
+            @input=${this.onInputChange}
             @keydown=${this.onKeydown}
             ?readonly=${this.readonly}
             ?disabled=${this.readonly}

--- a/web/src/nodes/prompt-block.ts
+++ b/web/src/nodes/prompt-block.ts
@@ -407,7 +407,7 @@ export class PromptBlock extends Executable {
     return html`
       <div class="bg-white/50 w-full max-h-[90vh] rounded overflow-y-auto mt-2">
         <div
-          class="max-w-prose mx-auto p-3"
+          class="max-w-[50rem] mx-auto pl-16 pr-5"
           style="color: var(--default-text-colour);"
         >
           <slot name="content"></slot>

--- a/web/src/ui/nodes/properties/code/code.ts
+++ b/web/src/ui/nodes/properties/code/code.ts
@@ -124,6 +124,8 @@ export class UINodeCode extends LitElement {
    */
   private editorView?: EditorView
 
+  // Compartments for toggling on editor functionality
+
   private viewEditable: Compartment
 
   private viewReadOnly: Compartment
@@ -144,12 +146,12 @@ export class UINodeCode extends LitElement {
   /**
    * Runs the current code
    *
-   * dispatches a `path-value-execute` command so the code is up to date upon execution
+   * Dispatches a `path-value-execute` command so the code is up to date upon execution
    */
   private runCode() {
     const value = this.editorView.state.doc.toString()
     this.dispatchEvent(
-      patchValueExecute(this.nodeType, this.nodeId, this.nodeProperty, value)
+      patchValueExecute(this.type, this.nodeId, this.nodeProperty, value)
     )
   }
 
@@ -394,7 +396,6 @@ export class UINodeCode extends LitElement {
         {
           key: 'Ctrl-Enter',
           run: () => {
-            console.log('hi')
             this.runCode()
             return true
           },

--- a/web/src/ui/nodes/properties/code/code.ts
+++ b/web/src/ui/nodes/properties/code/code.ts
@@ -16,11 +16,7 @@ import { apply } from '@twind/core'
 import { LitElement, PropertyValues, html } from 'lit'
 import { customElement, property } from 'lit/decorators'
 
-import {
-  patchValue,
-  patchValueExecute,
-  runNode,
-} from '../../../../clients/commands'
+import { patchValue, patchValueExecute } from '../../../../clients/commands'
 import { CompilationMessage } from '../../../../nodes/compilation-message'
 import { ExecutionMessage } from '../../../../nodes/execution-message'
 import { withTwind } from '../../../../twind'
@@ -372,7 +368,6 @@ export class UINodeCode extends LitElement {
       tr.newDoc.lines > 1 ? [] : tr
     )
 
-    // filter out default ctrl-enter keybinding
     const filteredKeyMap = defaultKeymap.filter((kb) => {
       if (kb.key) {
         return !['mod-enter', 'ctrl-enter'].includes(kb.key.toLowerCase())

--- a/web/src/ui/nodes/properties/code/utils.ts
+++ b/web/src/ui/nodes/properties/code/utils.ts
@@ -184,6 +184,7 @@ export const clipBoardKeyBindings = [
           to: view.state.selection.main.to,
           insert: '',
         },
+        userEvent: 'delete.cut',
       })
       return true // Cut successful
     },
@@ -200,6 +201,7 @@ export const clipBoardKeyBindings = [
           to: view.state.selection.main.from,
           insert: text,
         },
+        userEvent: 'input.paste',
       })
       return true // Paste successful
     },


### PR DESCRIPTION
**details**

- makes sure the editable codemirror views clipboard events cut and paste fires the patch-node cmd
- attaches a 'ctrl-Enter' keybinding to run the node, have to override the default here.
- Also makes the inlcude block source property editiable in the ui, with the smae ctrl-enter execute command

The `patchValueExecute` command kept failing in vscode lsp, but the command was being dispatched from the webview successfully.