### PR TITLE
fix(web): stop text overflow in author elements

### DIFF
--- a/web/src/nodes/figure.ts
+++ b/web/src/nodes/figure.ts
@@ -36,9 +36,7 @@ export class Figure extends Entity {
             <slot name="authors"></slot>
           </stencila-ui-node-authors>
         </div>
-        <div slot="content">
-          ${this.renderContent()}
-        </div>
+        <div slot="content">${this.renderContent()}</div>
       </stencila-ui-block-on-demand>
     `
   }

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -55,28 +55,27 @@ body {
 stencila-dynamic-view,
 stencila-vscode-view {
   > [root] {
-    @apply max-w-prose;
-    font-family: var(--font-family-serif);
-    color: var(--default-text-colour);
+    font-family: var(--font-family-serif, inherit);
+    color: var(--default-text-colour, inherit);
 
     > section {
       @apply min-w-80 w-full mx-auto;
       max-width: 72ch;
     }
 
-    h1 {
+    /* h1 {
       margin-top: 2rem;
-    }
+    } */
 
-    figure {
+    /* figure {
       @apply m-0;
     }
 
     li {
       @apply m-0 list-item w-full;
-    }
+    } */
 
-    stencila-figure,
+    /* stencila-figure,
     stencila-ui-block-on-demand {
       figure {
         @apply my-3 mx-0 max-w-full;
@@ -105,7 +104,7 @@ stencila-vscode-view {
       [slot='caption'] {
         @apply block;
       }
-    }
+    } */
   }
 
   /* Headings TOC nav */

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -60,7 +60,7 @@ stencila-vscode-view {
 
     > section {
       @apply min-w-80 w-full mx-auto;
-      max-width: 72ch;
+      max-width: 75ch;
     }
   }
 

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -62,49 +62,6 @@ stencila-vscode-view {
       @apply min-w-80 w-full mx-auto;
       max-width: 72ch;
     }
-
-    /* h1 {
-      margin-top: 2rem;
-    } */
-
-    /* figure {
-      @apply m-0;
-    }
-
-    li {
-      @apply m-0 list-item w-full;
-    } */
-
-    /* stencila-figure,
-    stencila-ui-block-on-demand {
-      figure {
-        @apply my-3 mx-0 max-w-full;
-      }
-    }
-
-    stencila-instruction-block {
-      [slot='messages'] {
-        display: block;
-      }
-
-      &:has(+ stencila-paragraph) {
-        table {
-          @apply mb-4;
-        }
-      }
-    }
-
-    stencila-table {
-      [slot='authors'] {
-        @apply mt-3;
-      }
-    }
-
-    stencila-code-chunk {
-      [slot='caption'] {
-        @apply block;
-      }
-    } */
   }
 
   /* Headings TOC nav */

--- a/web/src/themes/nodes.css
+++ b/web/src/themes/nodes.css
@@ -67,19 +67,19 @@ stencila-heading {
   }
 
   h1 {
-    margin-top: 3.5rem;
+    margin-top: 3rem;
     line-height: 1.1;
     @apply mb-4 text-3xl lg:text-4xl;
   }
 
   h2 {
-    margin-top: 2.5rem;
+    margin-top: 2rem;
     line-height: 1.1;
     @apply text-2xl lg:text-3xl;
   }
 
   h3 {
-    margin-top: 2rem;
+    margin-top: 1.5rem;
   }
 
   h2,

--- a/web/src/ui/nodes/properties/author.ts
+++ b/web/src/ui/nodes/properties/author.ts
@@ -110,7 +110,7 @@ export class UINodeAuthor extends LitElement {
     return html`
       <div class="@container w-full">
         <div class="flex flex-col gap-x-2 font-sans mb-4 @xs:flex-row @xs:mb-0">
-          <div class="flex flex-row flex-grow">
+          <div class="flex flex-row flex-grow min-w-0">
             <div class="flex items-center justify-center mr-2">
               <div
                 class="w-6 h-6 flex items-center justify-center grow-0 stretch-0"
@@ -118,7 +118,7 @@ export class UINodeAuthor extends LitElement {
                 ${this.renderIconOrAvatar()}
               </div>
             </div>
-            <div class="grow flex flex-col justify-center">
+            <div class="grow flex flex-col justify-center w-full">
               <span
                 class=${`text-2xs leading-none ${this.roleName ? '' : 'hidden'}`}
                 >${this.roleName}
@@ -127,14 +127,16 @@ export class UINodeAuthor extends LitElement {
                   : ''}</span
               >
               <span
-                class="text-xs leading-5 overflow-hidden whitespace-nowrap text-ellipsis inline-block"
-                >${this.renderName()}</span
+                class="block text-xs w-[90%] leading-5 overflow-hidden whitespace-nowrap text-ellipsis inline-block"
               >
+                ${this.renderName()}
+              </span>
               ${this.details
                 ? html`<span
-                    class=${`text-2xs leading-none overflow-hidden whitespace-nowrap text-ellipsis inline-block`}
-                    >${this.details}</span
-                  >`
+                    class=${`block text-2xs w-[90%] leading-none overflow-hidden whitespace-nowrap text-ellipsis inline-block`}
+                  >
+                    ${this.details}
+                  </span>`
                 : ''}
             </div>
           </div>


### PR DESCRIPTION
**details**

enforce the overflow ellipsis on the author node `<stencila-ui-node-author>` to stop details overflowing container