### PR TITLE
feat(rnw codec): add a `RnwCodec` for handling `.rnw` files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,6 +1175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codec-noweb"
+version = "0.0.0"
+dependencies = [
+ "codec",
+ "codec-latex",
+ "codec-pandoc",
+]
+
+[[package]]
 name = "codec-odt"
 version = "0.0.0"
 dependencies = [
@@ -1274,6 +1283,7 @@ dependencies = [
  "codec-latex",
  "codec-lexical",
  "codec-markdown",
+ "codec-noweb",
  "codec-odt",
  "codec-pandoc",
  "codec-pdf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "codec",
  "codec-latex",
  "codec-pandoc",
+ "common-dev",
 ]
 
 [[package]]

--- a/json/CodeExpression.schema.json
+++ b/json/CodeExpression.schema.json
@@ -16,6 +16,9 @@
       "executable": "yes"
     }
   },
+  "latex": {
+    "derive": false
+  },
   "markdown": {
     "derive": false
   },

--- a/rust/codec-docx/src/lib.rs
+++ b/rust/codec-docx/src/lib.rs
@@ -69,7 +69,7 @@ impl Codec for DocxCodec {
         let pandoc = pandoc_from_format(
             "",
             Some(path),
-            PANDOC_FORMAT,
+            &[PANDOC_FORMAT, "+styles"].concat(),
             options
                 .map(|options| options.passthrough_args)
                 .unwrap_or_default(),
@@ -88,7 +88,7 @@ impl Codec for DocxCodec {
         pandoc_to_format(
             &pandoc,
             Some(path),
-            &[PANDOC_FORMAT, "+native_numbering"].concat(),
+            &[PANDOC_FORMAT, "+styles+native_numbering"].concat(),
             options
                 .map(|options| options.passthrough_args)
                 .unwrap_or_default(),

--- a/rust/codec-latex-trait/src/lib.rs
+++ b/rust/codec-latex-trait/src/lib.rs
@@ -1,6 +1,7 @@
 //! Provides the `LatexCodec` trait for generating Latex for Stencila Schema nodes
 
 use codec_info::{Losses, Mapping, NodeId, NodeProperty, NodeType};
+use format::Format;
 
 pub use codec_latex_derive::LatexCodec;
 
@@ -23,6 +24,8 @@ where
 
 #[derive(Default)]
 pub struct LatexEncodeContext {
+    pub format: Format,
+
     /// The encoded Latex content
     pub content: String,
 
@@ -40,8 +43,11 @@ pub struct LatexEncodeContext {
 }
 
 impl LatexEncodeContext {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(format: Format) -> Self {
+        Self {
+            format,
+            ..Default::default()
+        }
     }
 
     /// Get the current insertion position (i.e. the number of characters in the content)

--- a/rust/codec-latex/src/lib.rs
+++ b/rust/codec-latex/src/lib.rs
@@ -75,9 +75,10 @@ impl Codec for LatexCodec {
         options: Option<EncodeOptions>,
     ) -> Result<(String, EncodeInfo)> {
         let options = options.unwrap_or_default();
+        let format = options.format.unwrap_or(Format::Latex);
 
         if let Some("--builtin") = options.passthrough_args.first().map(|arg| arg.as_str()) {
-            let mut context = LatexEncodeContext::default();
+            let mut context = LatexEncodeContext::new(format);
             node.to_latex(&mut context);
 
             let mut output = context.content;
@@ -92,7 +93,7 @@ impl Codec for LatexCodec {
 
             Ok((output, info))
         } else {
-            let (pandoc, info) = root_to_pandoc(node, Format::Latex)?;
+            let (pandoc, info) = root_to_pandoc(node, format)?;
 
             let mut args = options.passthrough_args;
             args.push("--listings".into());

--- a/rust/codec-noweb/Cargo.toml
+++ b/rust/codec-noweb/Cargo.toml
@@ -8,5 +8,8 @@ codec = { path = "../codec" }
 codec-latex = { path = "../codec-latex" }
 codec-pandoc = { path = "../codec-pandoc" }
 
+[dev-dependencies]
+common-dev = { path = "../common-dev" }
+
 [lints]
 workspace = true

--- a/rust/codec-noweb/Cargo.toml
+++ b/rust/codec-noweb/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "codec-noweb"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+codec = { path = "../codec" }
+codec-latex = { path = "../codec-latex" }
+codec-pandoc = { path = "../codec-pandoc" }
+
+[lints]
+workspace = true

--- a/rust/codec-noweb/src/lib.rs
+++ b/rust/codec-noweb/src/lib.rs
@@ -1,0 +1,74 @@
+use codec::{
+    Codec, CodecAvailability, CodecSupport, DecodeInfo, DecodeOptions, EncodeInfo, EncodeOptions,
+    NodeType,
+    common::{async_trait::async_trait, eyre::Result},
+    format::Format,
+    schema::Node,
+    status::Status,
+};
+use codec_latex::LatexCodec;
+
+/// A codec for Noweb
+///
+/// Noweb is an early literate programming format (https://en.wikipedia.org/wiki/Noweb).
+/// Although, the original Noweb, could be used with other formats such as HTML and plain text,
+/// this codec is for Noweb + LaTeX only.
+/// 
+/// In addition to the code chunks of the original Noweb, this codec also supports
+/// Rnw style `\Sexpr` elements for inline code expressions.
+pub struct NowebCodec;
+
+#[async_trait]
+impl Codec for NowebCodec {
+    fn name(&self) -> &str {
+        "noweb"
+    }
+
+    fn status(&self) -> Status {
+        Status::UnderDevelopment
+    }
+
+    fn availability(&self) -> CodecAvailability {
+        LatexCodec.availability()
+    }
+
+    fn supports_from_format(&self, format: &Format) -> CodecSupport {
+        match format {
+            Format::Noweb => CodecSupport::LowLoss,
+            _ => CodecSupport::None,
+        }
+    }
+
+    fn supports_to_format(&self, format: &Format) -> CodecSupport {
+        match format {
+            Format::Noweb => CodecSupport::LowLoss,
+            _ => CodecSupport::None,
+        }
+    }
+
+    fn supports_from_type(&self, node_type: NodeType) -> CodecSupport {
+        LatexCodec.supports_from_type(node_type)
+    }
+
+    fn supports_to_type(&self, node_type: NodeType) -> CodecSupport {
+        LatexCodec.supports_to_type(node_type)
+    }
+
+    async fn from_str(
+        &self,
+        noweb: &str,
+        options: Option<DecodeOptions>,
+    ) -> Result<(Node, DecodeInfo)> {
+        let latex = noweb;
+        LatexCodec.from_str(latex, options).await
+    }
+
+    async fn to_string(
+        &self,
+        node: &Node,
+        options: Option<EncodeOptions>,
+    ) -> Result<(String, EncodeInfo)> {
+        let (latex, info) = LatexCodec.to_string(node, options).await?;
+        Ok((latex, info))
+    }
+}

--- a/rust/codec-noweb/src/lib.rs
+++ b/rust/codec-noweb/src/lib.rs
@@ -1,7 +1,12 @@
 use codec::{
     Codec, CodecAvailability, CodecSupport, DecodeInfo, DecodeOptions, EncodeInfo, EncodeOptions,
     NodeType,
-    common::{async_trait::async_trait, eyre::Result},
+    common::{
+        async_trait::async_trait,
+        eyre::Result,
+        once_cell::sync::Lazy,
+        regex::{Captures, Regex},
+    },
     format::Format,
     schema::Node,
     status::Status,
@@ -13,7 +18,7 @@ use codec_latex::LatexCodec;
 /// Noweb is an early literate programming format (https://en.wikipedia.org/wiki/Noweb).
 /// Although, the original Noweb, could be used with other formats such as HTML and plain text,
 /// this codec is for Noweb + LaTeX only.
-/// 
+///
 /// In addition to the code chunks of the original Noweb, this codec also supports
 /// Rnw style `\Sexpr` elements for inline code expressions.
 pub struct NowebCodec;
@@ -59,8 +64,8 @@ impl Codec for NowebCodec {
         noweb: &str,
         options: Option<DecodeOptions>,
     ) -> Result<(Node, DecodeInfo)> {
-        let latex = noweb;
-        LatexCodec.from_str(latex, options).await
+        let latex = latex_from_noweb(&noweb);
+        LatexCodec.from_str(&latex, options).await
     }
 
     async fn to_string(
@@ -68,7 +73,41 @@ impl Codec for NowebCodec {
         node: &Node,
         options: Option<EncodeOptions>,
     ) -> Result<(String, EncodeInfo)> {
-        let (latex, info) = LatexCodec.to_string(node, options).await?;
-        Ok((latex, info))
+        let options = EncodeOptions {
+            format: Some(Format::Noweb),
+            ..options.unwrap_or_default()
+        };
+        let (noweb, info) = LatexCodec.to_string(node, Some(options)).await?;
+        Ok((noweb, info))
     }
+}
+
+/// Translate Noweb LaTeX into pure LaTeX which can be passed [`LatexCodec`] for decoding
+///
+/// Uses regexes to convert code chunks (<<id>>=) into `lstlisting` directives
+/// and code expressions (\Sexpr) into `lstinline` directives
+/// (both with the `exec` attributes). These directives are then decoded by
+/// the LaTeX codec into `CodeChunk` and `CodeExpression` nodes respectively.
+fn latex_from_noweb(noweb: &str) -> String {
+    static SEXPR: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\\Sexpr\{([^}]*)\}").expect("invalid regex"));
+
+    let latex = SEXPR.replace_all(noweb, |captures: &Captures| {
+        let code = &captures[1];
+
+        // Delimiting character depends upon whether it is in the code
+        let char = if !code.contains("!") {
+            "!"
+        } else if !code.contains("|") {
+            "|"
+        } else if !code.contains("+") {
+            "+"
+        } else {
+            "?"
+        };
+
+        [r"\lstinline[language=rexec]", char, code, char].concat()
+    });
+
+    latex.into()
 }

--- a/rust/codec-noweb/tests/examples.rs
+++ b/rust/codec-noweb/tests/examples.rs
@@ -1,0 +1,48 @@
+use std::path::PathBuf;
+
+use codec::{
+    Codec, EncodeOptions,
+    common::{eyre::Result, glob::glob, tokio},
+};
+
+use codec_noweb::NowebCodec;
+use common_dev::insta::{assert_json_snapshot, assert_snapshot, assert_yaml_snapshot};
+
+/// Decode each example of a Noweb document and create JSON and Noweb snapshots
+/// including snapshots for losses
+#[tokio::test]
+async fn examples() -> Result<()> {
+    let pattern = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/examples")
+        .canonicalize()?
+        .to_string_lossy()
+        .to_string()
+        + "/*.nw";
+
+    for path in glob(&pattern)?.flatten() {
+        let name = path
+            .file_stem()
+            .expect("should have file stem")
+            .to_string_lossy();
+
+        let (article, info) = NowebCodec.from_path(&path, None).await?;
+
+        assert_json_snapshot!(format!("{name}.json"), article);
+        assert_yaml_snapshot!(format!("{name}.decode.losses"), info.losses);
+
+        let (noweb, info) = NowebCodec
+            .to_string(
+                &article,
+                Some(EncodeOptions {
+                    passthrough_args: vec!["--builtin".into()],
+                    ..Default::default()
+                }),
+            )
+            .await?;
+
+        assert_snapshot!(format!("{name}.nw"), &noweb);
+        assert_yaml_snapshot!(format!("{name}.encode.losses"), info.losses);
+    }
+
+    Ok(())
+}

--- a/rust/codec-noweb/tests/examples/chunk.nw
+++ b/rust/codec-noweb/tests/examples/chunk.nw
@@ -1,0 +1,16 @@
+Chunk name, no options, no code:
+
+<<chunkname>>=
+@
+
+No chunk name, options and code:
+
+<<echo=FALSE>>=
+# Some code
+@
+
+All:
+
+<<chunkname, echo=FALSE, hide=TRUE>>=
+# Some code
+@

--- a/rust/codec-noweb/tests/examples/sexpr.nw
+++ b/rust/codec-noweb/tests/examples/sexpr.nw
@@ -1,0 +1,9 @@
+A code expression \Sexpr{6*7} within a paragraph.
+
+Handles possible delimiter characters in code:
+
+\begin{itemize}
+  \item \Sexpr{!foo}
+  \item \Sexpr{!foo|bar}
+  \item \Sexpr{!foo|bar+baz}
+\end{itemize}

--- a/rust/codec-noweb/tests/snapshots/examples__chunk.decode.losses.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__chunk.decode.losses.snap
@@ -1,0 +1,5 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: info.losses
+---
+{}

--- a/rust/codec-noweb/tests/snapshots/examples__chunk.encode.losses.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__chunk.encode.losses.snap
@@ -1,0 +1,5 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: info.losses
+---
+{}

--- a/rust/codec-noweb/tests/snapshots/examples__chunk.json.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__chunk.json.snap
@@ -1,0 +1,66 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: article
+---
+{
+  "type": "Article",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        {
+          "type": "Text",
+          "value": {
+            "string": "Chunk name, no options, no code:"
+          }
+        }
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "code": {
+        "string": ""
+      },
+      "programmingLanguage": "r"
+    },
+    {
+      "type": "Paragraph",
+      "content": [
+        {
+          "type": "Text",
+          "value": {
+            "string": "No chunk name, options and code:"
+          }
+        }
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "code": {
+        "string": "# Some code"
+      },
+      "programmingLanguage": "r",
+      "isEchoed": false
+    },
+    {
+      "type": "Paragraph",
+      "content": [
+        {
+          "type": "Text",
+          "value": {
+            "string": "All:"
+          }
+        }
+      ]
+    },
+    {
+      "type": "CodeChunk",
+      "code": {
+        "string": "# Some code"
+      },
+      "programmingLanguage": "r",
+      "isEchoed": false,
+      "isHidden": true
+    }
+  ]
+}

--- a/rust/codec-noweb/tests/snapshots/examples__chunk.nw.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__chunk.nw.snap
@@ -1,0 +1,21 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: "&noweb"
+---
+Chunk name, no options, no code:
+
+<<unnamed>>=
+
+@
+
+No chunk name, options and code:
+
+<<unnamed, echo=FALSE>>=
+# Some code
+@
+
+All:
+
+<<unnamed, echo=FALSE, hidden=TRUE>>=
+# Some code
+@

--- a/rust/codec-noweb/tests/snapshots/examples__sexpr.decode.losses.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__sexpr.decode.losses.snap
@@ -1,0 +1,5 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: info.losses
+---
+{}

--- a/rust/codec-noweb/tests/snapshots/examples__sexpr.encode.losses.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__sexpr.encode.losses.snap
@@ -1,0 +1,5 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: info.losses
+---
+{}

--- a/rust/codec-noweb/tests/snapshots/examples__sexpr.json.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__sexpr.json.snap
@@ -1,0 +1,101 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: article
+---
+{
+  "type": "Article",
+  "content": [
+    {
+      "type": "Paragraph",
+      "content": [
+        {
+          "type": "Text",
+          "value": {
+            "string": "A code expression "
+          }
+        },
+        {
+          "type": "CodeExpression",
+          "code": {
+            "string": "6*7"
+          },
+          "programmingLanguage": "r"
+        },
+        {
+          "type": "Text",
+          "value": {
+            "string": " within a paragraph."
+          }
+        }
+      ]
+    },
+    {
+      "type": "Paragraph",
+      "content": [
+        {
+          "type": "Text",
+          "value": {
+            "string": "Handles possible delimiter characters in code:"
+          }
+        }
+      ]
+    },
+    {
+      "type": "List",
+      "items": [
+        {
+          "type": "ListItem",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": {
+                    "string": "!foo"
+                  },
+                  "programmingLanguage": "r"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ListItem",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": {
+                    "string": "!foo|bar"
+                  },
+                  "programmingLanguage": "r"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ListItem",
+          "content": [
+            {
+              "type": "Paragraph",
+              "content": [
+                {
+                  "type": "CodeExpression",
+                  "code": {
+                    "string": "!foo|bar+baz"
+                  },
+                  "programmingLanguage": "r"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "order": "Unordered"
+    }
+  ]
+}

--- a/rust/codec-noweb/tests/snapshots/examples__sexpr.nw.snap
+++ b/rust/codec-noweb/tests/snapshots/examples__sexpr.nw.snap
@@ -1,0 +1,13 @@
+---
+source: rust/codec-noweb/tests/examples.rs
+expression: "&noweb"
+---
+A code expression \Sexpr{6*7} within a paragraph.
+
+Handles possible delimiter characters in code:
+
+\begin{itemize}
+    \item \Sexpr{!foo}
+    \item \Sexpr{!foo|bar}
+    \item \Sexpr{!foo|bar+baz}
+\end{itemize}

--- a/rust/codec-pandoc/src/blocks.rs
+++ b/rust/codec-pandoc/src/blocks.rs
@@ -464,6 +464,16 @@ fn code_block_from_pandoc(
             programming_language = None;
         }
 
+        let is_echoed = attrs.attributes.iter().find_map(|(name, value)| {
+            (name == "echo")
+                .then_some(["true", "yes", "1"].contains(&value.to_lowercase().as_str()))
+        });
+
+        let is_hidden = attrs.attributes.iter().find_map(|(name, value)| {
+            (name == "hide")
+                .then_some(["true", "yes", "1"].contains(&value.to_lowercase().as_str()))
+        });
+
         let execution_mode = attrs
             .classes
             .iter()
@@ -498,6 +508,8 @@ fn code_block_from_pandoc(
 
         return Block::CodeChunk(CodeChunk {
             programming_language,
+            is_echoed,
+            is_hidden,
             execution_mode,
             execution_bounds,
             label_type,

--- a/rust/codec-pandoc/src/inlines.rs
+++ b/rust/codec-pandoc/src/inlines.rs
@@ -379,8 +379,12 @@ fn code_inline_from_pandoc(
     code: String,
     _context: &mut PandocDecodeContext,
 ) -> Inline {
+    // Note: Pandoc currently only observes the `language` option
+    // (and puts its value into the `attrs.classes`). This differs to the handling
+    // of code blocks (in which all attributes are preserved in `attrs.attributes`).
+    // For that reason we rely on the language name being "exec", or suffixed with "exec",
+    // to be able to identify code expressions
     let programming_language = attrs.classes.first().cloned();
-
     if let Some(lang) = programming_language
         .as_ref()
         .and_then(|lang| lang.strip_suffix("exec"))

--- a/rust/codecs/Cargo.toml
+++ b/rust/codecs/Cargo.toml
@@ -26,7 +26,8 @@ codec-jsonld = { path = "../codec-jsonld" }
 codec-latex = { path = "../codec-latex" }
 codec-lexical = { path = "../codec-lexical" }
 codec-markdown = { path = "../codec-markdown" }
-codec-odt = {path = "../codec-odt"}
+codec-noweb = { path = "../codec-noweb" }
+codec-odt = { path = "../codec-odt" }
 codec-pandoc = { path = "../codec-pandoc" }
 codec-pdf = { path = "../codec-pdf" }
 codec-pmcoap = { path = "../codec-pmcoap" }

--- a/rust/codecs/src/lib.rs
+++ b/rust/codecs/src/lib.rs
@@ -34,6 +34,7 @@ pub fn list() -> Vec<Box<dyn Codec>> {
         Box::new(codec_latex::LatexCodec),
         Box::new(codec_lexical::LexicalCodec),
         Box::new(codec_markdown::MarkdownCodec),
+        Box::new(codec_noweb::NowebCodec),
         Box::new(codec_odt::OdtCodec),
         Box::new(codec_pandoc::PandocCodec),
         Box::new(codec_pmcoap::PmcOapCodec),

--- a/rust/format/src/lib.rs
+++ b/rust/format/src/lib.rs
@@ -41,6 +41,7 @@ pub enum Format {
     Llmd,
     // Typesetting / text formats
     Latex,
+    Noweb,
     Pdf,
     Text,
     // Notebook formats
@@ -153,6 +154,7 @@ impl Format {
             Mp3 => "MPEG-3",
             Mp4 => "MPEG-4",
             Myst => "MyST Markdown",
+            Noweb => "Noweb LaTeX",
             Odt => "OpenDocument ODT",
             Ogg => "Ogg Vorbis",
             Ogv => "Ogg Vorbis Video",
@@ -294,6 +296,7 @@ impl Format {
             "mkv" => Mkv,
             "mp3" => Mp3,
             "mp4" => Mp4,
+            "nw" | "rnw" => Noweb,
             "odt" => Odt,
             "ogg" => Ogg,
             "ogv" => Ogv,
@@ -477,6 +480,7 @@ impl Display for Format {
             Mp3 => "mp3",
             Mp4 => "mp4",
             Myst => "myst",
+            Noweb => "nw",
             Odt => "odt",
             Ogg => "ogg",
             Ogv => "ogv",

--- a/rust/schema/src/implem/code_chunk.rs
+++ b/rust/schema/src/implem/code_chunk.rs
@@ -142,52 +142,80 @@ impl DomCodec for CodeChunk {
 
 impl LatexCodec for CodeChunk {
     fn to_latex(&self, context: &mut LatexEncodeContext) {
-        const ENVIRON: &str = "lstlisting";
-
         context
             .enter_node(self.node_type(), self.node_id())
-            .merge_losses(lost_options!(self, id))
-            .environ_begin(ENVIRON);
+            .merge_losses(lost_options!(self, id));
 
-        context.str("[");
-        if let Some(lang) = &self.programming_language {
+        if matches!(context.format, Format::Noweb) {
+            let name = self.label.as_deref().unwrap_or("unnamed");
+            context.str("<<").str(name);
+
+            if let Some(is_echoed) = self.is_echoed {
+                context
+                    .str(", echo=")
+                    .str(&is_echoed.to_string().to_uppercase());
+            }
+
+            if let Some(is_hidden) = self.is_hidden {
+                context
+                    .str(", hidden=")
+                    .str(&is_hidden.to_string().to_uppercase());
+            }
+
             context
-                .str("language=")
-                .property_str(NodeProperty::ProgrammingLanguage, lang)
-                .str(", exec");
+                .str(">>=")
+                .newline()
+                .property_fn(NodeProperty::Code, |context| self.code.to_latex(context));
+
+            if !self.code.ends_with('\n') {
+                context.newline();
+            }
+
+            context.str("@").newline();
         } else {
-            context.str("exec");
-        }
+            const ENVIRON: &str = "lstlisting";
+            context.environ_begin(ENVIRON).str("[");
 
-        if let Some(mode) = &self.execution_mode {
-            if !matches!(mode, ExecutionMode::Need) {
-                context.str(" ").property_str(
-                    NodeProperty::ExecutionMode,
-                    &mode.to_string().to_lowercase(),
-                );
+            if let Some(lang) = &self.programming_language {
+                context
+                    .str("language=")
+                    .property_str(NodeProperty::ProgrammingLanguage, lang)
+                    .str(", exec");
+            } else {
+                context.str("exec");
             }
-        }
 
-        if let Some(bounds) = &self.execution_bounds {
-            if !matches!(bounds, ExecutionBounds::Main) {
-                context.str(" ").property_str(
-                    NodeProperty::ExecutionBounds,
-                    &bounds.to_string().to_lowercase(),
-                );
+            if let Some(mode) = &self.execution_mode {
+                if !matches!(mode, ExecutionMode::Need) {
+                    context.str(" ").property_str(
+                        NodeProperty::ExecutionMode,
+                        &mode.to_string().to_lowercase(),
+                    );
+                }
             }
+
+            if let Some(bounds) = &self.execution_bounds {
+                if !matches!(bounds, ExecutionBounds::Main) {
+                    context.str(" ").property_str(
+                        NodeProperty::ExecutionBounds,
+                        &bounds.to_string().to_lowercase(),
+                    );
+                }
+            }
+
+            context
+                .str("]")
+                .newline()
+                .property_fn(NodeProperty::Code, |context| self.code.to_latex(context));
+
+            if !self.code.ends_with('\n') {
+                context.newline();
+            }
+
+            context.environ_end(ENVIRON);
         }
 
-        context.str("]");
-
-        context
-            .newline()
-            .property_fn(NodeProperty::Code, |context| self.code.to_latex(context));
-
-        if !self.code.ends_with('\n') {
-            context.newline();
-        }
-
-        context.environ_end(ENVIRON).exit_node().newline();
+        context.exit_node().newline();
     }
 }
 

--- a/rust/schema/src/implem/code_expression.rs
+++ b/rust/schema/src/implem/code_expression.rs
@@ -2,6 +2,29 @@ use codec_info::{lost_exec_options, lost_options};
 
 use crate::{prelude::*, CodeExpression};
 
+impl LatexCodec for CodeExpression {
+    fn to_latex(&self, context: &mut LatexEncodeContext) {
+        context
+            .enter_node(self.node_type(), self.node_id())
+            .merge_losses(lost_options!(self, id, execution_mode, execution_bounds));
+
+        if matches!(context.format, Format::Noweb) {
+            context
+                .str(r"\Sexpr{")
+                .property_fn(NodeProperty::Code, |context| self.code.to_latex(context))
+                .str("}");
+        } else if let Some(output) = &self.output {
+            context
+                .add_loss("CodeExpression.code")
+                .property_fn(NodeProperty::Output, |context| output.to_latex(context));
+        } else {
+            context.property_str(NodeProperty::Code, &self.code);
+        }
+
+        context.exit_node();
+    }
+}
+
 impl MarkdownCodec for CodeExpression {
     fn to_markdown(&self, context: &mut MarkdownEncodeContext) {
         context

--- a/rust/schema/src/types/code_expression.rs
+++ b/rust/schema/src/types/code_expression.rs
@@ -24,7 +24,7 @@ use super::timestamp::Timestamp;
 /// An executable code expression.
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, ProbeNode, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, LatexCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, ProbeNode, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 #[derive(derive_more::Display)]
@@ -111,7 +111,7 @@ pub struct CodeExpression {
 
 #[skip_serializing_none]
 #[serde_as]
-#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, ProbeNode, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, LatexCodec, TextCodec)]
+#[derive(Debug, SmartDefault, Clone, PartialEq, Serialize, Deserialize, ProbeNode, StripNode, WalkNode, WriteNode, ReadNode, PatchNode, DomCodec, HtmlCodec, JatsCodec, TextCodec)]
 #[serde(rename_all = "camelCase", crate = "common::serde")]
 #[cfg_attr(feature = "proptest", derive(Arbitrary))]
 pub struct CodeExpressionOptions {

--- a/schema/CodeExpression.yaml
+++ b/schema/CodeExpression.yaml
@@ -11,6 +11,8 @@ jats:
   elem: code
   attrs:
     executable: 'yes'
+latex:
+  derive: false
 markdown:
   derive: false
 proptest: {}


### PR DESCRIPTION
- Currently named `NwCodec` and adds `Format::Nw` but given that `Rnw` appears to be the only extant use of `noweb` syntax and to avoid having to add something to apss language from file format through to `CodeChunk`/`CodeExpression` will rename to `RnwCodec` etc.

- Likely to merge this, as is, soon and not do further development: will be superseded by new `stencila knit` command which is less lossy with respect to LaTeX elements that Pandoc does not support.