### PR TITLE
Fix/bump web depenedencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -311,10 +311,11 @@
       }
     },
     "node_modules/@argos-ci/api-client": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@argos-ci/api-client/-/api-client-0.7.2.tgz",
-      "integrity": "sha512-ojKOhb4CXugJcHNzGH4Gp7G6gqqBEbhO2B5FNfU/ieBCDsYY+urE0hQ5L7+4TfmMoKb/xVpvtu2mQdEpMt4JVg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@argos-ci/api-client/-/api-client-0.8.0.tgz",
+      "integrity": "sha512-UHa1vAf8gwHVpkqM/RaSryrFe1juqWH6dHpPeMtT4e/ZMB9hNYwYFinaGq/KRWe88JEi2WeAu776YdoeUSZQkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
         "openapi-fetch": "0.13.4"
@@ -324,22 +325,24 @@
       }
     },
     "node_modules/@argos-ci/browser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@argos-ci/browser/-/browser-2.2.2.tgz",
-      "integrity": "sha512-pxoUKAVA/3whUKZU1BV93vI4JBYD6utKOd8yfMdZk70kRBL+ZEY+wIPDgQCXiDk02/od64xTn3YiD+N20V45RA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@argos-ci/browser/-/browser-3.0.1.tgz",
+      "integrity": "sha512-dqRXWCllulbKlqzwNE2bjbCtNqxVnUUrYpI1iIJQCMvyStmPdGHOYD7BoQQQ2uNPT2pCHeDyysrxc5T3mDyScg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@argos-ci/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@argos-ci/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-00xNAPwE8O7sKCgn9oeiKGE0cyZYuC3ouCxN+DBAMqZLIG+8zoUZUuB+ZJsKwjMHA9un/bzFX9l8z2Z8rgkQ7w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@argos-ci/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-bo/pNKk6P0pz4NRdymgU1letwQrRbMPTeFyMsUEW8fhKNdesSFnFIWZBFGsGkkh05uw75PBjl2ZN4PvQ2TxSog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@argos-ci/api-client": "0.7.2",
-        "@argos-ci/util": "2.2.2",
+        "@argos-ci/api-client": "0.8.0",
+        "@argos-ci/util": "2.3.0",
         "axios": "^1.7.9",
         "convict": "^6.2.4",
         "debug": "^4.4.0",
@@ -352,14 +355,15 @@
       }
     },
     "node_modules/@argos-ci/playwright": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@argos-ci/playwright/-/playwright-3.10.0.tgz",
-      "integrity": "sha512-kL83M8+KJ+A3bVbAWwPUMZNVlzP1FZMi3E5Y8Er4LnpqAutkbmL+YNeSamgX61WjOS8Zq3tIwf9923/rWvEkiQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@argos-ci/playwright/-/playwright-4.1.0.tgz",
+      "integrity": "sha512-7/6/fRQvs/ZObZG76qNVHRyv5nK21oBLxzzd8T1OmJMC/+UmV9omiuOO3x75H5kc5e3vlKsCc0hClFCqtbye7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@argos-ci/browser": "2.2.2",
-        "@argos-ci/core": "3.0.0",
-        "@argos-ci/util": "2.2.2",
+        "@argos-ci/browser": "3.0.1",
+        "@argos-ci/core": "3.1.0",
+        "@argos-ci/util": "2.3.0",
         "chalk": "^5.4.1",
         "debug": "^4.4.0"
       },
@@ -380,10 +384,11 @@
       }
     },
     "node_modules/@argos-ci/util": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@argos-ci/util/-/util-2.2.2.tgz",
-      "integrity": "sha512-MpKAz/3dMNjsUO49sEMYfw+qZFUrEeji8EmSbr0rgL8bw+Q7hIYNesRtEIQnFPub0FgX1/AV3sRZ9yqWTgGgUw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@argos-ci/util/-/util-2.3.0.tgz",
+      "integrity": "sha512-tkxnCpaj7yN9nCFzo9MX0FJ5YjUepEOGYfdvF8COQqp+EdY1qubOPpc4Z0l1B60BlC8YtjQv/oRxHSh1XzxWFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -8339,7 +8344,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -8395,10 +8401,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
+      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -9232,6 +9239,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -9405,6 +9413,7 @@
       "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
       "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "yargs-parser": "^20.2.7"
