### PR TITLE
fix(ghost): add rollup to compile command

### DIFF
--- a/ghost/Makefile
+++ b/ghost/Makefile
@@ -1,3 +1,4 @@
 compile:
 	make -C ../web install
+	npm run build
 	npm run compile-stencila

--- a/ghost/README.md
+++ b/ghost/README.md
@@ -130,7 +130,7 @@ ln -s /path/to/stencila/repo/ghost /ghost/content/themes/stencila
 Then compile the stencila web components into the theme by running the following `make` command from the stencila repo root:
 
 ```bash
-make -C ghost compile-stencila
+make -C ghost compile
 ```
 
 In the browser navigate to your local ghost admin site (usually http://localhost:2368/ghost/).

--- a/ghost/partials/docPageLinks.hbs
+++ b/ghost/partials/docPageLinks.hbs
@@ -1,3 +1,4 @@
+{{!lists the links for all the pages tagged with '#doc-page'}}
 <div class="mb-8">
   <ul>
     {{#get 'pages' filter="tag:hash-doc-page" limit='all' order="published_at desc" }}

--- a/ghost/partials/docviewer.hbs
+++ b/ghost/partials/docviewer.hbs
@@ -42,7 +42,6 @@
                                             {{#get "posts" filter="tags:{{slug}}+tags:hash-doc" limit="all" order="published_at asc"}}
                                                 {{#foreach posts as |post|}}
                                                     <li class="mb-2 ml-4 flex items-start hover:text-[var(--ghost-accent-color)]">
-                                                        {{!-- <div class="w-4 h-4 mr-4 mt-1 flex-none">{{>icons/paragraph}}</div> --}}
                                                         <a href="{{post.url}}" class="{{#match ../../../../currentSlug "=" post.slug}}active font-semibold underline{{else}} hover:text-[var(--ghost-accent-color)]{{/match}}">
                                                             {{post.title}}
                                                         </a>

--- a/ghost/post.hbs
+++ b/ghost/post.hbs
@@ -3,7 +3,7 @@
 {{#post}}
     {{#has tag="#doc"}}
         {{#foreach tags}}
-            {{#get "pages" filter="tag:{{slug}}" limit="1" include="tags" }}
+            {{#get "pages" filter="tag:{{slug}}+tag:hash-doc-page" limit="1" include="tags" }}
                 {{#foreach pages limit="1" as |page|}}
                     {{> docviewer post=../../.. page=page currentSlug=../../../slug }}    
                 {{/foreach }}

--- a/ghost/stencila-site-routes.yaml
+++ b/ghost/stencila-site-routes.yaml
@@ -14,7 +14,7 @@ collections:
     data: page.docs
     filter: "tag:hash-doc+tag:-hash-schema"
 
-  /schema/:
+  /docs/schema/:
     permalink: /docs/schema/{slug}/
     template: index
     data: page.schema


### PR DESCRIPTION
**details**

some touch ups and fixes to the ghost theme:

- run the rollup with the web compile so all assets are compiled at once
- tighten up the page query on the post page to avoid picking up the wrong page context


