### PR TITLE
feat(knit): add `stencila knit` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,7 @@ dependencies = [
  "flate2",
  "format",
  "kernels",
+ "knit",
  "lsp",
  "models",
  "node-execute",
@@ -3432,6 +3433,19 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework 3.2.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "knit"
+version = "0.0.0"
+dependencies = [
+ "codec-latex-trait",
+ "common",
+ "document",
+ "format",
+ "images",
+ "rand 0.9.0",
+ "schema",
 ]
 
 [[package]]

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -22,6 +22,7 @@ document = { path = "../document" }
 flate2 = { workspace = true }
 format = { path = "../format" }
 kernels = { path = "../kernels" }
+knit = { path = "../knit" }
 lsp = { path = "../lsp" }
 models = { path = "../models" }
 node-execute = { path = "../node-execute" }

--- a/rust/cli/src/cli.rs
+++ b/rust/cli/src/cli.rs
@@ -116,6 +116,8 @@ pub enum Command {
     Execute(execute::Cli),
     Render(render::Cli),
 
+    Knit(knit::cli::Knit),
+
     Preview(preview::Cli),
     Publish(publish::Cli),
 
@@ -167,6 +169,8 @@ impl Cli {
             Command::Lint(lint) => lint.run().await?,
             Command::Execute(execute) => execute.run().await?,
             Command::Render(render) => render.run().await?,
+
+            Command::Knit(knit) => knit.run().await?,
 
             Command::Preview(preview) => preview.run().await?,
             Command::Publish(publish) => publish.run().await?,

--- a/rust/images/src/lib.rs
+++ b/rust/images/src/lib.rs
@@ -16,13 +16,11 @@ use common::{
 use image::{ImageFormat, ImageReader};
 use mime_guess::from_path;
 
-/**
- * Covert an image URL to a HTTP or data URI
- *
- * URL beginning with `http://`, `https://`, or `data:` will be returned unchanged.
- * Other URLs, including those beginning with `file://`, are assumed to be filesystem
- * path and will be converted to a sata URI.
- */
+/// Covert an image URL to a HTTP or data URI
+///
+/// URL beginning with `http://`, `https://`, or `data:` will be returned unchanged.
+/// Other URLs, including those beginning with `file://`, are assumed to be filesystem
+/// path and will be converted to a sata URI.
 pub fn ensure_http_or_data_uri(url: &str) -> Result<String> {
     if url.starts_with("http://") || url.starts_with("https://") || url.starts_with("data:") {
         return Ok(url.into());
@@ -34,9 +32,7 @@ pub fn ensure_http_or_data_uri(url: &str) -> Result<String> {
     path_to_data_uri(&path)
 }
 
-/**
- * Convert a filesystem path to an image into a data URI
- */
+/// Convert a filesystem path to an image into a data URI
 pub fn path_to_data_uri(path: &Path) -> Result<String> {
     let mime_type = from_path(path).first_or_octet_stream();
 
@@ -58,22 +54,20 @@ pub fn path_to_data_uri(path: &Path) -> Result<String> {
     Ok(format!("data:{};base64,{}", mime_type, encoded))
 }
 
-/**
- * Convert a data URI into an image file
- *
- * The image will be converted into an image file with a name
- * based on the hash of the URI and an extension based on the
- * type of data URI.
- *
- * # Arguments
- *
- * - `data_uri`: the data URI
- * - `images_dir`: the destination images directory
- *
- * # Returns
- *
- * The file name of the image within `images_dir`.
- */
+/// Convert a data URI into an image file
+///
+/// The image will be converted into an image file with a name
+/// based on the hash of the URI and an extension based on the
+/// type of data URI.
+///
+/// # Arguments
+///
+/// - `data_uri`: the data URI
+/// - `images_dir`: the destination images directory
+///
+/// # Returns
+///
+/// The file name of the image within `images_dir`.
 pub fn data_uri_to_file(data_uri: &str, images_dir: &Path) -> Result<String> {
     // Parse the data URI
     let Some((header, data)) = data_uri.split(',').collect_tuple() else {
@@ -117,22 +111,20 @@ pub fn data_uri_to_file(data_uri: &str, images_dir: &Path) -> Result<String> {
     Ok(image_name)
 }
 
-/**
- * Convert a file URI to a filesystem path to an image
- *
- * The absolute path of the source image will be resolved
- * from `file_uri` and `src_path` and the image copied to `images_dir`.
- *
- * # Arguments
- *
- * - `file_uri`: an absolute or relative filesystem path, which may be prefixed with `file://`
- * - `src_path`: the path that any relative paths are relative to
- * - `images_dir`: the destination images directory
- *
- * # Returns
- *
- * The file name of the image within `images_dir`.
- */
+/// Convert a file URI to a filesystem path to an image
+///
+/// The absolute path of the source image will be resolved
+/// from `file_uri` and `src_path` and the image copied to `images_dir`.
+///
+/// # Arguments
+///
+/// - `file_uri`: an absolute or relative filesystem path, which may be prefixed with `file://`
+/// - `src_path`: the path that any relative paths are relative to
+/// - `images_dir`: the destination images directory
+///
+/// # Returns
+///
+/// The file name of the image within `images_dir`.
 pub fn file_uri_to_file(
     file_uri: &str,
     src_path: Option<&Path>,

--- a/rust/knit/Cargo.toml
+++ b/rust/knit/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "knit"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+codec-latex-trait = { path = "../codec-latex-trait" }
+common = { path = "../common" }
+format = { path = "../format" }
+images = { path = "../images" }
+document = { path = "../document" }
+rand = { workspace = true }
+schema = { path = "../schema" }
+
+[lints]
+workspace = true

--- a/rust/knit/src/cli.rs
+++ b/rust/knit/src/cli.rs
@@ -9,13 +9,24 @@ use format::Format;
 use super::knit;
 
 /// Knit a document
+///
+/// Additional, passthrough arguments can be associated with each output e.g.
+///
+/// ```sh
+/// stencila knit report.tex report.docx --reference-doc=reference.docx out.pdf
+/// ```
+///
+/// Note that passthrough arguments, must come after the output path they are
+/// associated with, must begin with a hyphen and not contain any spaces (e.g.
+/// use `--reference-doc=reference.docx`, not `--reference-doc reference.docx`).
 #[derive(Default, Debug, Parser)]
 pub struct Knit {
     /// The path of the input document
     input: PathBuf,
 
-    /// The path of the output document
-    output: PathBuf,
+    /// The paths of the output documents and any associated passthrough options
+    #[arg(allow_hyphen_values = true)]
+    outputs: Vec<String>,
 
     /// The format of the input document
     ///
@@ -23,15 +34,15 @@ pub struct Knit {
     #[arg(long, short)]
     from: Option<Format>,
 
-    /// The format of the output document
+    /// The format of the output documents
     ///
-    /// If not supplied is inferred from the filename extension of the output.
+    /// If not supplied is inferred from the filename extension of each output.
     #[arg(long, short)]
     to: Option<Format>,
 }
 
 impl Knit {
     pub async fn run(self) -> Result<()> {
-        knit::knit(&self.input, &self.output, self.from, self.to).await
+        knit::knit(self.input, self.outputs, self.from, self.to).await
     }
 }

--- a/rust/knit/src/cli.rs
+++ b/rust/knit/src/cli.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+use common::{
+    clap::{self, Parser},
+    eyre::Result,
+};
+use format::Format;
+
+use super::knit;
+
+/// Knit a document
+#[derive(Default, Debug, Parser)]
+pub struct Knit {
+    /// The path of the input document
+    input: PathBuf,
+
+    /// The path of the output document
+    output: PathBuf,
+
+    /// The format of the input document
+    ///
+    /// If not supplied is inferred from the filename extension of the input.
+    #[arg(long, short)]
+    from: Option<Format>,
+
+    /// The format of the output document
+    ///
+    /// If not supplied is inferred from the filename extension of the output.
+    #[arg(long, short)]
+    to: Option<Format>,
+}
+
+impl Knit {
+    pub async fn run(self) -> Result<()> {
+        knit::knit(&self.input, &self.output, self.from, self.to).await
+    }
+}

--- a/rust/knit/src/knit.rs
+++ b/rust/knit/src/knit.rs
@@ -1,6 +1,10 @@
-use std::path::Path;
+use std::path::PathBuf;
 
-use common::{eyre::{bail, Result}, tracing};
+use common::{
+    eyre::{Result, bail},
+    itertools::Itertools,
+    tracing,
+};
 use document::{Document, ExecuteOptions};
 use format::Format;
 use schema::Node;
@@ -10,19 +14,20 @@ use crate::latex;
 /// Knit a document
 #[tracing::instrument]
 pub(super) async fn knit(
-    input: &Path,
-    output: &Path,
+    input: PathBuf,
+    outputs: Vec<String>,
     from: Option<Format>,
     to: Option<Format>,
 ) -> Result<()> {
-    let from = from.unwrap_or_else(|| Format::from_path(input));
-    let to = to.unwrap_or_else(|| Format::from_path(output));
+    let from = from.unwrap_or_else(|| Format::from_path(&input));
 
+    // Decode from the input file
     let article = match from {
         Format::Latex | Format::Tex => latex::latex_to_article(&input),
         _ => bail!("Unsupported from format: {from}"),
     }?;
 
+    // Execute the article
     let document = Document::from(Node::Article(article), Some(input.to_path_buf())).await?;
     document.execute(ExecuteOptions::default()).await?;
     document.diagnostics_print().await?;
@@ -31,15 +36,31 @@ pub(super) async fn knit(
         bail!("Expected article")
     };
 
-    match from {
-        Format::Latex | Format::Tex => match to {
-            Format::Latex | Format::Tex => latex::article_to_latex(&article, &output)?,
-            Format::Pdf => latex::article_to_pdf(&article, &output)?,
-            Format::Docx => latex::article_to_docx(&article, &output)?,
-            _ => bail!("Unsupported to format: {to}"),
-        },
-        _ => bail!("Unsupported from format: {from}"),
-    };
+    let mut outputs = outputs.into_iter();
+    loop {
+        // Get the output file path
+        let Some(output) = outputs.next() else { break };
+        let output = PathBuf::from(output);
+
+        // Get any passthrough args by collecting any following
+        // args that begin with a hyphen.
+        let passthrough_args: Vec<String> = outputs
+            .take_while_ref(|option| option.starts_with("-"))
+            .collect();
+
+        let to = to.clone().unwrap_or_else(|| Format::from_path(&output));
+
+        // Encode to format, with passthrough args
+        match from {
+            Format::Latex | Format::Tex => match to {
+                Format::Latex | Format::Tex => latex::article_to_latex(&article, &output)?,
+                Format::Pdf => latex::article_to_pdf(&article, &output, &passthrough_args)?,
+                Format::Docx => latex::article_to_docx(&article, &output, &passthrough_args)?,
+                _ => bail!("Unsupported to format: {to}"),
+            },
+            _ => bail!("Unsupported from format: {from}"),
+        };
+    }
 
     Ok(())
 }

--- a/rust/knit/src/knit.rs
+++ b/rust/knit/src/knit.rs
@@ -13,7 +13,7 @@ use crate::latex;
 
 /// Knit a document
 #[tracing::instrument]
-pub(super) async fn knit(
+pub async fn knit(
     input: PathBuf,
     outputs: Vec<String>,
     from: Option<Format>,

--- a/rust/knit/src/knit.rs
+++ b/rust/knit/src/knit.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+use common::{eyre::{bail, Result}, tracing};
+use document::{Document, ExecuteOptions};
+use format::Format;
+use schema::Node;
+
+use crate::latex;
+
+/// Knit a document
+#[tracing::instrument]
+pub(super) async fn knit(
+    input: &Path,
+    output: &Path,
+    from: Option<Format>,
+    to: Option<Format>,
+) -> Result<()> {
+    let from = from.unwrap_or_else(|| Format::from_path(input));
+    let to = to.unwrap_or_else(|| Format::from_path(output));
+
+    let article = match from {
+        Format::Latex | Format::Tex => latex::latex_to_article(&input),
+        _ => bail!("Unsupported from format: {from}"),
+    }?;
+
+    let document = Document::from(Node::Article(article), Some(input.to_path_buf())).await?;
+    document.execute(ExecuteOptions::default()).await?;
+    document.diagnostics_print().await?;
+
+    let Node::Article(article) = document.root().await else {
+        bail!("Expected article")
+    };
+
+    match from {
+        Format::Latex | Format::Tex => match to {
+            Format::Latex | Format::Tex => latex::article_to_latex(&article, &output)?,
+            Format::Pdf => latex::article_to_pdf(&article, &output)?,
+            Format::Docx => latex::article_to_docx(&article, &output)?,
+            _ => bail!("Unsupported to format: {to}"),
+        },
+        _ => bail!("Unsupported from format: {from}"),
+    };
+
+    Ok(())
+}

--- a/rust/knit/src/latex.rs
+++ b/rust/knit/src/latex.rs
@@ -1,0 +1,360 @@
+use std::{
+    fs::{File, create_dir_all, read_to_string, rename, write},
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use rand::{Rng, distr::Alphanumeric, rng};
+
+use codec_latex_trait::to_latex;
+use common::{
+    eyre::{Result, bail},
+    once_cell::sync::Lazy,
+    regex::Regex,
+    tempfile::tempdir,
+    tracing,
+};
+use format::Format;
+use schema::{Article, Block, CodeChunk, Node, RawBlock, Section};
+
+/// Decode a LaTeX to a knitted [`Article`]
+#[tracing::instrument]
+pub(super) fn latex_to_article(path: &Path) -> Result<Article> {
+    tracing::trace!("Decoding LaTeX to Article");
+
+    let latex = read_to_string(path)?;
+    Ok(Article::new(latex_to_blocks(&latex)))
+}
+
+/// Encode a knitted [`Article`] to LaTeX
+#[tracing::instrument(skip(article))]
+pub(super) fn article_to_latex(article: &Article, path: &Path) -> Result<()> {
+    tracing::trace!("Encoding Article to LaTeX");
+
+    let temp = tempdir()?;
+
+    let latex = blocks_to_latex(&article.content, &Format::Latex, temp.path())?;
+
+    Ok(write(path, latex)?)
+}
+
+/// Encode a knitted [`Article`] to PDF
+#[tracing::instrument(skip(article))]
+pub(super) fn article_to_pdf(article: &Article, path: &Path) -> Result<()> {
+    tracing::trace!("Encoding Article to PDF");
+
+    let temp = tempdir()?;
+
+    let latex = blocks_to_latex(&article.content, &Format::Pdf, temp.path())?;
+
+    let input = temp.path().join("main.tex");
+    let output = temp.path().join("main.pdf");
+
+    write(&input, latex)?;
+
+    let status = Command::new("latex")
+        .current_dir(temp.path())
+        .args([
+            "-interaction=batchmode",
+            "-halt-on-error",
+            "-output-format=pdf",
+            "main.tex",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    if !status.success() {
+        let log = read_to_string(temp.path().join("main.log"))?;
+        bail!("latex failed with log:\n\n{log}");
+    }
+
+    if let Some(dir) = path.parent() {
+        create_dir_all(dir)?;
+    }
+    rename(&output, path)?;
+
+    Ok(())
+}
+
+/// Encode a knitted [`Article`] to DOCX
+#[tracing::instrument(skip(article))]
+pub(super) fn article_to_docx(article: &Article, path: &Path) -> Result<()> {
+    tracing::trace!("Encoding Article to DOCX");
+
+    let temp = tempdir()?;
+    let temp_path = temp.path();
+
+    // Uncomment the following path during development for debugging intermediate files
+    // let temp_path = &PathBuf::from("temp");
+
+    let latex = blocks_to_latex(&article.content, &Format::Docx, temp_path)?;
+
+    let input = temp_path.join("main.tex");
+    let output = temp_path.join("main.docx");
+
+    write(&input, latex)?;
+
+    let status = Command::new("pandoc")
+        .current_dir(temp_path)
+        .args(["main.tex", "-omain.docx"])
+        .stdout(Stdio::null())
+        .status()?;
+    if !status.success() {
+        bail!("pandoc failed");
+    }
+
+    if let Some(dir) = path.parent() {
+        create_dir_all(dir)?;
+    }
+    rename(&output, path)?;
+
+    Ok(())
+}
+
+/// Decode LaTeX into a vector of [`Block`]s
+fn latex_to_blocks(latex: &str) -> Vec<Block> {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"(?sx)                                   # s = . matches \n, x = ignore whitespace & allow comments
+            \\code\{(?P<code_cmd>[^}]*)\}                # \code{<...>}
+          | \\begin\{code\} \s*                          # \begin{code}
+              (?:\[(?P<code_opts>[^\]]*?)\])? \s*        #   [opt1, opt2]   ← OPTIONAL
+              (?P<code_env>.*?)                          #   body (lazy)
+            \\end\{code\}                                # \end{code}
+          | \\begin\{island\} (?P<island>.*?) \\end\{island\}  # island env
+        ",
+        )
+        .expect("invalid regex")
+    });
+
+    let mut blocks = Vec::new();
+    let mut cursor = 0;
+
+    for captures in RE.captures_iter(latex) {
+        let m = captures.get(0).expect("always present");
+        if m.start() > cursor {
+            blocks.push(Block::RawBlock(RawBlock::new(
+                Format::Latex.to_string(),
+                latex[cursor..m.start()].into(),
+            )));
+        }
+
+        if let Some(mat) = captures.name("code_cmd").or(captures.name("code_env")) {
+            let code = mat.as_str().into();
+
+            let mut programming_language = None;
+            let mut is_echoed = None;
+            let mut is_hidden = None;
+            if let Some(options) = captures.name("code_opts") {
+                for option in options
+                    .as_str()
+                    .split(',')
+                    .map(|s| s.trim())
+                    .filter(|s| !s.is_empty())
+                {
+                    if option == "hide" {
+                        is_hidden = Some(true);
+                    } else if option == "echo" {
+                        is_echoed = Some(true);
+                    } else if programming_language.is_none() {
+                        programming_language = Some(option.to_string());
+                    }
+                }
+            }
+
+            blocks.push(Block::CodeChunk(CodeChunk {
+                programming_language,
+                is_hidden,
+                is_echoed,
+                code,
+                ..Default::default()
+            }));
+        } else if let Some(mat) = captures.name("island") {
+            blocks.push(Block::Section(Section::new(latex_to_blocks(mat.as_str()))));
+        }
+
+        cursor = m.end();
+    }
+
+    if cursor < latex.len() {
+        blocks.push(Block::RawBlock(RawBlock::new(
+            Format::Latex.to_string(),
+            latex[cursor..].into(),
+        )));
+    }
+
+    blocks
+}
+
+/// Encode a vector of [`Block`]s to LaTeX
+///
+/// The `format` argument represents the final destination format. This function always
+/// returns a LaTeX string but the style of that LaTeX is dependent upon the destination format.
+fn blocks_to_latex(blocks: &Vec<Block>, format: &Format, dir: &Path) -> Result<String> {
+    let mut latex = String::new();
+    for block in blocks {
+        match block {
+            Block::RawBlock(RawBlock { content, .. }) => latex.push_str(&content),
+            Block::CodeChunk(CodeChunk {
+                code,
+                outputs,
+                is_hidden,
+                ..
+            }) => {
+                if is_hidden.unwrap_or_default() {
+                    continue;
+                }
+
+                let is_block = code.contains("\n");
+
+                if let Some(outputs) = outputs {
+                    let mut outputs_latex = String::new();
+                    for output in outputs {
+                        let output_latex = match output {
+                            Node::ImageObject(image) => {
+                                let path = if image.content_url.starts_with("data:") {
+                                    images::data_uri_to_file(&image.content_url, dir)?
+                                } else {
+                                    image.content_url.clone()
+                                };
+                                highlight_png(dir, &PathBuf::from(&path))?;
+                                [r"\includegraphics{", &path, "}"].concat()
+                            }
+                            _ => to_latex(output),
+                        };
+                        outputs_latex.push_str(&output_latex);
+                    }
+
+                    if matches!(format, Format::Docx) {
+                        if !is_block {
+                            let verbatim = [r"\verb!", &outputs_latex, "!"].concat();
+                            latex.push_str(&verbatim)
+                        } else if outputs_latex.contains("includegraphics") {
+                            latex.push_str(&outputs_latex)
+                        } else {
+                            let png = latex_to_png(&outputs_latex, dir)?;
+                            highlight_png(dir, &png)?;
+                            let image =
+                                [r"\includegraphics{", &png.to_string_lossy(), "}"].concat();
+                            latex.push_str(&image)
+                        }
+                    } else {
+                        latex.push_str(&outputs_latex);
+                    }
+                } else if matches!(format, Format::Latex) {
+                    // If there are no outputs, and final format is LaTeX, then display code
+                    if is_block {
+                        latex.push_str(r"\begin{code}");
+                        latex.push_str(&code);
+                        latex.push_str(r"\end{code}");
+                    } else {
+                        latex.push_str(r"\code{");
+                        latex.push_str(&code);
+                        latex.push('}');
+                    }
+                }
+            }
+            Block::Section(Section { content, .. }) => {
+                let section = blocks_to_latex(content, &Format::Latex, dir)?;
+                let png = latex_to_png(&section, dir)?;
+                highlight_png(dir, &png)?;
+                let image = [
+                    r"\includegraphics[width=\linewidth]{",
+                    &png.to_string_lossy(),
+                    "}",
+                ]
+                .concat();
+                latex.push_str(&image)
+            }
+            _ => {}
+        }
+    }
+    Ok(latex)
+}
+
+/// Compile the given LaTeX snippet to a PNG
+///
+/// Places the provided LaTeX within a standalone document and calls `latex`
+/// and `dvipng` successively to generate a PNG from it.
+#[tracing::instrument(skip(latex))]
+fn latex_to_png(latex: &str, dir: &Path) -> Result<PathBuf> {
+    tracing::trace!("Converting LaTex to PNG");
+
+    // TODO: add more usepackages here and/or allow packages to be specified
+    let latex = format!(
+        r"
+\documentclass[border=5pt,preview]{{standalone}}
+
+\usepackage{{pdflscape}}
+
+\begin{{document}}
+{latex}
+\end{{document}}
+"
+    );
+
+    let id: String = rng()
+        .sample_iter(&Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect();
+
+    let tex_name = format!("{id}.tex");
+    let tex_path = dir.join(&tex_name);
+    let dvi_name = format!("{id}.dvi");
+    let png_name = format!("{id}.png");
+    let png_path = dir.join(&png_name);
+
+    let mut tex_file = File::create(&tex_path)?;
+    tex_file.write_all(latex.as_bytes())?;
+
+    let status = Command::new("latex")
+        .current_dir(dir)
+        .args(["-interaction=batchmode", &tex_name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    if !status.success() {
+        let log = read_to_string(dir.join(format!("{id}.log")))?;
+        bail!("latex failed with log:\n\n{log}");
+    }
+
+    let status = Command::new("dvipng")
+        .current_dir(dir)
+        .args(["-D300", "-o", &png_name, &dvi_name])
+        .status()?;
+    if !status.success() {
+        bail!("dvipng failed");
+    }
+
+    Ok(png_path)
+}
+
+/// Highlight a PNG image a being a code output or an island
+///
+/// Currently, places a green border around the image. This could be
+/// be made customizable in the future.
+#[tracing::instrument]
+fn highlight_png(dir: &Path, png: &Path) -> Result<()> {
+    tracing::trace!("Highlighting PNG");
+
+    const BORDER_COLOR: &str = "#32CD32";
+    const BORDER_WIDTH: &str = "5";
+
+    let status = Command::new("mogrify")
+        .current_dir(dir)
+        .args([
+            "-bordercolor",
+            BORDER_COLOR,
+            "-border",
+            BORDER_WIDTH,
+            &png.to_string_lossy(),
+        ])
+        .status()?;
+    if !status.success() {
+        bail!("mogrify failed");
+    }
+
+    Ok(())
+}

--- a/rust/knit/src/lib.rs
+++ b/rust/knit/src/lib.rs
@@ -3,3 +3,7 @@ mod latex;
 mod knit;
 
 pub mod cli;
+
+// Exported for external crates
+pub use knit::knit;
+pub use format::Format;

--- a/rust/knit/src/lib.rs
+++ b/rust/knit/src/lib.rs
@@ -1,0 +1,5 @@
+mod latex;
+
+mod knit;
+
+pub mod cli;

--- a/rust/lsp/src/text_document.rs
+++ b/rust/lsp/src/text_document.rs
@@ -504,7 +504,7 @@ impl TextDocument {
         let Some(home) = path.parent() else {
             bail!("File does not have a parent dir")
         };
-        let doc = Document::init(home.into(), Some(path), Some(node_type))?;
+        let doc = Document::init(home.into(), Some(path), None, Some(node_type))?;
 
         let format = Format::from_name(&format);
 


### PR DESCRIPTION
- A new `knit` command which is similar to Sweave or Knitr it its approach. It uses existing infrastructure for document execution, but which rather than using existing codec, "decodes" documents into `Article`s made up of only:

  - `RawBlock` - to hold raw markup (e.g. LaTeX, Markdown)
  - `CodeChunk` - to hold executable code
  - `Section` - for "islands" of markup and/or executable code that are not intended to be edited (useful for things like complex tables, diagrams etc)

- To do:

  - [ ] Add snapshot based test of knitted LaTeX
  - [ ] Support for `\input` commands
  - [ ] Improve support for `xtable` in R kernel
  - [x] CLI to support multiple destinations to avoid repeating execution e.g. `stencila knit report.tex report.pdf report.docx`
  - [ ] Add CLI flag for whether reproducible elements should be highlighted in docz
  - [x] CLI to support Pandoc pass-through arguments
  - [ ] Setup and embed reference docx with consistent font & highlighting of reproducible elements

- Anticipate adding `unknit` command (to merge in changes form docx) soon, but not part of this PR.