@@ -10470,6 +10479,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -11691,6 +11701,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -11736,13 +11747,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -14323,7 +14336,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -15039,6 +15053,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -15048,6 +15063,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -15590,6 +15606,7 @@
       "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.4.tgz",
       "integrity": "sha512-JHX7UYjLEiHuQGCPxa3CCCIqe/nc4bTIF9c4UYVC8BegAbWoS3g4gJxKX5XcG7UtYQs2060kY6DH64KkvNZahg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "openapi-typescript-helpers": "^0.0.15"
       }
@@ -15598,7 +15615,8 @@
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
       "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -17796,7 +17814,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/publint": {
       "version": "0.3.7",
@@ -21681,7 +21700,7 @@
         "vega-lite": "5.23.0"
       },
       "devDependencies": {
-        "@argos-ci/playwright": "3.10.0",
+        "@argos-ci/playwright": "4.1.0",
         "@parcel/compressor-brotli": "2.13.3",
         "@parcel/transformer-inline-string": "2.13.3",
         "@parcel/transformer-typescript-tsc": "2.13.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16124,9 +16124,10 @@
       }
     },
     "node_modules/plotly.js-dist-min": {
-      "version": "2.35.3",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.35.3.tgz",
-      "integrity": "sha512-sz2HLP8gkysLx/BanM2PtJTtZ1PLPwdHwMWNri2YxLBy3IOeuDsVQtlmWa4hoK3j/fi4naaD3uZJqH5ozM3zGg=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-3.0.1.tgz",
+      "integrity": "sha512-RReOqr6TfoHaTbVAoHR1UbTCOSRDsQ7Hbthd+3XAxOwaKmxCE3oejMhLG7urQSqWC65DAcSKV23kZd8e+7mG7w==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
@@ -21693,7 +21694,7 @@
         "mermaid": "10.9.3",
         "moment": "2.30.1",
         "pagedjs": "0.4.3",
-        "plotly.js-dist-min": "2.35.3",
+        "plotly.js-dist-min": "3.0.1",
         "pretty-ms": "9.2.0",
         "tailwindcss": "3.4.17",
         "vega-embed": "6.29.0",
@@ -21705,7 +21706,7 @@
         "@parcel/transformer-inline-string": "2.13.3",
         "@parcel/transformer-typescript-tsc": "2.13.3",
         "@playwright/test": "1.49.1",
-        "@types/katex": "^0.16.7",
+        "@types/katex": "0.16.7",
         "@types/plotly.js-dist-min": "2.3.4",
         "glob": "11.0.1",
         "parcel": "2.13.3",

--- a/web/package.json
+++ b/web/package.json
@@ -100,7 +100,7 @@
     "mermaid": "10.9.3",
     "moment": "2.30.1",
     "pagedjs": "0.4.3",
-    "plotly.js-dist-min": "2.35.3",
+    "plotly.js-dist-min": "3.0.1",
     "pretty-ms": "9.2.0",
     "tailwindcss": "3.4.17",
     "vega-embed": "6.29.0",

--- a/web/package.json
+++ b/web/package.json
@@ -107,12 +107,12 @@
     "vega-lite": "5.23.0"
   },
   "devDependencies": {
-    "@argos-ci/playwright": "3.10.0",
+    "@argos-ci/playwright": "4.1.0",
     "@parcel/compressor-brotli": "2.13.3",
     "@parcel/transformer-inline-string": "2.13.3",
     "@parcel/transformer-typescript-tsc": "2.13.3",
     "@playwright/test": "1.49.1",
-    "@types/katex": "^0.16.7",
+    "@types/katex": "0.16.7",
     "@types/plotly.js-dist-min": "2.3.4",
     "glob": "11.0.1",
     "parcel": "2.13.3",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,3 +1,4 @@
+import { createArgosReporterOptions } from '@argos-ci/playwright/reporter'
 import { defineConfig, devices } from '@playwright/test'
 
 /**
@@ -27,9 +28,9 @@ export default defineConfig({
     process.env.CI ? ['dot'] : ['list'],
     [
       '@argos-ci/playwright/reporter',
-      {
+      createArgosReporterOptions({
         uploadToArgos: !!process.env.CI,
-      },
+      }),
     ],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
bumps the web dependencies for 'plotly-js' and 'argos-playwright' to there latest major releases

closes #2538 #2537 